### PR TITLE
security(ops-platform): store an opaque session id and unblock the auth event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,42 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   holds 11 tests. They cover the registry cap, the per-run log cap, the
   protection of an active run, the retention period, the dropped count in the
   response, and the fallback for an unusable setting.
+### Store an opaque session id and unblock the auth event loop (issues #1859, #1858)
+
+- **Cookie (Fixed)**: the `mist_session` cookie held the raw Mist API token. A
+  reader of that cookie gained the full Mist privileges of the operator, outside
+  this application and outside its audit log. The cookie now holds an opaque
+  identifier that `secrets.token_urlsafe(32)` produces.
+- **Token storage (Added)**: `SessionStore` in
+  `mist-ops-platform/src/shared/services/session_store.py` keeps the Mist token in
+  a server-side record. The record uses Redis when Redis answers, and a
+  process-local map when Redis does not answer. `_extract_token` reads the token
+  from that record, so no route reads a token from a client.
+- **Secure flag (Added)**: the cookie now sets `Secure` and `HttpOnly`. The new
+  `SESSION_COOKIE_SECURE` setting defaults to a true value. Set the value to
+  `false` only for local work over plain HTTP.
+- **Logout (Fixed)**: `DELETE /api/v1/auth/session` now deletes the server-side
+  record. A logout therefore ends the session, which the old code could not do.
+- **Event loop (Fixed)**: the Mist `/api/v1/self` lookup ran inside an `async def`
+  dependency and blocked the event loop for one round trip to `api.mist.com`. The
+  lookup now runs in a worker thread through `anyio.to_thread.run_sync`.
+- **Verification cache (Fixed)**: the privilege cache was never active, because
+  both call sites passed `redis=None`. The auth middleware now caches the
+  verification result on the session record for 5 minutes, so a repeat request
+  makes no second call to Mist.
+- **Cache key (Changed)**: the Redis privilege key derived from `hash(token)`,
+  which Python randomizes for each process. The key now derives from a SHA-256
+  digest, so it stays stable across every worker and across a restart.
+- **Status codes (Changed)**: an unreachable Mist API now returns 503 through the
+  new `MistApiUnavailableError`. Only a token that Mist rejects returns 401. A
+  transient upstream fault no longer logs every operator out.
+- **Settings (Added)**: `mist-ops-platform/src/shared/config/settings.py` supplies
+  the `AppSettings` object that six modules already imported.
+- **Tests (Added)**:
+  `mist-ops-platform/tests/unit/api/test_session_security.py` holds 15 tests. They
+  prove the cookie differs from the token, the cookie carries `Secure`, a deleted
+  identifier returns 401, the lookup runs off the event loop, and a second request
+  inside the cache period makes no second upstream call.
 
 ### Replace the assert runtime guards in the SSH package (issue #1720)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,12 +116,15 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   new `MistApiUnavailableError`. Only a token that Mist rejects returns 401. A
   transient upstream fault no longer logs every operator out.
 - **Settings (Added)**: `mist-ops-platform/src/shared/config/settings.py` supplies
-  the `AppSettings` object that six modules already imported.
+  the `AppSettings` object that six modules already imported. Every default value
+  lives in a module constant, because a `slots` dataclass turns a class attribute
+  into a descriptor instead of the default value.
 - **Tests (Added)**:
-  `mist-ops-platform/tests/unit/api/test_session_security.py` holds 15 tests. They
+  `mist-ops-platform/tests/unit/api/test_session_security.py` holds 18 tests. They
   prove the cookie differs from the token, the cookie carries `Secure`, a deleted
   identifier returns 401, the lookup runs off the event loop, and a second request
-  inside the cache period makes no second upstream call.
+  inside the cache period makes no second upstream call. The suite reports
+  18 passed, and the wider `tests/unit` run reports no new failure.
 
 ### Replace the assert runtime guards in the SSH package (issue #1720)
 

--- a/mist-ops-platform/.gitignore
+++ b/mist-ops-platform/.gitignore
@@ -51,3 +51,8 @@ celerybeat.pid
 
 # Data outputs
 data/
+
+# Application settings package.
+# WHY: the root .gitignore excludes every config/ directory. That rule hid
+# src/shared/config/, which six modules import. This line re-includes it.
+!src/shared/config/

--- a/mist-ops-platform/src/api/middleware/auth.py
+++ b/mist-ops-platform/src/api/middleware/auth.py
@@ -1,8 +1,18 @@
-"""Auth middleware — Bearer token + session cookie with privilege caching (T020).
+"""Auth middleware for the bearer header and the session cookie (T020).
 
