### PR TITLE
fix(web-portal): add a real readiness probe and keep health cheap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   cases. They prove `/ready` returns 503 for a read-only data directory, that the
   body names the failed check, that `/ready` returns 200 when the directory is
   writable, and that `/health` answers while every disk call raises.
+- **SQLite query (Changed)**: the database check runs
+  `SELECT count(*) FROM sqlite_master`. That query reads a real page, so SQLite
+  validates the file header. The first version ran `SELECT 1`, which answers from
+  memory. A corrupt database therefore passed the check on the Linux build of
+  SQLite, and the test caught the miss only in CI.
 - **Deferred**: the `Containerfile`, the `Dockerfile`, and `compose.yml` still
   need a probe. Open pull request #1825 owns those three files today.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Add a real readiness probe and keep the health endpoint cheap (issue #1863)
+
+- **Defect (Fixed)**: the `/health` endpoint returned the fixed text `healthy` on
+  every call. It never tested write access to the data directory, which is the
+  one resource with a documented failure. A portal that could not write a single
+  output file still reported a good state, so no monitor saw the fault.
+- **`/health` (Changed)**: the route is now a liveness probe. It reports the
+  process state and the uptime. It reads no disk and it opens no network
+  connection, so a blocked resource cannot slow the reply down. The response
+  keeps the word `healthy`, so an existing monitor still matches.
+- **`/ready` (Added)**: the route tests every resource the portal needs. It
+  writes and deletes one temporary file in the data directory, it opens the
+  SQLite database read-only when the file exists, and it reads the Mist API
+  session state without a network call.
+- **Failure report (Added)**: `/ready` returns code 503 when a check fails, and
+  the body names each failed check under `failed_checks`. The body also carries
+  a detail line for each check, so the operator learns how to repair it.
+- **Quadlet probe (Added)**: `deploy/misthelper.container` now sets `HealthCmd=`
+  against `/ready`, with an interval of 30 seconds, a timeout of 5 seconds,
+  3 retries, a start period of 20 seconds, and `HealthOnFailure=restart`. A
+  wedged portal now restarts, because `Restart=always` alone could not see it.
+- **Tests (Added)**: `tests/unit/web_portal/test_dashboard_readiness.py` holds 14
+  cases. They prove `/ready` returns 503 for a read-only data directory, that the
+  body names the failed check, that `/ready` returns 200 when the directory is
+  writable, and that `/health` answers while every disk call raises.
+- **Deferred**: the `Containerfile`, the `Dockerfile`, and `compose.yml` still
+  need a probe. Open pull request #1825 owns those three files today.
+
 ### Bound the web portal operation run registry (issue #1860)
 
 - **Defect (Fixed)**: `OperationExecutor` kept every run in memory forever, and

--- a/deploy/misthelper.container
+++ b/deploy/misthelper.container
@@ -4,6 +4,16 @@ PublishPort=2200:2200
 PublishPort=8055:8055
 Volume=./data:/app/data:rw
 EnvironmentFile=./.env
+# The container image sets no HEALTHCHECK instruction, because the OCI image
+# format rejects it. Quadlet supplies the probe instead. The probe calls the
+# readiness endpoint, because that endpoint tests write access to the data
+# directory. A read-only data mount then marks the container unhealthy.
+HealthCmd=curl --fail --silent --show-error http://localhost:8055/ready
+HealthInterval=30s
+HealthTimeout=5s
+HealthRetries=3
+HealthStartPeriod=20s
+HealthOnFailure=restart
 
 [Service]
 Restart=always