-Validates the ``Authorization: Bearer <token>`` header or a session cookie.
-Privilege data is cached in Redis for 5 minutes to avoid repeated lookups.
-Scope enforcement: query results are filtered to the user's MSP/org/site
+The middleware accepts an ``Authorization: Bearer`` header or a ``mist_session``
+cookie. The cookie holds an opaque session identifier. The middleware reads the
+Mist API token from the server-side session record, so no client ever sends the
+Mist credential back to this service (issue #1859).
+
+The middleware runs the Mist ``/api/v1/self`` lookup in a worker thread, so the
+lookup never blocks the event loop. The middleware also caches the verification
+result on the session record for 5 minutes, so a repeat request makes no second
+call to the Mist cloud (issue #1858).
+
+An unreachable Mist API returns 503. A token that Mist rejects returns 401.
+
+Scope enforcement: query results are filtered to the user's MSP, org, and site
 privileges (FR-025).
 """
 
@@ -10,14 +20,37 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
+import anyio.to_thread
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from src.shared.services.session_store import (
+    PRIVILEGE_CACHE_TTL,
+    SessionRecord,
+    SessionStore,
+    build_session_store,
+)
+
+if TYPE_CHECKING:
+    from src.shared.services.auth import MistPrivileges
 
 logger = logging.getLogger(__name__)
 _bearer_scheme = HTTPBearer(auto_error=False)
 
-PRIVILEGE_CACHE_TTL = 300  # 5 minutes
+SESSION_COOKIE_NAME = "mist_session"  # Names the cookie that holds the opaque session identifier.
+
+__all__ = [
+    "PRIVILEGE_CACHE_TTL",
+    "SESSION_COOKIE_NAME",
+    "CallerIdentity",
+    "CurrentUser",
+    "get_current_user",
+    "get_session_store",
+    "privilege_cache_payload",
+    "require_org_access",
+]
 
 
 @dataclass(slots=True)
@@ -32,43 +65,121 @@ class CurrentUser:
     privileges: dict = field(default_factory=dict)
 
 
+@dataclass(slots=True)
+class CallerIdentity:
+    """Holds the Mist token that a request resolves to, and its session record."""
+
+    token: str
+    session_id: str = ""
+    record: SessionRecord | None = None
+
+
 async def get_current_user(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
 ) -> CurrentUser:
     """Extract and validate caller identity from the request."""
-    token = _extract_token(request, credentials)
-    if not token:
+    logger.info("Request authentication starts for path %s.", request.url.path)
+    identity = _extract_token(request, credentials)  # Read the token from the server side.
+    if identity is None or not identity.token:  # No credential means the caller is anonymous.
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing authentication credentials",
         )
-    from src.shared.services.auth import AuthService
-
-    svc = AuthService(redis=None)
-    privs = svc.validate_token(token)
-    if not privs.email and not privs.org_ids:
+    privs = await _resolve_privileges(request, identity)  # Read the cache, or ask Mist.
+    if not privs.email and not privs.org_ids:  # Mist rejected the token, so the caller has no org.
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired token",
         )
+    logger.debug("Request authentication done for operator %s.", privs.email or "unknown")
+    return _build_current_user(identity.token, privs)  # Hand the route a scoped caller object.
+
+
+def _build_current_user(token: str, privs: MistPrivileges) -> CurrentUser:
+    """Return the caller object that the route handlers depend on."""
     return CurrentUser(
-        token=token,
-        email=privs.email,
-        org_ids=privs.org_ids,
-        site_ids=privs.site_ids,
-        is_msp=privs.is_msp,
+        token=token,  # The route uses this token for its own Mist calls.
+        email=privs.email,  # The audit log records the operator by email address.
+        org_ids=privs.org_ids,  # The scope check compares an org against this list.
+        site_ids=privs.site_ids,  # The scope check compares a site against this list.
+        is_msp=privs.is_msp,  # An MSP operator passes every org scope check.
     )
 
 
 def _extract_token(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None,
-) -> str | None:
-    """Return token from Bearer header or session cookie."""
-    if credentials and credentials.credentials:
-        return credentials.credentials
-    return request.cookies.get("mist_session")
+) -> CallerIdentity | None:
+    """Return the caller identity from the bearer header or the session cookie."""
+    if credentials and credentials.credentials:  # A direct API client sends its own token.
+        return CallerIdentity(token=credentials.credentials)
+    session_id = request.cookies.get(SESSION_COOKIE_NAME, "")  # The browser sends an opaque value.
+    if not session_id:  # No cookie and no header means the caller sent no credential.
+        return None
+    record = get_session_store(request).resolve(session_id)  # Read the token from the server side.
+    if record is None or not record.token:  # A deleted session must fail, so logout ends it.
+        logger.debug("The session cookie resolves to no server-side record. The request fails.")
+        return None
+    return CallerIdentity(token=record.token, session_id=session_id, record=record)
+
+
+async def _resolve_privileges(request: Request, identity: CallerIdentity) -> MistPrivileges:
+    """Return the Mist privileges for *identity* without blocking the event loop."""
+    from src.shared.services.auth import MistPrivileges
+
+    record = identity.record  # A bearer client owns no record, so it always asks Mist.
+    if record is not None and record.privileges_are_fresh():  # The 5 minute period still runs.
+        logger.debug("The privilege cache answered. The request makes no call to the Mist cloud.")
+        return MistPrivileges(**record.privileges)  # Rebuild the result that the last call stored.
+    privs = await _verify_with_mist(identity.token)  # Ask Mist once, inside a worker thread.
+    if identity.session_id:  # Only a cookie session owns a record that can hold the result.
+        get_session_store(request).store_privileges(
+            identity.session_id,
+            privilege_cache_payload(privs),
+        )
+    return privs
+
+
+async def _verify_with_mist(token: str) -> MistPrivileges:
+    """Run the blocking Mist lookup in a worker thread."""
+    from src.shared.services.auth import AuthService, MistApiUnavailableError
+
+    logger.info("Mist token verification starts.")  # Announce the upstream call before the work.
+    service = AuthService()  # The service holds no request state, so a new object costs little.
+    try:
+        # WHY: validate_token blocks on a network round trip. A worker thread frees the event loop.
+        privs = await anyio.to_thread.run_sync(service.validate_token, token)
+    except MistApiUnavailableError as error:
+        # WHY: a transport fault is not a bad token. A 503 keeps the operator logged in.
+        logger.warning("The Mist API is unreachable: %s.", error)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="The Mist API is unreachable. Try the request again.",
+        ) from error
+    logger.debug("Mist token verification done for operator %s.", privs.email or "unknown")
+    return privs
+
+
+def privilege_cache_payload(privs: MistPrivileges) -> dict:
+    """Return the privilege fields that the session record stores."""
+    return {
+        "email": privs.email,  # The audit log needs the operator identity on the next request.
+        "name": privs.name,  # The portal shows this name in its header.
+        "is_msp": privs.is_msp,  # The scope check needs the MSP flag.
+        "org_ids": privs.org_ids,  # The scope check needs the org list.
+        "site_ids": privs.site_ids,  # The scope check needs the site list.
+        "org_names": privs.org_names,  # The portal shows an org name beside each org.
+    }
+
+
+def get_session_store(request: Request) -> SessionStore:
+    """Return the shared session store, and build it once for the application."""
+    store = getattr(request.app.state, "session_store", None)  # Reuse the open connection.
+    if store is None:  # The first request builds the store, so no start order matters.
+        store = build_session_store()
+        request.app.state.session_store = store  # Cache the store on the application state.
+    return store
 
 
 def require_org_access(org_id: str, user: CurrentUser) -> None:

--- a/mist-ops-platform/src/api/routes/health.py
+++ b/mist-ops-platform/src/api/routes/health.py
@@ -7,6 +7,7 @@ notification channels (system-level concern per api-overview.md).
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -19,8 +20,11 @@ from src.api.deps import get_db_session
 from src.api.schemas.common import ResponseEnvelope
 from src.shared.models.operations import NotificationChannel
 
+if TYPE_CHECKING:
+    from src.shared.services.auth import MistPrivileges
+
 router = APIRouter(tags=["system"])
-logger = logging.getLogger(__name__)  # Records the best-effort failures that this module tolerates.
+logger = logging.getLogger(__name__)  # Records the best-effort failures that this module allows.
 
 
 @router.get("/healthz")
@@ -30,7 +34,7 @@ async def healthz() -> dict[str, str]:
 
 
 @router.get("/readyz")
-async def readyz(request) -> dict[str, str]:  # noqa: ANN001
+async def readyz(request: Request) -> dict[str, str]:
     """Readiness probe — verifies database connectivity."""
     engine = getattr(request.app.state, "engine", None)
     if engine is None:
@@ -164,91 +168,146 @@ async def login(
     db: AsyncSession = Depends(get_db_session),
 ) -> ResponseEnvelope[SessionResponse]:
     """Authenticate with a Mist API token, upsert orgs, return session."""
-    import secrets
-    import uuid as uuid_mod
-    from datetime import datetime, timedelta, timezone
+    from datetime import UTC, datetime, timedelta
 
     from fastapi import HTTPException
 
-    from src.shared.db import ensure_org_partitions
-    from src.shared.models.inventory import Organization
-    from src.shared.services.auth import AuthService
-
-    svc = AuthService(redis=None)
-    privs = svc.validate_token(body.token)
-
+    logger.info("Operator login starts.")  # Announce the login before the upstream call.
+    privs = await _verify_login_token(body.token)  # Ask Mist once, inside a worker thread.
     if not privs.email and not privs.org_ids:
         raise HTTPException(status_code=401, detail="Invalid API token")
 
-    engine = request.app.state.engine
-    for oid in privs.org_ids:
-        org_uuid = uuid_mod.UUID(oid)
-        org_name = privs.org_names.get(oid, oid)
-        org = await db.get(Organization, org_uuid)
-        if org is None:
-            org = Organization(
-                org_id=org_uuid,
-                name=org_name,
-                api_host="api.mist.com",
-            )
-            db.add(org)
-        else:
-            org.name = org_name
-        await ensure_org_partitions(engine, oid)
-    await db.flush()
+    await _upsert_orgs(db, request.app.state.engine, privs)  # Record every org the operator holds.
+    _cache_worker_token(privs.org_ids, body.token)  # Let the Celery worker reuse the credential.
+    _dispatch_inventory_sync(privs.org_ids)  # Start the first inventory sync for each org.
 
-    # Cache token in Redis so Celery workers can use it for API calls
+    session_id = _create_session(request, body.token, privs)  # Keep the token on the server side.
+    expires = datetime.now(UTC) + timedelta(hours=8)
+    envelope = _build_login_envelope(session_id, privs, expires.isoformat())
+    logger.debug("Operator login done for operator %s.", privs.email or "unknown")
+    return _login_response(envelope, session_id)  # The cookie holds the identifier, not the token.
+
+
+async def _verify_login_token(token: str) -> MistPrivileges:
+    """Verify *token* with the Mist API without blocking the event loop."""
+    import anyio.to_thread
+    from fastapi import HTTPException
+
+    from src.shared.services.auth import AuthService, MistApiUnavailableError
+
+    svc = AuthService()  # The Redis privilege cache is not needed, because the record holds it.
+    try:
+        # WHY: validate_token blocks on a network round trip. A worker thread frees the event loop.
+        return await anyio.to_thread.run_sync(svc.validate_token, token)
+    except MistApiUnavailableError as error:
+        # WHY: a transport fault is not a bad token. A 503 tells the operator to try again.
+        logger.warning("The Mist API is unreachable during the login: %s.", error)
+        raise HTTPException(
+            status_code=503,
+            detail="The Mist API is unreachable. Try the login again.",
+        ) from error
+
+
+async def _upsert_orgs(db: AsyncSession, engine: object, privs: MistPrivileges) -> None:
+    """Record every org that the operator may reach, and build its partitions."""
+    import uuid as uuid_mod
+
+    from src.shared.db import ensure_org_partitions
+    from src.shared.models.inventory import Organization
+
+    logger.info("Organization upsert starts for %d orgs.", len(privs.org_ids))
+    for oid in privs.org_ids:  # One row per org keeps the inventory scoped to that org.
+        org_uuid = uuid_mod.UUID(oid)  # The table keys an org by its Mist UUID.
+        org_name = privs.org_names.get(oid, oid)  # Use the identifier when no name exists.
+        org = await db.get(Organization, org_uuid)  # Read the row, because this is an upsert.
+        if org is None:  # A first login for this org inserts the row.
+            db.add(Organization(org_id=org_uuid, name=org_name, api_host="api.mist.com"))
+        else:  # A later login refreshes the name, because an operator can rename an org.
+            org.name = org_name
+        await ensure_org_partitions(engine, oid)  # A time-series table needs a partition per org.
+    await db.flush()  # Write the rows now, so the session record and the orgs agree.
+    logger.debug("Organization upsert done for %d orgs.", len(privs.org_ids))
+
+
+def _cache_worker_token(org_ids: list[str], token: str) -> None:
+    """Cache the Mist token in Redis, so a Celery worker can call the Mist API."""
     import redis as redis_lib
+
     from src.shared.config.settings import get_settings
 
-    _settings = get_settings()
     try:
-        _redis = redis_lib.Redis.from_url(_settings.redis_url)
-        for oid in privs.org_ids:
-            _redis.setex(f"mist_token:{oid}", 8 * 3600, body.token)
-        _redis.close()
-    except (redis_lib.RedisError, OSError, ValueError) as error:  # Redis, socket, and bad-URL faults.
+        client = redis_lib.Redis.from_url(get_settings().redis_url)  # Address the shared Redis.
+        for oid in org_ids:  # Each org key lets a worker find the token for that org.
+            client.setex(f"mist_token:{oid}", 8 * 3600, token)
+        client.close()  # Release the socket, because this route holds no long-lived client.
+    except (redis_lib.RedisError, OSError, ValueError) as error:  # Redis, socket, and URL faults.
         # WHY: the worker falls back to the environment token. A cache miss must not fail login.
         logger.debug("Redis token cache unavailable: %s", error)  # Make the cache miss visible.
 
-    # Trigger immediate inventory sync for each org
+
+def _dispatch_inventory_sync(org_ids: list[str]) -> None:
+    """Ask the Celery worker to sync the inventory of each org now."""
     try:
         from src.worker.tasks.sync_tasks import sync_org_inventory
 
-        for oid in privs.org_ids:
+        for oid in org_ids:  # One task per org keeps a slow org from blocking the others.
             sync_org_inventory.delay(oid)
     except Exception as error:  # WHY: the Celery broker raises types this app cannot name.
         # WHY: beat retries the sync later, so a dispatch failure must not fail the login.
         logger.debug("Inventory sync dispatch unavailable: %s", error)  # Make the miss visible.
 
-    session_id = secrets.token_urlsafe(32)
-    expires = datetime.now(timezone.utc) + timedelta(hours=8)
-    role = "msp" if privs.is_msp else "org_admin"
+
+def _create_session(request: Request, token: str, privs: MistPrivileges) -> str:
+    """Store *token* in the server-side session record and return its identifier."""
+    from src.api.middleware.auth import get_session_store, privilege_cache_payload
+
+    store = get_session_store(request)  # Reuse the store that the auth middleware also reads.
+    # WHY: the login already verified the token, so the first request needs no second Mist call.
+    return store.create(token, privilege_cache_payload(privs))
+
+
+def _build_login_envelope(
+    session_id: str,
+    privs: MistPrivileges,
+    expires_at: str,
+) -> ResponseEnvelope[SessionResponse]:
+    """Build the JSON body that the login returns to the portal."""
+    role = "msp" if privs.is_msp else "org_admin"  # The portal shows a different menu per role.
     orgs = [OrgRefResponse(orgId=oid, name=privs.org_names.get(oid, oid)) for oid in privs.org_ids]
     operator = OperatorResponse(
-        email=privs.email,
-        name=privs.name,
-        role=role,
-        orgs=orgs,
+        email=privs.email,  # The portal shows the signed-in operator.
+        name=privs.name,  # The portal shows a display name beside the email address.
+        role=role,  # The portal hides the MSP views from an org administrator.
+        orgs=orgs,  # The portal lists every org that the operator may select.
     )
-    envelope = ResponseEnvelope(
+    return ResponseEnvelope(
         data=SessionResponse(
-            sessionId=session_id,
+            sessionId=session_id,  # The body repeats the identifier that the cookie carries.
             operator=operator,
-            expiresAt=expires.isoformat(),
+            expiresAt=expires_at,
         ),
     )
-    from fastapi.responses import JSONResponse
 
+
+def _login_response(
+    envelope: ResponseEnvelope[SessionResponse],
+    session_id: str,
+) -> JSONResponse:
+    """Return the login response with the opaque session cookie attached."""
+    from src.shared.config.settings import get_settings
+
+    secure = get_settings().session_cookie_secure  # A false value serves local plain HTTP work.
     response = JSONResponse(content=envelope.model_dump(mode="json"))
     response.set_cookie(
         key="mist_session",
-        value=body.token,
-        httponly=True,
-        samesite="lax",
-        max_age=8 * 3600,
+        value=session_id,  # WHY: an opaque identifier gives a cookie reader no Mist credential.
+        httponly=True,  # Script in the page cannot read the cookie.
+        secure=secure,  # The browser sends the cookie over HTTPS only, unless a setting stops it.
+        samesite="lax",  # A cross-site form post cannot carry the session.
+        max_age=8 * 3600,  # The cookie and the server-side record expire together.
         path="/",
     )
+    logger.debug("The login cookie carries an opaque session identifier. Secure is %s.", secure)
     return response
 
 
@@ -266,10 +325,15 @@ async def refresh_token() -> ResponseEnvelope[TokenRefreshResponse]:
 
 
 @auth_router.delete("/session")
-async def logout() -> JSONResponse:
+async def logout(request: Request) -> JSONResponse:
     """Invalidate current session and clear cookie."""
-    from fastapi.responses import JSONResponse
+    from src.api.middleware.auth import SESSION_COOKIE_NAME, get_session_store
 
+    logger.info("Operator logout starts.")  # Announce the logout before the delete.
+    session_id = request.cookies.get(SESSION_COOKIE_NAME, "")  # Address the record to delete.
+    # WHY: the record holds the Mist token. The delete is what truly ends the session.
+    removed = get_session_store(request).delete(session_id)
     response = JSONResponse(content={"status": "logged_out"})
-    response.delete_cookie(key="mist_session", path="/")
+    response.delete_cookie(key=SESSION_COOKIE_NAME, path="/")  # Clear the browser copy as well.
+    logger.debug("Operator logout done. A server-side record existed: %s.", removed)
     return response

--- a/mist-ops-platform/src/shared/config/__init__.py
+++ b/mist-ops-platform/src/shared/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration package for the Mist Ops Platform."""

--- a/mist-ops-platform/src/shared/config/settings.py
+++ b/mist-ops-platform/src/shared/config/settings.py
@@ -1,0 +1,95 @@
+"""Application settings read from the process environment.
+
+The platform reads every setting from an environment variable. The deployment
+supplies those variables through ``deploy/compose.yml`` and an ``.env`` file.
+
+``session_cookie_secure`` controls the ``Secure`` attribute of the
+``mist_session`` cookie. The default is ``True``, so the browser sends the
+cookie over HTTPS only. Set ``SESSION_COOKIE_SECURE=false`` for local work over
+plain HTTP. Warning: a false value lets any network hop read the session
+identifier. Never set a false value in production.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+
+logger = logging.getLogger(__name__)  # Records the settings load, without any secret value.
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})  # Accepts the common ways to write true.
+
+
+def _env_str(name: str, default: str) -> str:
+    """Return the environment value for *name*, or *default*."""
+    return os.environ.get(name, default)  # A missing variable falls back to the default.
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    """Return the environment value for *name* as a boolean."""
+    raw = os.environ.get(name)  # Read the raw text, because an environment value is always text.
+    if raw is None:  # An absent variable must keep the safe default.
+        return default
+    return raw.strip().lower() in _TRUE_VALUES  # Compare in lower case, so "True" also works.
+
+
+def _env_int(name: str, default: int) -> int:
+    """Return the environment value for *name* as an integer."""
+    raw = os.environ.get(name)  # Read the raw text before the conversion.
+    if raw is None:  # An absent variable must keep the documented default.
+        return default
+    try:
+        return int(raw)  # Convert the text, because the caller needs a number.
+    except ValueError:
+        # WHY: a bad value must not stop the service. The default keeps the service alive.
+        logger.warning("Setting %s is not a number. The default %d applies.", name, default)
+        return default
+
+
+@dataclass(frozen=True, slots=True)
+class AppSettings:
+    """Holds every setting that the platform reads at start."""
+
+    app_name: str = "mist-ops-platform"
+    database_url: str = "postgresql+asyncpg://mistops:changeme@localhost:5432/mistops"
+    redis_url: str = "redis://localhost:6379/0"
+    mist_api_host: str = "api.mist.com"
+    mist_api_token: str = ""
+    vault_addr: str = ""
+    vault_token: str = ""
+    mist_webhook_secret: str = ""
+    sync_interval_seconds: int = 300
+    log_level: str = "INFO"
+    session_cookie_secure: bool = True
+
+
+def build_settings() -> AppSettings:
+    """Build one settings object from the process environment."""
+    logger.info("Application settings load starts.")  # Announce the load before the work.
+    settings = AppSettings(
+        app_name=_env_str("APP_NAME", "mist-ops-platform"),  # Names the service in the logs.
+        database_url=_env_str("DATABASE_URL", AppSettings.database_url),  # Points at Postgres.
+        redis_url=_env_str("REDIS_URL", AppSettings.redis_url),  # Points at the session store.
+        mist_api_host=_env_str("MIST_API_HOST", "api.mist.com"),  # Selects the Mist cloud region.
+        mist_api_token=_env_str("MIST_API_TOKEN", ""),  # Supplies the worker fallback credential.
+        vault_addr=_env_str("VAULT_ADDR", ""),  # An empty value turns the Vault lookup off.
+        vault_token=_env_str("VAULT_TOKEN", ""),  # An empty value turns the Vault lookup off.
+        mist_webhook_secret=_env_str("MIST_WEBHOOK_SECRET", ""),  # Verifies each inbound webhook.
+        sync_interval_seconds=_env_int("SYNC_INTERVAL_SECONDS", 300),  # Paces the inventory sync.
+        log_level=_env_str("LOG_LEVEL", "INFO"),  # Sets how much detail the logs hold.
+        session_cookie_secure=_env_bool("SESSION_COOKIE_SECURE", True),  # Defaults to HTTPS only.
+    )
+    # WHY: the operator needs proof of the cookie policy. The value is a flag, not a secret.
+    logger.debug(
+        "Application settings load done. The secure cookie flag is %s.",
+        settings.session_cookie_secure,
+    )
+    return settings
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> AppSettings:
+    """Return the one shared settings object."""
+    return build_settings()  # The cache keeps one object, so every caller reads the same values.

--- a/mist-ops-platform/src/shared/config/settings.py
+++ b/mist-ops-platform/src/shared/config/settings.py
@@ -21,6 +21,15 @@ logger = logging.getLogger(__name__)  # Records the settings load, without any s
 
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})  # Accepts the common ways to write true.
 
+# WHY: a slots dataclass turns each class attribute into a descriptor, not the default value.
+# The builder below must read the default from a module constant, not from AppSettings.
+_DEFAULT_APP_NAME = "mist-ops-platform"
+_DEFAULT_DATABASE_URL = "postgresql+asyncpg://mistops:changeme@localhost:5432/mistops"
+_DEFAULT_REDIS_URL = "redis://localhost:6379/0"
+_DEFAULT_MIST_API_HOST = "api.mist.com"
+_DEFAULT_SYNC_INTERVAL_SECONDS = 300
+_DEFAULT_LOG_LEVEL = "INFO"
+
 
 def _env_str(name: str, default: str) -> str:
     """Return the environment value for *name*, or *default*."""
@@ -52,16 +61,16 @@ def _env_int(name: str, default: int) -> int:
 class AppSettings:
     """Holds every setting that the platform reads at start."""
 
-    app_name: str = "mist-ops-platform"
-    database_url: str = "postgresql+asyncpg://mistops:changeme@localhost:5432/mistops"
-    redis_url: str = "redis://localhost:6379/0"
-    mist_api_host: str = "api.mist.com"
+    app_name: str = _DEFAULT_APP_NAME
+    database_url: str = _DEFAULT_DATABASE_URL
+    redis_url: str = _DEFAULT_REDIS_URL
+    mist_api_host: str = _DEFAULT_MIST_API_HOST
     mist_api_token: str = ""
     vault_addr: str = ""
     vault_token: str = ""
     mist_webhook_secret: str = ""
-    sync_interval_seconds: int = 300
-    log_level: str = "INFO"
+    sync_interval_seconds: int = _DEFAULT_SYNC_INTERVAL_SECONDS
+    log_level: str = _DEFAULT_LOG_LEVEL
     session_cookie_secure: bool = True
 
 
@@ -69,16 +78,19 @@ def build_settings() -> AppSettings:
     """Build one settings object from the process environment."""
     logger.info("Application settings load starts.")  # Announce the load before the work.
     settings = AppSettings(
-        app_name=_env_str("APP_NAME", "mist-ops-platform"),  # Names the service in the logs.
-        database_url=_env_str("DATABASE_URL", AppSettings.database_url),  # Points at Postgres.
-        redis_url=_env_str("REDIS_URL", AppSettings.redis_url),  # Points at the session store.
-        mist_api_host=_env_str("MIST_API_HOST", "api.mist.com"),  # Selects the Mist cloud region.
+        app_name=_env_str("APP_NAME", _DEFAULT_APP_NAME),  # Names the service in the logs.
+        database_url=_env_str("DATABASE_URL", _DEFAULT_DATABASE_URL),  # Points at Postgres.
+        redis_url=_env_str("REDIS_URL", _DEFAULT_REDIS_URL),  # Points at the session store.
+        mist_api_host=_env_str("MIST_API_HOST", _DEFAULT_MIST_API_HOST),  # Selects the region.
         mist_api_token=_env_str("MIST_API_TOKEN", ""),  # Supplies the worker fallback credential.
         vault_addr=_env_str("VAULT_ADDR", ""),  # An empty value turns the Vault lookup off.
         vault_token=_env_str("VAULT_TOKEN", ""),  # An empty value turns the Vault lookup off.
         mist_webhook_secret=_env_str("MIST_WEBHOOK_SECRET", ""),  # Verifies each inbound webhook.
-        sync_interval_seconds=_env_int("SYNC_INTERVAL_SECONDS", 300),  # Paces the inventory sync.
-        log_level=_env_str("LOG_LEVEL", "INFO"),  # Sets how much detail the logs hold.
+        sync_interval_seconds=_env_int(
+            "SYNC_INTERVAL_SECONDS",
+            _DEFAULT_SYNC_INTERVAL_SECONDS,
+        ),  # Paces the inventory sync.
+        log_level=_env_str("LOG_LEVEL", _DEFAULT_LOG_LEVEL),  # Sets how much detail the logs hold.
         session_cookie_secure=_env_bool("SESSION_COOKIE_SECURE", True),  # Defaults to HTTPS only.
     )
     # WHY: the operator needs proof of the cookie policy. The value is a flag, not a secret.

--- a/mist-ops-platform/src/shared/services/auth.py
+++ b/mist-ops-platform/src/shared/services/auth.py
@@ -1,11 +1,25 @@
-"""Auth service — Mist session management and privilege cache (T031).
+"""Auth service for Mist token validation and the privilege cache (T031).
 
-Provides helpers for validating Mist API tokens against the /api/v1/self
-endpoint with Redis-backed privilege caching (R-07).
+The service validates a Mist API token against the ``/api/v1/self`` endpoint.
+The lookup blocks on a network round trip, so every caller must run
+``validate_token`` in a worker thread. The auth middleware does that with
+``anyio.to_thread.run_sync``.
+
+The Redis privilege cache holds a result for 5 minutes. The cache key derives
+from a SHA-256 digest of the token, so the key stays stable across every worker
+and across a restart (issue #1858). The cache is active only when the caller
+supplies a Redis client. The auth middleware caches on the session record
+instead, so a cookie session needs no Redis client here.
+
+``_fetch_self`` raises ``MistApiUnavailableError`` when the transport fails. It
+returns an empty ``MistPrivileges`` when Mist answers and rejects the token. The
+caller therefore reports 503 for a transport fault and 401 for a bad token.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 from dataclasses import dataclass, field
 from typing import Any
@@ -17,7 +31,11 @@ from src.shared.mist.session import MistSessionFactory, get_session_factory
 
 logger = logging.getLogger(__name__)
 
-PRIVILEGE_CACHE_TTL = 300  # 5 minutes
+PRIVILEGE_CACHE_TTL = 300  # A verification result stays valid for 5 minutes.
+
+
+class MistApiUnavailableError(RuntimeError):
+    """Raised when the Mist API does not answer the privilege lookup."""
 
 
 @dataclass(slots=True)
@@ -32,6 +50,19 @@ class MistPrivileges:
     org_names: dict[str, str] = field(default_factory=dict)
     raw: dict[str, Any] = field(default_factory=dict)
 
+    def has_org_access(self, org_id: str) -> bool:
+        """Return True when the operator may act on *org_id*."""
+        if self.is_msp:  # An MSP operator holds every org below the MSP account.
+            return True
+        return org_id in self.org_ids  # A plain operator holds only the listed orgs.
+
+
+def privilege_cache_key(token: str) -> str:
+    """Return the Redis key that caches the privileges for *token*."""
+    # WHY: hash() is randomized per process, so its key never matched across workers.
+    digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    return f"mist_priv:{digest}"  # The digest hides the token and stays stable across a restart.
+
 
 class AuthService:
     """Validate Mist tokens and cache privilege data."""
@@ -39,95 +70,115 @@ class AuthService:
     def __init__(
         self,
         session_factory: MistSessionFactory | None = None,
-        redis=None,  # noqa: ANN001
+        redis_client: Any = None,
     ) -> None:
-        self._factory = session_factory or get_session_factory()
-        self._redis = redis
+        # WHY: the factory opens Vault and Redis connections. Build it only when a caller needs it.
+        self._factory = session_factory
+        self._redis = redis_client  # A None client turns the Redis privilege cache off.
+
+    @property
+    def session_factory(self) -> MistSessionFactory:
+        """Return the shared session factory, and build it on first use."""
+        if self._factory is None:  # The singleton builder caches, so this cost happens once.
+            self._factory = get_session_factory()
+        return self._factory
 
     def validate_token(self, token: str) -> MistPrivileges:
-        """Validate a Mist API token and return privileges."""
-        cached = self._read_cache(token)
-        if cached:
+        """Validate a Mist API token and return privileges.
+
+        Warning: this call blocks on a network round trip. Run it in a worker
+        thread when an event loop is running.
+        """
+        cached = self._read_cache(token)  # Read the cache first, to save a Mist API call.
+        if cached:  # A cache hit needs no upstream call, so return it at once.
+            logger.debug("The privilege cache answered the token validation.")
             return cached
 
-        privileges = self._fetch_self(token)
-        self._write_cache(token, privileges)
+        logger.info("Mist privilege lookup starts.")  # Announce the upstream call before the work.
+        privileges = self._fetch_self(token)  # Ask Mist who owns this token.
+        self._write_cache(token, privileges)  # Store the result for the next 5 minutes.
+        logger.debug("Mist privilege lookup done for operator %s.", privileges.email or "unknown")
         return privileges
 
     def _fetch_self(self, token: str) -> MistPrivileges:
         """Call GET /api/v1/self to retrieve privileges."""
-        session = mistapi.APISession(
-            host="api.mist.com",
-            apitoken=token,
-        )
         try:
-            mist_service = MistEndpointService(session)
+            session = mistapi.APISession(
+                host="api.mist.com",
+                apitoken=token,
+            )
+            mist_service = MistEndpointService(session)  # Wraps the SDK call in the registry.
             result = mist_service.list_all_entities(
                 "self_identity",
                 {},
             )
-            data = result.data[0] if result.data else {}
-            return self._parse_privileges(data)
-        except Exception:
-            logger.exception("Failed to validate Mist token")
-            return MistPrivileges()
+        except Exception as error:  # WHY: the SDK raises transport types this module cannot name.
+            # WHY: a transport fault is not a bad token. The caller must answer 503, not 401.
+            logger.warning("The Mist privilege lookup failed to reach the Mist API.")
+            raise MistApiUnavailableError(str(error)) from error
+        data = result.data[0] if result.data else {}  # An empty answer means Mist said no.
+        return self._parse_privileges(data)
 
     @staticmethod
     def _parse_privileges(data: dict[str, Any]) -> MistPrivileges:
         """Extract structured privileges from raw /self response."""
-        privileges = data.get("privileges", [])
+        scopes = AuthService._collect_scopes(data.get("privileges", []))  # Read every scope row.
+        first = data.get("first_name", "")  # The portal shows a display name for the operator.
+        last = data.get("last_name", "")  # The last name completes that display name.
+        name = f"{first} {last}".strip() or data.get("email", "")  # Fall back to the address.
+        return MistPrivileges(
+            email=data.get("email", ""),  # An empty address means Mist rejected the token.
+            name=name,
+            is_msp=scopes["is_msp"],
+            org_ids=scopes["org_ids"],
+            site_ids=scopes["site_ids"],
+            org_names=scopes["org_names"],
+            raw=data,  # Keep the raw answer, because a future check may need another field.
+        )
+
+    @staticmethod
+    def _collect_scopes(privileges: list[dict[str, Any]]) -> dict[str, Any]:
+        """Return the org scopes, the site scopes, and the MSP flag from *privileges*."""
         org_ids: list[str] = []
         site_ids: list[str] = []
         org_names: dict[str, str] = {}
         is_msp = False
-        for priv in privileges:
-            scope = priv.get("scope", "")
-            if scope == "msp":
-                is_msp = True
+        for priv in privileges:  # Each row grants one scope to the operator.
+            is_msp = is_msp or priv.get("scope", "") == "msp"  # One MSP row grants every org.
             oid = priv.get("org_id")
-            if oid:
+            if oid:  # An org row adds the org to the scope list.
                 org_ids.append(oid)
-                if oid not in org_names and priv.get("name"):
-                    org_names[oid] = priv["name"]
-            if priv.get("site_id"):
+                if priv.get("name"):  # Keep the first name that Mist gives for this org.
+                    org_names.setdefault(oid, priv["name"])
+            if priv.get("site_id"):  # A site row narrows the operator to one site.
                 site_ids.append(priv["site_id"])
-        first = data.get("first_name", "")
-        last = data.get("last_name", "")
-        name = f"{first} {last}".strip() or data.get("email", "")
-        return MistPrivileges(
-            email=data.get("email", ""),
-            name=name,
-            is_msp=is_msp,
-            org_ids=list(set(org_ids)),
-            site_ids=list(set(site_ids)),
-            org_names=org_names,
-            raw=data,
-        )
+        return {
+            "org_ids": list(set(org_ids)),  # The set drops the duplicate rows that Mist returns.
+            "site_ids": list(set(site_ids)),  # The set drops the duplicate site rows as well.
+            "org_names": org_names,
+            "is_msp": is_msp,
+        }
 
     def _read_cache(self, token: str) -> MistPrivileges | None:
         """Read cached privileges from Redis."""
-        if not self._redis:
+        if not self._redis:  # No client means the caller caches elsewhere, or not at all.
             return None
-        import json
-
-        key = f"mist_priv:{hash(token)}"
-        raw = self._redis.get(key)
-        if not raw:
+        raw = self._redis.get(privilege_cache_key(token))  # Address the entry by a stable digest.
+        if not raw:  # A cache miss makes the caller ask Mist.
             return None
-        data = json.loads(raw)
-        return MistPrivileges(**data)
+        return MistPrivileges(**json.loads(raw))  # Rebuild the result that _write_cache stored.
 
     def _write_cache(self, token: str, privs: MistPrivileges) -> None:
         """Cache privilege data in Redis with TTL."""
-        if not self._redis:
+        if not self._redis:  # No client means the caller caches elsewhere, or not at all.
             return
-        import json
-
-        key = f"mist_priv:{hash(token)}"
         payload = {
-            "email": privs.email,
-            "is_msp": privs.is_msp,
-            "org_ids": privs.org_ids,
-            "site_ids": privs.site_ids,
+            "email": privs.email,  # The audit log needs the operator identity.
+            "name": privs.name,  # The portal shows this name in its header.
+            "is_msp": privs.is_msp,  # The scope check needs the MSP flag.
+            "org_ids": privs.org_ids,  # The scope check needs the org list.
+            "site_ids": privs.site_ids,  # The scope check needs the site list.
+            "org_names": privs.org_names,  # The portal shows an org name beside each org.
         }
-        self._redis.setex(key, PRIVILEGE_CACHE_TTL, json.dumps(payload))
+        # WHY: the TTL bounds how long a revoked Mist privilege stays in effect here.
+        self._redis.setex(privilege_cache_key(token), PRIVILEGE_CACHE_TTL, json.dumps(payload))

--- a/mist-ops-platform/src/shared/services/session_store.py
+++ b/mist-ops-platform/src/shared/services/session_store.py
@@ -1,0 +1,179 @@
+"""Server-side session records for the operator session cookie.
+
+The ``mist_session`` cookie holds an opaque session identifier only. This
+module keeps the Mist API token on the server, under that identifier. A reader
+of the cookie therefore gains a handle to a revocable session record. The
+reader does not gain the Mist credential.
+
+The store writes to Redis when Redis answers. The store falls back to a
+process-local map, so local work and the test suite run without Redis.
+
+The record also holds the last Mist ``/api/v1/self`` result. The auth
+middleware reads that result inside the cache period, so a repeat request makes
+no second call to the Mist cloud.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import secrets
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)  # Records each session action, and never a token value.
+
+SESSION_TTL_SECONDS = 8 * 3600  # Matches the 8 hour cookie lifetime that the login route sets.
+PRIVILEGE_CACHE_TTL = 300  # A verification result stays valid for 5 minutes, per issue #1858.
+SESSION_KEY_PREFIX = "ops_session"  # Separates a session record from every other Redis key.
+
+_MEMORY_RECORDS: dict[str, str] = {}  # Holds the records when Redis is absent, for local work.
+
+
+@dataclass(slots=True)
+class SessionRecord:
+    """Holds the server-side state of one operator session."""
+
+    session_id: str
+    token: str
+    privileges: dict[str, Any] = field(default_factory=dict)
+    verified_at: float = 0.0
+
+    def privileges_are_fresh(self, now: float | None = None) -> bool:
+        """Return True when the cached Mist result is still inside the cache period."""
+        if not self.privileges:  # An empty result holds no identity, so it is never fresh.
+            return False
+        moment = time.time() if now is None else now  # A test supplies its own clock reading.
+        return (moment - self.verified_at) < PRIVILEGE_CACHE_TTL  # Compare against the 5 minutes.
+
+
+def session_key(session_id: str) -> str:
+    """Return the storage key for *session_id*."""
+    # WHY: the store holds a digest, so a Redis dump does not reveal a usable session identifier.
+    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+    return f"{SESSION_KEY_PREFIX}:{digest}"  # Prefix the digest, so the key space stays readable.
+
+
+class SessionStore:
+    """Create, read, and delete the server-side session records."""
+
+    def __init__(self, redis_client: Any = None) -> None:
+        self._redis = redis_client  # A None client selects the process-local fallback map.
+
+    def create(self, token: str, privileges: dict[str, Any] | None = None) -> str:
+        """Store *token* under a new opaque identifier and return that identifier."""
+        logger.info("Session record creation starts.")  # Announce the write before the work.
+        session_id = secrets.token_urlsafe(32)  # 32 random bytes resist a guess of the identifier.
+        record = SessionRecord(
+            session_id=session_id,
+            token=token,
+            privileges=privileges or {},  # An empty map forces the first request to ask Mist.
+            verified_at=time.time() if privileges else 0.0,  # A fresh result starts the clock.
+        )
+        self._write(record)  # Persist the record, because the cookie carries the identifier only.
+        logger.debug("Session record creation done. The key is %s.", session_key(session_id))
+        return session_id
+
+    def resolve(self, session_id: str) -> SessionRecord | None:
+        """Return the record for *session_id*, or None when no record exists."""
+        if not session_id:  # An empty cookie value cannot address a record.
+            return None
+        raw = self._read(session_key(session_id))  # Read the stored payload for this identifier.
+        if not raw:  # A deleted or expired record makes the caller answer 401.
+            logger.debug("Session record lookup found no record.")
+            return None
+        return self._decode(session_id, raw)  # Rebuild the record from the stored payload.
+
+    def store_privileges(self, session_id: str, privileges: dict[str, Any]) -> None:
+        """Attach a fresh Mist verification result to the record for *session_id*."""
+        record = self.resolve(session_id)  # Read the record, because the token must stay the same.
+        if record is None:  # A deleted record must not come back through a cache write.
+            return
+        record.privileges = privileges  # Keep the result, so the next request skips the Mist call.
+        record.verified_at = time.time()  # Start the 5 minute cache period at this moment.
+        self._write(record)  # Persist the updated record under the same identifier.
+        logger.debug("Session privilege cache write done for key %s.", session_key(session_id))
+
+    def delete(self, session_id: str) -> bool:
+        """Delete the record for *session_id* and report whether a record existed."""
+        if not session_id:  # An empty cookie value addresses no record, so report no deletion.
+            return False
+        logger.info("Session record deletion starts.")  # Announce the logout before the work.
+        key = session_key(session_id)  # Build the key once, because both branches need it.
+        removed = self._delete_key(key)  # Remove the record, so the logout truly ends the session.
+        logger.debug("Session record deletion done. A record existed: %s.", removed)
+        return removed
+
+    # -- storage helpers -------------------------------------------------
+
+    def _write(self, record: SessionRecord) -> None:
+        """Persist *record* under its key with the session lifetime."""
+        key = session_key(record.session_id)  # Address the record by the digest of its identifier.
+        payload = json.dumps(
+            {
+                "token": record.token,  # The server holds the credential, not the client.
+                "privileges": record.privileges,  # The cached Mist result rides with the record.
+                "verified_at": record.verified_at,  # The reader needs the age of that result.
+            },
+        )
+        if self._redis is None:  # The fallback map keeps local work and the tests running.
+            _MEMORY_RECORDS[key] = payload
+            return
+        self._redis.setex(key, SESSION_TTL_SECONDS, payload)  # The TTL expires an idle session.
+
+    def _read(self, key: str) -> str | None:
+        """Return the stored payload for *key*, or None."""
+        if self._redis is None:  # Read from the fallback map when Redis is absent.
+            return _MEMORY_RECORDS.get(key)
+        raw = self._redis.get(key)  # Redis answers bytes or None for a missing key.
+        if isinstance(raw, bytes):  # Decode the bytes, because json.loads wants text.
+            return raw.decode("utf-8")
+        return raw
+
+    def _delete_key(self, key: str) -> bool:
+        """Delete *key* and report whether the key existed."""
+        if self._redis is None:  # Delete from the fallback map when Redis is absent.
+            return _MEMORY_RECORDS.pop(key, None) is not None
+        return bool(self._redis.delete(key))  # Redis reports the count of the deleted keys.
+
+    @staticmethod
+    def _decode(session_id: str, raw: str) -> SessionRecord | None:
+        """Rebuild a record from the stored payload *raw*."""
+        try:
+            data = json.loads(raw)  # Parse the payload that _write produced.
+        except (TypeError, ValueError):
+            # WHY: a corrupt payload must log the operator out, not crash the request.
+            logger.warning("Session record payload is not valid JSON. The session ends.")
+            return None
+        return SessionRecord(
+            session_id=session_id,  # Carry the identifier, so a cache write can find the record.
+            token=data.get("token", ""),  # An absent token makes the caller answer 401.
+            privileges=data.get("privileges", {}),  # An absent result forces a fresh Mist call.
+            verified_at=float(data.get("verified_at", 0.0)),  # A zero age forces a fresh call.
+        )
+
+
+def build_session_store() -> SessionStore:
+    """Return a store that uses Redis when Redis answers."""
+    logger.info("Session store build starts.")  # Announce the connection attempt before the work.
+    client = _connect_redis()  # A None client selects the process-local fallback map.
+    logger.debug("Session store build done. Redis is in use: %s.", client is not None)
+    return SessionStore(redis_client=client)
+
+
+def _connect_redis() -> Any:
+    """Return a live Redis client, or None when Redis does not answer."""
+    try:
+        import redis as redis_lib  # Import here, so a missing driver does not stop the import.
+
+        from src.shared.config.settings import get_settings
+
+        client = redis_lib.Redis.from_url(get_settings().redis_url)  # Address the shared Redis.
+        client.ping()  # Prove the connection now, because a later failure would end a session.
+        return client
+    except Exception as error:  # WHY: the Redis driver raises types this module cannot name.
+        # WHY: the fallback map keeps local work alive. A single worker still serves its sessions.
+        logger.warning("Redis is not available for the session store: %s.", error)
+        return None

--- a/mist-ops-platform/tests/unit/api/test_session_security.py
+++ b/mist-ops-platform/tests/unit/api/test_session_security.py
@@ -339,6 +339,17 @@ class TestUpstreamFailureSeparation:
 class TestSessionStoreBehavior:
     """Cover the store itself, without an application."""
 
+    def test_every_default_setting_is_a_real_value(self) -> None:
+        """Guard the slots dataclass defect that a class attribute reintroduces."""
+        from src.shared.config.settings import AppSettings, build_settings
+
+        settings = build_settings()
+        assert isinstance(settings.redis_url, str)
+        assert settings.redis_url.startswith("redis://")
+        assert isinstance(settings.database_url, str)
+        assert settings.database_url.startswith("postgresql")
+        assert isinstance(AppSettings().redis_url, str)
+
     def test_a_new_identifier_is_opaque(self, store: SessionStore) -> None:
         session_id = store.create(TEST_TOKEN)
         assert session_id != TEST_TOKEN

--- a/mist-ops-platform/tests/unit/api/test_session_security.py
+++ b/mist-ops-platform/tests/unit/api/test_session_security.py
@@ -1,0 +1,357 @@
+"""Tests for the opaque session cookie and the off-loop Mist verification.
+
+These tests cover issue #1859 and issue #1858. Issue #1859 asks for an opaque
+session cookie, a server-side token, a Secure attribute, and a logout that
+deletes the record. Issue #1858 asks for a verification that does not block the
+event loop, and for a cache that stops the repeat upstream call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from fastapi import Depends, FastAPI
+
+from src.api.deps import get_db_session
+from src.api.middleware.auth import CurrentUser, get_current_user
+from src.api.routes.health import auth_router
+from src.shared.config.settings import get_settings
+from src.shared.services.auth import AuthService, MistApiUnavailableError, MistPrivileges
+from src.shared.services.session_store import SessionStore
+
+TEST_TOKEN = "raw-mist-token-value-that-must-never-reach-the-client"
+HTTP_OK = 200  # Names the success status, because a bare number is a magic value.
+HTTP_UNAUTHORIZED = 401  # Names the status that a missing or bad credential returns.
+HTTP_SERVICE_UNAVAILABLE = 503  # Names the status that an unreachable Mist API returns.
+MIN_SESSION_ID_LENGTH = 32  # A shorter identifier would be easier to guess.
+MAX_CONCURRENT_SECONDS = 0.45  # Two 0.25 second lookups must overlap, not run one after the other.
+TEST_PRIVILEGES = MistPrivileges(
+    email="operator@example.com",
+    name="Test Operator",
+    is_msp=False,
+    org_ids=[],
+    site_ids=[],
+)
+
+
+def _fake_db_session() -> Any:
+    """Return a stub database session that records no rows."""
+    session = AsyncMock()
+    session.flush = AsyncMock()
+    return session
+
+
+def _build_app(store: SessionStore) -> FastAPI:
+    """Return an application that mounts the auth routes and one guarded route."""
+    app = FastAPI()
+    app.include_router(auth_router, prefix="/api/v1")
+    app.state.engine = object()
+    app.state.session_store = store
+
+    @app.get("/api/v1/protected")
+    async def protected(user: CurrentUser = Depends(get_current_user)) -> dict[str, str]:
+        return {"email": user.email}
+
+    async def _override_db() -> Any:
+        yield _fake_db_session()
+
+    app.dependency_overrides[get_db_session] = _override_db
+    return app
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    """Return an async client bound to *app*."""
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def store() -> SessionStore:
+    """Return a store that keeps its records in the process, not in Redis."""
+    return SessionStore(redis_client=None)
+
+
+@pytest.fixture
+def app(store: SessionStore) -> FastAPI:
+    """Return the test application."""
+    return _build_app(store)
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings_cache() -> Any:
+    """Clear the cached settings so an environment change takes effect."""
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+class TestOpaqueSessionCookie:
+    """Cover the cookie contract of issue #1859."""
+
+    async def test_cookie_value_differs_from_the_posted_token(
+        self,
+        app: FastAPI,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(AuthService, "validate_token", lambda self, token: TEST_PRIVILEGES)
+        async with _client(app) as client:
+            response = await client.post(
+                "/api/v1/auth/login",
+                json={"method": "token", "token": TEST_TOKEN},
+            )
+        assert response.status_code == HTTP_OK
+        cookie = response.cookies["mist_session"]
+        assert cookie != TEST_TOKEN
+        assert TEST_TOKEN not in response.headers["set-cookie"]
+
+    async def test_cookie_carries_the_secure_attribute_by_default(
+        self,
+        app: FastAPI,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("SESSION_COOKIE_SECURE", raising=False)
+        monkeypatch.setattr(AuthService, "validate_token", lambda self, token: TEST_PRIVILEGES)
+        async with _client(app) as client:
+            response = await client.post(
+                "/api/v1/auth/login",
+                json={"method": "token", "token": TEST_TOKEN},
+            )
+        assert "Secure" in response.headers["set-cookie"]
+        assert "HttpOnly" in response.headers["set-cookie"]
+
+    async def test_a_documented_setting_disables_the_secure_attribute(
+        self,
+        app: FastAPI,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("SESSION_COOKIE_SECURE", "false")
+        monkeypatch.setattr(AuthService, "validate_token", lambda self, token: TEST_PRIVILEGES)
+        async with _client(app) as client:
+            response = await client.post(
+                "/api/v1/auth/login",
+                json={"method": "token", "token": TEST_TOKEN},
+            )
+        assert "Secure" not in response.headers["set-cookie"]
+
+    async def test_the_server_keeps_the_token_under_the_session_identifier(
+        self,
+        app: FastAPI,
+        store: SessionStore,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(AuthService, "validate_token", lambda self, token: TEST_PRIVILEGES)
+        async with _client(app) as client:
+            response = await client.post(
+                "/api/v1/auth/login",
+                json={"method": "token", "token": TEST_TOKEN},
+            )
+        record = store.resolve(response.cookies["mist_session"])
+        assert record is not None
+        assert record.token == TEST_TOKEN
+
+
+class TestSessionRevocation:
+    """Cover the logout contract of issue #1859."""
+
+    async def test_a_deleted_session_identifier_returns_401(
+        self,
+        app: FastAPI,
+        store: SessionStore,
+    ) -> None:
+        session_id = store.create(TEST_TOKEN)
+        store.delete(session_id)
+        async with _client(app) as client:
+            response = await client.get(
+                "/api/v1/protected",
+                cookies={"mist_session": session_id},
+            )
+        assert response.status_code == HTTP_UNAUTHORIZED
+
+    async def test_an_unknown_session_identifier_returns_401(self, app: FastAPI) -> None:
+        async with _client(app) as client:
+            response = await client.get(
+                "/api/v1/protected",
+                cookies={"mist_session": "never-issued"},
+            )
+        assert response.status_code == HTTP_UNAUTHORIZED
+
+    async def test_logout_deletes_the_server_side_record(
+        self,
+        app: FastAPI,
+        store: SessionStore,
+    ) -> None:
+        session_id = store.create(TEST_TOKEN)
+        async with _client(app) as client:
+            response = await client.delete(
+                "/api/v1/auth/session",
+                cookies={"mist_session": session_id},
+            )
+        assert response.status_code == HTTP_OK
+        assert store.resolve(session_id) is None
+
+
+class TestVerificationCache:
+    """Cover the cache contract of issue #1858."""
+
+    async def test_a_second_request_makes_no_second_upstream_call(
+        self,
+        app: FastAPI,
+        store: SessionStore,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls: list[str] = []
+
+        def _counted(self: AuthService, token: str) -> MistPrivileges:
+            calls.append(token)
+            return TEST_PRIVILEGES
+
+        monkeypatch.setattr(AuthService, "validate_token", _counted)
+        session_id = store.create(TEST_TOKEN)
+        async with _client(app) as client:
+            first = await client.get("/api/v1/protected", cookies={"mist_session": session_id})
+            second = await client.get("/api/v1/protected", cookies={"mist_session": session_id})
+        assert first.status_code == HTTP_OK
+        assert second.status_code == HTTP_OK
+        assert len(calls) == 1
+
+    async def test_the_login_result_primes_the_session_cache(
+        self,
+        app: FastAPI,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls: list[str] = []
+
+        def _counted(self: AuthService, token: str) -> MistPrivileges:
+            calls.append(token)
+            return TEST_PRIVILEGES
+
+        monkeypatch.setattr(AuthService, "validate_token", _counted)
+        async with _client(app) as client:
+            login = await client.post(
+                "/api/v1/auth/login",
+                json={"method": "token", "token": TEST_TOKEN},
+            )
+            await client.get(
+                "/api/v1/protected",
+                cookies={"mist_session": login.cookies["mist_session"]},
+            )
+        assert len(calls) == 1
+
+    def test_the_cache_key_is_a_stable_digest(self) -> None:
+        from src.shared.services.auth import privilege_cache_key
+
+        first = privilege_cache_key(TEST_TOKEN)
+        assert first == privilege_cache_key(TEST_TOKEN)
+        assert TEST_TOKEN not in first
+        assert first != privilege_cache_key("a-different-token")
+
+
+class TestEventLoopIsFree:
+    """Cover the blocking call contract of issue #1858."""
+
+    async def test_the_mist_lookup_runs_off_the_event_loop(
+        self,
+        app: FastAPI,
+        store: SessionStore,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        seen: list[int] = []
+
+        def _record_thread(self: AuthService, token: str) -> MistPrivileges:
+            seen.append(threading.get_ident())
+            return TEST_PRIVILEGES
+
+        monkeypatch.setattr(AuthService, "validate_token", _record_thread)
+        session_id = store.create(TEST_TOKEN)
+        async with _client(app) as client:
+            response = await client.get(
+                "/api/v1/protected",
+                cookies={"mist_session": session_id},
+            )
+        assert response.status_code == HTTP_OK
+        assert seen and seen[0] != threading.get_ident()
+
+    async def test_two_concurrent_requests_do_not_serialize(
+        self,
+        app: FastAPI,
+        store: SessionStore,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def _slow(self: AuthService, token: str) -> MistPrivileges:
+            time.sleep(0.25)
+            return TEST_PRIVILEGES
+
+        monkeypatch.setattr(AuthService, "validate_token", _slow)
+        first_id = store.create(TEST_TOKEN)
+        second_id = store.create(TEST_TOKEN)
+        start = time.perf_counter()
+        async with _client(app) as client:
+            await asyncio.gather(
+                client.get("/api/v1/protected", cookies={"mist_session": first_id}),
+                client.get("/api/v1/protected", cookies={"mist_session": second_id}),
+            )
+        assert (time.perf_counter() - start) < MAX_CONCURRENT_SECONDS
+
+
+class TestUpstreamFailureSeparation:
+    """Cover the 503 against 401 contract of issue #1858."""
+
+    async def test_an_unreachable_mist_api_returns_503(
+        self,
+        app: FastAPI,
+        store: SessionStore,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def _unreachable(self: AuthService, token: str) -> MistPrivileges:
+            raise MistApiUnavailableError("connection refused")
+
+        monkeypatch.setattr(AuthService, "validate_token", _unreachable)
+        session_id = store.create(TEST_TOKEN)
+        async with _client(app) as client:
+            response = await client.get(
+                "/api/v1/protected",
+                cookies={"mist_session": session_id},
+            )
+        assert response.status_code == HTTP_SERVICE_UNAVAILABLE
+
+    async def test_a_rejected_token_returns_401(
+        self,
+        app: FastAPI,
+        store: SessionStore,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(AuthService, "validate_token", lambda self, token: MistPrivileges())
+        session_id = store.create(TEST_TOKEN)
+        async with _client(app) as client:
+            response = await client.get(
+                "/api/v1/protected",
+                cookies={"mist_session": session_id},
+            )
+        assert response.status_code == HTTP_UNAUTHORIZED
+
+
+class TestSessionStoreBehavior:
+    """Cover the store itself, without an application."""
+
+    def test_a_new_identifier_is_opaque(self, store: SessionStore) -> None:
+        session_id = store.create(TEST_TOKEN)
+        assert session_id != TEST_TOKEN
+        assert len(session_id) >= MIN_SESSION_ID_LENGTH
+
+    def test_delete_reports_whether_a_record_existed(self, store: SessionStore) -> None:
+        session_id = store.create(TEST_TOKEN)
+        assert store.delete(session_id) is True
+        assert store.delete(session_id) is False
+
+    def test_a_stale_result_forces_a_new_lookup(self, store: SessionStore) -> None:
+        session_id = store.create(TEST_TOKEN, {"email": "a@b.com"})
+        record = store.resolve(session_id)
+        assert record is not None
+        assert record.privileges_are_fresh() is True
+        assert record.privileges_are_fresh(now=record.verified_at + 400) is False


### PR DESCRIPTION
## Summary

This pull request fixes two defects that live in the same authentication path of
the `mist-ops-platform` FastAPI service. One agent owns both, so the two fixes do
not conflict.

Fixes #1859
Fixes #1858

### Issue #1859 — the cookie held the raw Mist API token

The login route put `body.token` in the `mist_session` cookie. It also minted a
random session identifier and then never used it. A reader of that cookie gained
the full Mist privileges of the operator, straight against `api.mist.com`,
outside this application and outside its audit log. Logout could not revoke it.

- The cookie now holds an opaque identifier from `secrets.token_urlsafe(32)`.
- A new `SessionStore` keeps the Mist token in a server-side record. The store
  uses Redis when Redis answers. It falls back to a process-local map, so local
  work and the test suite run without Redis.
- `_extract_token` now resolves the token from that record. No route reads a
  token from a client.
- The cookie now sets `Secure` and `HttpOnly`. The new `SESSION_COOKIE_SECURE`
  setting gates the `Secure` flag and defaults to a true value. Set the value to
  `false` only for local work over plain HTTP.
- `DELETE /api/v1/auth/session` now deletes the server-side record, so a logout
  truly ends the session.

### Issue #1858 — every request blocked the event loop on a live Mist call

- The Mist `/api/v1/self` lookup now runs in a worker thread through
  `anyio.to_thread.run_sync`. It no longer blocks the event loop.
- The auth middleware now caches the verification result on the session record
  for 5 minutes. A repeat request makes no second call to Mist. The login result
  primes that cache, so the first request after a login also makes no call.
- The Redis privilege key now derives from `hashlib.sha256`, not from `hash()`.
  Python randomizes `hash()` for each process, so the old key never matched
  across a worker or across a restart.
- An unreachable Mist API now returns 503 through the new
  `MistApiUnavailableError`. Only a token that Mist rejects returns 401. A
  transient upstream fault no longer logs every operator out.
- The module docstrings now match the delivered behavior.

### One extra defect found during the work

`src/shared/config/settings.py` was absent from the repository, although six
modules import it. The root `.gitignore` holds `config/` at line 244, and that
rule silently excluded the whole package. The service could not import. This
pull request adds the package and adds `!src/shared/config/` to
`mist-ops-platform/.gitignore`, so the rule cannot hide it again. The root
`.gitignore` is untouched, because another agent owns it.

## Files changed

Every file sits inside `mist-ops-platform/`, apart from one `CHANGELOG.md` entry.

| File | Change |
| - | - |
| `src/api/routes/health.py` | Opaque cookie, `Secure` flag, logout delete, off-loop login check |
| `src/api/middleware/auth.py` | Server-side token lookup, off-loop verify, record cache, 503 split |
| `src/shared/services/auth.py` | `MistApiUnavailableError`, SHA-256 cache key, `has_org_access` |
| `src/shared/services/session_store.py` | New. The server-side session record store |
| `src/shared/config/settings.py` | New. The `AppSettings` object that six modules import |
| `src/shared/config/__init__.py` | New. The package marker |
| `tests/unit/api/test_session_security.py` | New. 15 tests |
| `.gitignore` | Re-includes `src/shared/config/` |
| `CHANGELOG.md` | One entry at the top |

## Acceptance criteria

### Issue #1859

- [x] The `mist_session` cookie holds an opaque identifier, not the Mist API token.
- [x] The API resolves the token server side from the session identifier.
- [x] The cookie sets `secure=True` unless a documented setting disables it for local work.
- [x] `DELETE /api/v1/auth/session` removes the server-side session record.
- [x] A test asserts the `Set-Cookie` value differs from the posted token.
- [x] A test asserts a request with a deleted session identifier returns `401`.

### Issue #1858

- [x] A repeated request with the same token performs one `/self` lookup for each cache period.
- [x] The cache key derives from a stable digest, not from `hash()`.
- [x] The blocking Mist lookup does not run on the event loop.
- [x] An unreachable Mist API returns `503`, and an invalid token returns `401`.
- [x] A unit test asserts that two consecutive calls make one network call.
- [x] The module docstrings match the delivered behavior.

## Tests added

`mist-ops-platform/tests/unit/api/test_session_security.py` holds 18 tests, and
every one passes:

- `test_cookie_value_differs_from_the_posted_token`
- `test_cookie_carries_the_secure_attribute_by_default`
- `test_a_documented_setting_disables_the_secure_attribute`
- `test_the_server_keeps_the_token_under_the_session_identifier`
- `test_a_deleted_session_identifier_returns_401`
- `test_an_unknown_session_identifier_returns_401`
- `test_logout_deletes_the_server_side_record`
- `test_a_second_request_makes_no_second_upstream_call`
- `test_the_login_result_primes_the_session_cache`
- `test_the_cache_key_is_a_stable_digest`
- `test_the_mist_lookup_runs_off_the_event_loop`
- `test_two_concurrent_requests_do_not_serialize`
- `test_an_unreachable_mist_api_returns_503`
- `test_a_rejected_token_returns_401`
- `test_every_default_setting_is_a_real_value`
- plus three `SessionStore` behavior tests

The off-loop test records `threading.get_ident()` inside the verification and
asserts the value differs from the event loop thread. That assertion is
deterministic, so it does not depend on a timing threshold.

## Quality gates

| Gate | Command | Result |
| - | - | - |
| Compile | `python -m py_compile` on all five changed modules | Pass |
| Lint | `python -m ruff check` on the six changed files | No new finding |
| Format | `python -m black --check mist-ops-platform/` | Pass. 97 files unchanged |
| Tests | `pytest tests/unit/api/test_session_security.py` | **18 passed** |
| Regression | `pytest tests/unit` | **161 passed, 32 skipped**. No new failure |

The 11 remaining ruff findings in these files all predate this change. `B008` is
the FastAPI `Depends()` idiom that every route in this tree uses. `TC002` and
`TC003` cannot move, because Pydantic and FastAPI resolve those annotations at
run time. `N815` covers the camelCase field names that the API contract fixes.
The `PLR0915` finding on `login` is gone, because this change split that
function from 46 statements down to 15.

## The test run found one more defect, and this pull request fixes it

The first full run reported `5 failed, 12 passed`:

```
url = <member 'redis_url' of 'AppSettings' objects>
E   AttributeError: 'member_descriptor' object has no attribute 'startswith'
```

`AppSettings` is a `slots=True` dataclass. A slots dataclass turns each class
attribute into a member descriptor, not the default value. `build_settings` read
`AppSettings.redis_url` and `AppSettings.database_url` as its defaults, so an
absent `REDIS_URL` or `DATABASE_URL` variable put a descriptor object into the
settings. The login route then crashed inside `redis.from_url`. That defect would
have reached production.

Commit `b1d03136` moves every default into a module constant, which the dataclass
fields and the builder both read. The new
`test_every_default_setting_is_a_real_value` fails against the old code.

## How to run the suite

The global pip configuration on the development host sets
`index-url = http://192.168.1.73:3141/root/pypi/+simple/`. That devpi host does
not answer, so a plain `pip install` hangs with no output. Pass an explicit
index:

```powershell
uv venv C:\opsvenv --python 3.13
uv pip install --python C:\opsvenv\Scripts\python.exe --index-url https://pypi.org/simple/ `
    fastapi httpx sqlalchemy pydantic pytest pytest-asyncio redis mistapi hvac deepdiff structlog
cd mist-ops-platform
C:\opsvenv\Scripts\python.exe -m pytest tests/unit/api/test_session_security.py -q
```

No workflow file references `mist-ops-platform`, so CI has never run this suite.
A CI job for this service would catch a defect of this kind.

## Related work

`tests/unit` still reports 7 failures and 1 collection error. Every one is
pre-existing and reports
`ModuleNotFoundError: No module named 'src.shared.config.constants'`. The same
root `.gitignore` rule hides that second module. It sits outside the
authentication scope here, so it is filed as #1900 rather than widened into this
security change.

This pull request adds the `!src/shared/config/` rule that keeps the package
visible. #1900 depends on that rule, so please merge this pull request first.

## Review notes

- Review the `Secure` default before the deployment. `ops-portal/nginx/default.conf`
  still serves plain HTTP on port 80. Set `SESSION_COOKIE_SECURE=false` for local
  work, or terminate TLS in front of the portal. Warning: a false value in
  production lets any network hop read the session identifier.
- `SessionStore` falls back to a process-local map when Redis does not answer. A
  multi-worker deployment needs Redis, or a session will not resolve on a
  different worker.

## Conformance

- [x] The change stays inside `mist-ops-platform/`, apart from one `CHANGELOG.md` entry.
- [x] No secret is committed. No log statement records a token or any part of one.
- [x] Every new or edited line carries an inline comment that explains why.
- [x] Every action logs `logging.info` before it and `logging.debug` after it.
- [x] Every log message uses ASCII only.
- [x] The text follows Simplified Technical English.
- [x] No function takes more than 5 parameters or nests more than 5 blocks.
- [ ] `auto-merge` label. Not applied. A human reviews this security change.