--- a/tests/unit/web_portal/__init__.py
+++ b/tests/unit/web_portal/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the MistHelper web portal package."""

--- a/tests/unit/web_portal/test_dashboard_readiness.py
+++ b/tests/unit/web_portal/test_dashboard_readiness.py
@@ -1,0 +1,222 @@
+"""Unit tests for the web portal liveness and readiness endpoints.
+
+Regression cover for issue #1863. The one health endpoint returned the
+fixed text ``healthy`` on every call, so a portal that could not write a
+single output file still reported a good state. These tests hold the
+split: ``/health`` reports process liveness only, and ``/ready`` tests
+write access to the data directory and returns 503 on a failure.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from web_portal.routes import dashboard as dashboard_module
+from web_portal.routes.dashboard import dashboard_bp
+
+
+def _build_test_app(data_dir: str, apisession: Any = None) -> Flask:
+    """Build a minimal Flask app that serves the dashboard blueprint."""
+    app = Flask(__name__)  # WHY: a bare app avoids the portal factory and its side effects.
+    app.config["DATA_DIR"] = data_dir  # WHY: the readiness check reads this key for the write test.
+    app.config["APISESSION"] = apisession  # WHY: the readiness check reads this key for the Mist test.
+    app.register_blueprint(dashboard_bp)  # WHY: register the routes under test only.
+    return app
+
+
+def _deny_write(probe_path: str) -> None:
+    """Raise the documented container failure for any probe write."""
+    raise PermissionError(13, "Permission denied", probe_path)
+
+
+@pytest.fixture
+def writable_data_dir(tmp_path) -> str:
+    """Return the path of a data directory the test process can write to."""
+    data_dir = tmp_path / "data"  # WHY: pathlib keeps the path correct on Windows and on Linux.
+    data_dir.mkdir()  # WHY: the readiness check needs a directory that exists.
+    return str(data_dir)  # WHY: the app config stores the directory as a string.
+
+
+class TestReadinessDataDirectory:
+    """Verify the readiness endpoint reports a data directory failure."""
+
+    def test_ready_returns_503_when_the_data_directory_rejects_a_write(
+        self,
+        writable_data_dir: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A read-only data mount must produce code 503."""
+        monkeypatch.setattr(dashboard_module, "_write_and_remove_probe_file", _deny_write)
+        client = _build_test_app(writable_data_dir).test_client()
+
+        response = client.get("/ready")
+
+        assert response.status_code == 503, "A rejected write must return 503, not 200"
+
+    def test_ready_names_the_failed_check_in_the_response_body(
+        self,
+        writable_data_dir: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The 503 body must name the check that failed."""
+        monkeypatch.setattr(dashboard_module, "_write_and_remove_probe_file", _deny_write)
+        client = _build_test_app(writable_data_dir).test_client()
+
+        payload = client.get("/ready").get_json()
+
+        assert payload["failed_checks"] == ["data_directory_writable"]
+        assert payload["status"] == "not ready"
+        assert "Permission denied" in payload["checks"]["data_directory_writable"]["detail"]
+
+    def test_ready_returns_503_when_the_data_directory_is_absent(self, tmp_path) -> None:
+        """An absent data directory must produce code 503."""
+        missing_dir = str(tmp_path / "no-such-directory")  # WHY: never created, so the write fails.
+        client = _build_test_app(missing_dir).test_client()
+
+        response = client.get("/ready")
+
+        assert response.status_code == 503
+        assert response.get_json()["failed_checks"] == ["data_directory_writable"]
+
+    def test_ready_returns_200_when_the_data_directory_is_writable(self, writable_data_dir: str) -> None:
+        """A writable data directory must produce code 200."""
+        client = _build_test_app(writable_data_dir).test_client()
+
+        response = client.get("/ready")
+
+        assert response.status_code == 200
+        assert response.get_json()["failed_checks"] == []
+        assert response.get_json()["status"] == "ready"
+
+    def test_ready_leaves_no_probe_file_behind(self, writable_data_dir: str) -> None:
+        """The write test must delete the temporary file it creates."""
+        client = _build_test_app(writable_data_dir).test_client()
+
+        response = client.get("/ready")
+
+        assert response.status_code == 200, "The route must run the write test before this check counts"
+        leftovers = [name for name in os.listdir(writable_data_dir) if name.startswith(".readiness-probe-")]
+        assert leftovers == [], "The probe file must not stay in the data directory"
+
+
+class TestReadinessSqliteDatabase:
+    """Verify the readiness endpoint reports a SQLite database failure."""
+
+    def test_ready_passes_when_the_database_file_does_not_exist(self, writable_data_dir: str) -> None:
+        """An absent database is not a fault, because the portal creates it."""
+        client = _build_test_app(writable_data_dir).test_client()
+
+        payload = client.get("/ready").get_json()
+
+        assert payload["checks"]["sqlite_database"]["ok"] is True
+
+    def test_ready_returns_503_when_the_database_file_is_corrupt(self, writable_data_dir: str) -> None:
+        """A file that SQLite cannot read must produce code 503."""
+        db_path = os.path.join(writable_data_dir, dashboard_module.SQLITE_DATABASE_FILENAME)
+        with open(db_path, "w", encoding="utf-8") as handle:  # WHY: plain text is not a SQLite file.
+            handle.write("this is not a database")
+        client = _build_test_app(writable_data_dir).test_client()
+
+        response = client.get("/ready")
+
+        assert response.status_code == 503
+        assert response.get_json()["failed_checks"] == ["sqlite_database"]
+
+    def test_ready_passes_when_the_database_answers_a_query(self, writable_data_dir: str) -> None:
+        """A real database file must pass the connection test."""
+        db_path = os.path.join(writable_data_dir, dashboard_module.SQLITE_DATABASE_FILENAME)
+        connection = sqlite3.connect(db_path)  # WHY: build a valid database file for the check.
+        connection.execute("CREATE TABLE probe (id INTEGER)")
+        connection.commit()
+        connection.close()
+        client = _build_test_app(writable_data_dir).test_client()
+
+        response = client.get("/ready")
+
+        assert response.status_code == 200
+        assert response.get_json()["checks"]["sqlite_database"]["ok"] is True
+
+
+class TestReadinessMistApiSession:
+    """Verify the readiness endpoint reports a Mist API session failure."""
+
+    def test_ready_passes_when_no_session_is_configured(self, writable_data_dir: str) -> None:
+        """The portal serves the data browser with no session, so this passes."""
+        client = _build_test_app(writable_data_dir, apisession=None).test_client()
+
+        payload = client.get("/ready").get_json()
+
+        assert payload["checks"]["mist_api_session"]["ok"] is True
+
+    def test_ready_returns_503_when_the_session_has_no_cloud_host(self, writable_data_dir: str) -> None:
+        """A session with no cloud host cannot reach Mist, so this fails."""
+        session = SimpleNamespace(host="")  # WHY: an empty host is the misconfigured state.
+        client = _build_test_app(writable_data_dir, apisession=session).test_client()
+
+        response = client.get("/ready")
+
+        assert response.status_code == 503
+        assert response.get_json()["failed_checks"] == ["mist_api_session"]
+
+    def test_ready_passes_when_the_session_names_a_cloud_host(self, writable_data_dir: str) -> None:
+        """A session with a cloud host passes without a network call."""
+        session = SimpleNamespace(host="api.mist.com")  # WHY: a configured host is the good state.
+        client = _build_test_app(writable_data_dir, apisession=session).test_client()
+
+        payload = client.get("/ready").get_json()
+
+        assert payload["checks"]["mist_api_session"]["detail"] == "Mist API session targets api.mist.com"
+
+
+class TestLivenessEndpoint:
+    """Verify the liveness endpoint stays cheap and never reads the disk."""
+
+    def test_health_returns_200_without_touching_the_disk(
+        self,
+        writable_data_dir: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The liveness route must answer while every disk call raises."""
+
+        def _fail_on_disk_access(*args: Any, **kwargs: Any) -> Any:
+            """Raise when the route reads the file system."""
+            raise AssertionError("The liveness route must not read the disk")
+
+        monkeypatch.setattr(dashboard_module.os, "scandir", _fail_on_disk_access)
+        monkeypatch.setattr(dashboard_module.os.path, "isdir", _fail_on_disk_access)
+        monkeypatch.setattr(dashboard_module, "_count_data_files", _fail_on_disk_access)
+        client = _build_test_app(writable_data_dir).test_client()
+
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "healthy"
+
+    def test_health_reports_process_liveness_only(self, writable_data_dir: str) -> None:
+        """The liveness body must hold no data directory field."""
+        client = _build_test_app(writable_data_dir).test_client()
+
+        payload = client.get("/health").get_json()
+
+        assert "data_files_count" not in payload, "A file count makes the liveness probe read the disk"
+        assert "data_directory" not in payload
+        assert payload["services"] == {"web_portal": "running"}
+        assert isinstance(payload["uptime_seconds"], int)
+
+    def test_health_stays_200_when_the_data_directory_rejects_a_write(
+        self,
+        writable_data_dir: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The liveness route must not fail on the readiness failure."""
+        monkeypatch.setattr(dashboard_module, "_write_and_remove_probe_file", _deny_write)
+        client = _build_test_app(writable_data_dir).test_client()
+
+        assert client.get("/health").status_code == 200
+        assert client.get("/ready").status_code == 503

--- a/tests/unit/web_portal/test_dashboard_readiness.py
+++ b/tests/unit/web_portal/test_dashboard_readiness.py
@@ -117,10 +117,15 @@ class TestReadinessSqliteDatabase:
         assert payload["checks"]["sqlite_database"]["ok"] is True
 
     def test_ready_returns_503_when_the_database_file_is_corrupt(self, writable_data_dir: str) -> None:
-        """A file that SQLite cannot read must produce code 503."""
+        """A file that SQLite cannot read must produce code 503.
+
+        The check must read a real database page. A query such as
+        ``SELECT 1`` answers from memory, so SQLite never validates the
+        file header and a corrupt file passes.
+        """
         db_path = os.path.join(writable_data_dir, dashboard_module.SQLITE_DATABASE_FILENAME)
-        with open(db_path, "w", encoding="utf-8") as handle:  # WHY: plain text is not a SQLite file.
-            handle.write("this is not a database")
+        with open(db_path, "wb") as handle:  # WHY: a wrong header makes SQLite reject the file.
+            handle.write(b"this is not a database" + b"\x00" * 4096)
         client = _build_test_app(writable_data_dir).test_client()
 
         response = client.get("/ready")

--- a/web_portal/routes/dashboard.py
+++ b/web_portal/routes/dashboard.py
@@ -1,10 +1,14 @@
 """Dashboard routes for the MistHelper web portal.
 
-Serves the home dashboard page and health check endpoint.
+Serves the home dashboard page, the cheap liveness endpoint, and the
+readiness endpoint that the container health probe calls.
 """
 
+import logging
 import os
+import sqlite3
 import time
+import uuid
 from datetime import datetime, timezone
 
 from flask import Blueprint, current_app, jsonify, render_template
@@ -12,6 +16,12 @@ from flask import Blueprint, current_app, jsonify, render_template
 dashboard_bp = Blueprint("dashboard", __name__)
 
 _start_time = time.time()
+
+SQLITE_DATABASE_FILENAME = "mist_data.db"
+
+READINESS_PROBE_PREFIX = ".readiness-probe-"
+
+READINESS_QUERY_TIMEOUT_SECONDS = 2
 
 
 @dashboard_bp.route("/")
@@ -24,19 +34,127 @@ def dashboard():
 
 @dashboard_bp.route("/health")
 def health():
-    """Return JSON health status for container monitoring."""
-    data_dir = current_app.config.get("DATA_DIR", "data")
-    file_count = _count_data_files(data_dir)
-    uptime = int(time.time() - _start_time)
+    """Return a cheap liveness result for the portal process.
+
+    This endpoint reports process liveness only. It reads no disk and
+    it opens no network connection, so a blocked resource cannot slow
+    the reply down.
+    """
+    # WHY: a container probe calls this route every few seconds. An INFO line
+    # for each call floods the log and hides the real operation records.
+    logging.debug("Liveness probe received a request")
+    uptime = int(time.time() - _start_time)  # WHY: arithmetic only keeps the reply free of disk cost.
+    logging.debug("Liveness probe reports alive after %d seconds", uptime)  # WHY: record the reply value.
     return jsonify(
         {
-            "status": "healthy",
-            "services": {"web_portal": "running"},
-            "uptime_seconds": uptime,
-            "data_directory": data_dir,
-            "data_files_count": file_count,
+            "status": "healthy",  # WHY: existing monitors match on this exact word.
+            "services": {"web_portal": "running"},  # WHY: name the one process this probe covers.
+            "uptime_seconds": uptime,  # WHY: the operator uses the age to spot a restart loop.
         }
     )
+
+
+@dashboard_bp.route("/ready")
+def ready():
+    """Return a readiness result that tests every resource the portal needs.
+
+    The route returns code 503 and names each failed check when a
+    resource is not usable. It returns code 200 when every check passes.
+    """
+    data_dir = current_app.config.get("DATA_DIR", "data")  # WHY: the portal writes every output file here.
+    apisession = current_app.config.get("APISESSION")  # WHY: the stored session shows the Mist cloud setup.
+    checks = _run_readiness_checks(data_dir, apisession)  # WHY: test each resource that can block the portal.
+    failed = _collect_failed_check_names(checks)  # WHY: the operator needs the name of each failed check.
+    status_code = 503 if failed else 200  # WHY: a monitor acts on 503, and it ignores 200.
+    payload = {
+        "status": "not ready" if failed else "ready",  # WHY: one word gives the operator the verdict.
+        "failed_checks": failed,  # WHY: the body must name the failed check, not only the code.
+        "checks": checks,  # WHY: the detail text tells the operator how to repair the resource.
+        "data_directory": data_dir,  # WHY: repeat the directory under test for a remote reader.
+        "uptime_seconds": int(time.time() - _start_time),  # WHY: correlate the failure with a restart.
+    }
+    logging.debug("Readiness probe replies %d with %d failed checks", status_code, len(failed))
+    return jsonify(payload), status_code
+
+
+def _run_readiness_checks(data_dir: str, apisession) -> dict:
+    """Run every readiness check and return one result for each check."""
+    logging.info("Readiness probe starts the resource checks")  # WHY: mark the start of the check run.
+    checks = {
+        "data_directory_writable": _check_data_dir_writable(data_dir),  # WHY: the documented failure.
+        "sqlite_database": _check_sqlite_database(data_dir),  # WHY: the local database holds the results.
+        "mist_api_session": _check_mist_api_session(apisession),  # WHY: a broken session blocks every operation.
+    }
+    logging.debug("Readiness probe completed %d checks", len(checks))  # WHY: record the check count.
+    return checks
+
+
+def _collect_failed_check_names(checks: dict) -> list:
+    """Return the name of every check that did not pass."""
+    return [name for name, result in checks.items() if not result["ok"]]  # WHY: names drive the 503 body.
+
+
+def _check_data_dir_writable(data_dir: str) -> dict:
+    """Test write access to the data directory with a temporary file."""
+    # WHY: os.path.join builds a path that works on Windows and in the container.
+    probe_path = os.path.join(data_dir, READINESS_PROBE_PREFIX + uuid.uuid4().hex)
+    logging.info("Readiness probe tests write access in %s", data_dir)  # WHY: log before the disk write.
+    try:
+        _write_and_remove_probe_file(probe_path)  # WHY: only a real write proves the mount is writable.
+    except OSError as exc:
+        logging.warning("Readiness probe cannot write in %s: %s", data_dir, exc)  # WHY: name the failure.
+        return {"ok": False, "detail": "cannot write in %s: %s" % (data_dir, exc)}
+    logging.debug("Readiness probe wrote and removed %s", probe_path)  # WHY: record the successful write.
+    return {"ok": True, "detail": "write access confirmed in %s" % data_dir}
+
+
+def _write_and_remove_probe_file(probe_path: str) -> None:
+    """Create the probe file, then delete the probe file again."""
+    with open(probe_path, "w", encoding="utf-8") as probe_file:  # WHY: open for write to test the mount.
+        probe_file.write("readiness")  # WHY: one short word forces a real write to the file system.
+    os.remove(probe_path)  # WHY: delete the probe file so the data directory stays clean.
+
+
+def _check_sqlite_database(data_dir: str) -> dict:
+    """Test the SQLite connection when the database file exists."""
+    db_path = os.path.join(data_dir, SQLITE_DATABASE_FILENAME)  # WHY: os.path.join fits both platforms.
+    if not os.path.isfile(db_path):
+        # WHY: the portal creates the database on demand, so an absent file is not a fault.
+        logging.debug("Readiness probe found no database at %s", db_path)
+        return {"ok": True, "detail": "database file not created yet"}
+    logging.info("Readiness probe opens the database at %s", db_path)  # WHY: log before the connection.
+    try:
+        _query_sqlite_database(db_path)  # WHY: one query proves the file opens and answers.
+    except sqlite3.Error as exc:
+        logging.warning("Readiness probe cannot read %s: %s", db_path, exc)  # WHY: name the failure.
+        return {"ok": False, "detail": "cannot read %s: %s" % (db_path, exc)}
+    logging.debug("Readiness probe read the database at %s", db_path)  # WHY: record the successful read.
+    return {"ok": True, "detail": "database answered a query"}
+
+
+def _query_sqlite_database(db_path: str) -> None:
+    """Open the database read-only and run one cheap query."""
+    uri = "file:%s?mode=ro" % db_path.replace("\\", "/")  # WHY: a SQLite URI accepts forward slashes only.
+    connection = sqlite3.connect(uri, uri=True, timeout=READINESS_QUERY_TIMEOUT_SECONDS)  # WHY: read-only is safe.
+    try:
+        connection.execute("SELECT 1")  # WHY: a trivial query proves the connection works.
+    finally:
+        connection.close()  # WHY: always close so the probe leaks no file handle.
+
+
+def _check_mist_api_session(apisession) -> dict:
+    """Test the stored Mist API session state without a network call."""
+    logging.info("Readiness probe inspects the Mist API session state")  # WHY: log before the read.
+    if apisession is None:
+        # WHY: the portal serves the data browser with no session, so an absent session is not a fault.
+        logging.debug("Readiness probe found no Mist API session")
+        return {"ok": True, "detail": "no Mist API session configured"}
+    host = getattr(apisession, "host", "")  # WHY: read the cloud host without a request to Mist.
+    if not host:
+        logging.warning("Readiness probe found a Mist API session with no cloud host")  # WHY: name the failure.
+        return {"ok": False, "detail": "Mist API session has no cloud host"}
+    logging.debug("Readiness probe found the Mist cloud host %s", host)  # WHY: record the configured host.
+    return {"ok": True, "detail": "Mist API session targets %s" % host}
 
 
 def _build_data_summary(data_dir: str) -> dict:

--- a/web_portal/routes/dashboard.py
+++ b/web_portal/routes/dashboard.py
@@ -133,11 +133,13 @@ def _check_sqlite_database(data_dir: str) -> dict:
 
 
 def _query_sqlite_database(db_path: str) -> None:
-    """Open the database read-only and run one cheap query."""
+    """Open the database read-only and read the schema table."""
     uri = "file:%s?mode=ro" % db_path.replace("\\", "/")  # WHY: a SQLite URI accepts forward slashes only.
     connection = sqlite3.connect(uri, uri=True, timeout=READINESS_QUERY_TIMEOUT_SECONDS)  # WHY: read-only is safe.
     try:
-        connection.execute("SELECT 1")  # WHY: a trivial query proves the connection works.
+        # WHY: this query reads a real page, so SQLite validates the file header.
+        # A query such as "SELECT 1" answers from memory and passes on a corrupt file.
+        connection.execute("SELECT count(*) FROM sqlite_master").fetchone()
     finally:
         connection.close()  # WHY: always close so the probe leaks no file handle.
 


### PR DESCRIPTION
# Spec Conformance Checklist

**Linked Spec Issue**: #1863

Fixes #1863

## What changed

The `/health` endpoint returned the fixed text `healthy` on every call. It never tested write
access to the data directory, which is the one resource with a documented failure. A portal that
could not write a single output file still reported a good state, so no monitor saw the fault. The
container also defined no health probe, so `Restart=always` never fired.

- **`/health` is now a liveness probe.** It reports the process state and the uptime. It reads no
  disk and it opens no network connection, so a blocked resource cannot slow the reply down. The
  body keeps the word `healthy`, so the existing monitor in `tests/e2e/test_portal_smoke.py` still
  matches.
- **`/ready` is a new readiness probe.** It writes one temporary file in the data directory and
  deletes the file again. Only a real write proves the mount is writable.
- **`/ready` also tests the SQLite database and the Mist API session.** It opens the database
  read-only when the file exists and runs one trivial query. It reads the session cloud host from
  the stored object, so it makes no network call to Mist.
- **`/ready` returns code 503 when a check fails.** The body names each failed check under
  `failed_checks`, and it carries a detail line for each check, so the operator learns how to repair
  the resource.
- **`deploy/misthelper.container` now defines a health command.** `HealthCmd=` calls `/ready`, with
  `HealthInterval=30s`, `HealthTimeout=5s`, `HealthRetries=3`, `HealthStartPeriod=20s`, and
  `HealthOnFailure=restart`. A comment states that the OCI image format rejects the `HEALTHCHECK`
  instruction, which is the reason Quadlet supplies the probe.

## Acceptance criteria from issue #1863

- [x] `/ready` returns code 503 when the data directory is not writable.
- [x] `/ready` names the failed check in the response body.
- [x] `/health` stays cheap and reports process liveness only.
- [x] `deploy/misthelper.container` defines a health command, and a comment states why the image
      cannot carry one.
- [ ] The `misthelper` service in `compose.yml` defines a health check. **Deferred.** See the
      checklist below.
- [x] A unit test asserts `/ready` returns 503 when the data directory is read-only.

## Deferred container work

Open pull request #1825 owns the `Containerfile`, the `Dockerfile`, and `compose.yml`.
`gh pr view 1825 --json state` reports `OPEN`, so this pull request leaves all three files untouched
to avoid a merge conflict. The exact remaining change:

- [ ] `compose.yml`, the `misthelper` service near lines 4 to 57: add a `healthcheck` block that
      runs `curl --fail --silent --show-error http://localhost:8055/ready`, with `interval: 30s`,
      `timeout: 5s`, `retries: 3`, and `start_period: 20s`. This matches the pattern the ArangoDB
      service at line 84 and the Redis service at line 105 already use.
- [ ] `Containerfile`, line 113: replace the comment
      `# Note: HEALTHCHECK removed for OCI/Podman compatibility` with a comment that names
      `deploy/misthelper.container` as the location of the probe. Restore a `HEALTHCHECK`
      instruction against `/ready` only when the build switches to the Docker image format.
- [ ] `Dockerfile`, line 109: apply the same change. The Docker image format accepts `HEALTHCHECK`,
      so this file can carry
      `HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=20s CMD curl --fail --silent http://localhost:8055/ready || exit 1`.
- [ ] Confirm the image carries `curl` before any probe lands. A missing `curl` makes every probe
      fail and marks a good container unhealthy.

## Test results

`tests/unit/web_portal/test_dashboard_readiness.py` is a new module with 14 cases. All 14 pass.
13 of the 14 fail against the code before this change, which proves the tests hold the defect.

```
collected 25 items
tests\unit\web_portal\test_dashboard_readiness.py ..............   [ 56%]
tests\unit\web_portal\test_operation_run_registry_caps.py ...........  [100%]
25 passed in 0.94s
```

The second module arrived on `main` in pull request #1867. Both modules pass together after the
rebase.

## CI history

The first run of the `pytest (coverage gate)` job failed. Coverage was not the cause. The total
reached 92.33 percent against the 80 percent floor. One case failed:
`test_ready_returns_503_when_the_database_file_is_corrupt` expected code 503 and received code 200.

Root cause: the database check ran `SELECT 1`. SQLite answers that query from memory, so it never
reads a page and it never validates the file header. A corrupt database therefore passed the check
on the Linux build of SQLite. The Windows build raised the error, so the miss appeared only in CI.

Fix: the check now runs `SELECT count(*) FROM sqlite_master`. That query reads a real page, so
SQLite validates the header on every platform. The test also writes the corrupt file in binary mode
with a wrong header and 4096 padding bytes, because SQLite treats a zero-length file as a valid
empty database.

The branch then showed no checks at all, because pull request #1867 merged first and made this
branch conflict on `CHANGELOG.md`. GitHub cannot run a `pull_request` check while the merge commit
does not compute. A rebase onto `main` resolved the conflict by keeping both changelog sections.

Local gate results:

| Gate | Command | Result |
| - | - | - |
| Compile | `python -m py_compile web_portal/routes/dashboard.py` | pass |
| Lint | `python -m ruff check .` | `All checks passed!` |
| Format | `python -m black --check web_portal/ tests/unit/web_portal/` | 19 files unchanged |
| Tests | `pytest tests/unit/web_portal/ -q` | 25 passed |
| Dead code | `vulture web_portal --min-confidence 70` | 0 findings |
| Docstring style | `pydocstyle web_portal` | 0 violations |

All 21 CI checks pass on the rebased branch. That set covers CodeQL, `analyze (python)`, Bandit,
mypy strict, Pylint, Radon, Vulture, Ruff, pydocstyle, Interrogate, pip-audit, Black, the E2E smoke
tests, the ops-portal job, the diagram lint, the menu drift check, and the coverage gate.

## Acceptance Criteria

- [x] All acceptance criteria from the linked Spec Issue are met
- [x] Each criterion has a corresponding test or verification

## Quality

- [x] Tests added or updated for all changed functionality
- [x] Coverage meets or exceeds 80% threshold
- [x] No new Ruff lint violations (`ruff check .`)
- [x] Code formatted with Ruff (`ruff format --check .`)
- [ ] mypy passes (`mypy MistHelper.py`). Not applicable, because `MYPY_PATHS` in
      `.github/workflows/ci.yml` excludes `web_portal`.

## Security

- [x] No hardcoded secrets, tokens, or passwords
- [x] Bandit passes with no new findings
- [x] pip-audit clean. This pull request changes no dependency.
- [x] Sensitive data handled through `.env` and environment variables only

## Deployment

- [x] Dry-run verified locally. The readiness route runs under the Flask test client.
- [x] `.env` changes documented in `deploy/.env.example`. Not applicable, because this change adds
      no environment variable.
- [ ] Container builds successfully. Not applicable, because the `Containerfile` is untouched.

## UI and E2E testing

- [ ] Playwright E2E tests added or updated in `tests/e2e/`. Not applicable. This change touches two
      JSON endpoints and no HTML page.
- [ ] Stable `data-testid` attributes added. Not applicable.
- [ ] AI agent verified selectors through the browser tools. Not applicable.
- [ ] Screenshots and traces captured. Not applicable.

The existing case `tests/e2e/test_portal_smoke.py::TestHealthEndpoint::test_health_returns_json`
still holds, because `/health` keeps code 200 and the word `healthy`.

## Documentation

- [ ] README.md updated. Not applicable, because the README documents no health endpoint today.
- [x] Changelog entry added

## Files changed

Only the four owned paths changed. No sibling agent shares any of them.

- `web_portal/routes/dashboard.py`
- `deploy/misthelper.container`
- `tests/unit/web_portal/__init__.py` and `tests/unit/web_portal/test_dashboard_readiness.py` (new)
- `CHANGELOG.md`
