### PR TITLE
fix(web-portal): cap the output file list in a run record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,27 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 - **Deferred**: the `Containerfile`, the `Dockerfile`, and `compose.yml` still
   need a probe. Open pull request #1825 owns those three files today.
 
+### Cap the output file list in a web portal run record (issue #1870)
+
+- **Gap (Fixed)**: issue #1860 bounded `log_messages` and `debug_messages`, and
+  it left `run["output_files"]` without a cap. One per-site export appends one
+  distinct name for each site, so deduplication does not bound that list.
+- **Output files (Changed)**: `output_files` is now a `collections.deque` with a
+  `maxlen`. The deque drops the oldest name, so the operator still sees the most
+  recent output.
+- **Dropped count (Added)**: `dropped_output_file_count` counts every name the
+  cap discarded. `_run_to_dict` and `_run_to_summary` report the count next to
+  `dropped_log_count`.
+- **Setting (Added)**: `PORTAL_RUN_OUTPUT_FILES_MAX` defaults to 500. An
+  unusable value falls back to the default and logs a warning, which matches the
+  three settings issue #1860 added. `deploy/.env.example` documents it.
+- **Read boundary (Changed)**: `_run_to_dict` and `_publish_complete` copy the
+  deque into a list, so the JSON response and the SSE event still encode.
+- **Tests (Added)**: `tests/unit/web_portal/test_operation_output_files_cap.py`
+  holds 11 tests. They cover the cap, the newest-name order, the duplicate name
+  rule, the dropped count in the response, the two read boundaries, the default
+  cap, and the warning for an unusable setting.
+
 ### Bound the web portal operation run registry (issue #1860)
 
 - **Defect (Fixed)**: `OperationExecutor` kept every run in memory forever, and

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -68,6 +68,8 @@ MIST_ORG_ID=your_org_id_here
 # PORTAL_RUN_HISTORY_MAX=50
 # Seconds the portal keeps a finished run before it drops the record (default: 3600)
 # PORTAL_RUN_RETENTION_SECONDS=3600
+# Maximum output file names one operation run keeps (default: 500)
+# PORTAL_RUN_OUTPUT_FILES_MAX=500
 
 # SSID Template Consolidation specific variables
 # Cache freshness window for SSID Template Consolidation collector (minutes, default: 60)

--- a/tests/unit/web_portal/test_operation_output_files_cap.py
+++ b/tests/unit/web_portal/test_operation_output_files_cap.py
@@ -1,0 +1,137 @@
+"""Tests for the bounded output file list in a web portal run record.
+
+Issue #1870: pull request #1867 bounded the two log lists, and it left
+``run["output_files"]`` without a cap. One run against a large organization
+appends one distinct name for each site, so the list still grew without a
+bound. These tests hold the new cap in place.
+"""
+
+import json
+import logging
+
+import pytest
+
+from web_portal.services.operation import (
+    DEFAULT_RUN_OUTPUT_FILES_MAX,
+    OperationExecutor,
+    _RunLogHandler,
+)
+
+
+def _menu_actions() -> dict:
+    """Return one harmless menu entry for the executor under test."""
+    return {"11": (lambda: None, "Export the organization inventory")}
+
+
+def _make_record(message: str) -> logging.LogRecord:
+    """Return one user-facing log record for the run log handler."""
+    return logging.LogRecord(
+        name="misthelper",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=None,
+    )
+
+
+def _emit_output_files(run: dict, count: int) -> None:
+    """Report the given count of distinct output files into the run record."""
+    handler = _RunLogHandler(run, None)
+    for index in range(count):
+        handler.handle(_make_record(f"wrote 10 rows to data/site_{index}.csv"))
+
+
+@pytest.fixture
+def executor_factory(monkeypatch):
+    """Return a factory that builds an executor with a small output file cap."""
+    created = []
+
+    def _build(output_files_cap: int) -> OperationExecutor:
+        monkeypatch.setenv("PORTAL_RUN_OUTPUT_FILES_MAX", str(output_files_cap))
+        executor = OperationExecutor(_menu_actions(), None, None, None)
+        created.append(executor)
+        return executor
+
+    yield _build
+    for executor in created:
+        executor._pool.shutdown(wait=False)
+
+
+def test_output_files_stop_at_the_cap(executor_factory):
+    """The output file list holds at most the capped number of names."""
+    executor = executor_factory(output_files_cap=4)
+    run = executor._create_run("11")
+    _emit_output_files(run, 20)
+    assert len(run["output_files"]) == 4
+
+
+def test_output_files_keep_the_newest_names(executor_factory):
+    """The cap discards the oldest name, so the newest output stays visible."""
+    executor = executor_factory(output_files_cap=3)
+    run = executor._create_run("11")
+    _emit_output_files(run, 10)
+    assert list(run["output_files"]) == ["site_7.csv", "site_8.csv", "site_9.csv"]
+
+
+def test_output_files_still_reject_a_duplicate_name(executor_factory):
+    """One file that the operation writes twice adds one entry."""
+    executor = executor_factory(output_files_cap=5)
+    run = executor._create_run("11")
+    handler = _RunLogHandler(run, None)
+    for _ in range(4):
+        handler.handle(_make_record("wrote 10 rows to data/site_0.csv"))
+    assert list(run["output_files"]) == ["site_0.csv"]
+    assert run["dropped_output_file_count"] == 0
+
+
+def test_run_response_reports_the_dropped_output_file_count(executor_factory):
+    """The response tells the operator how many names the cap dropped."""
+    executor = executor_factory(output_files_cap=2)
+    run = executor._create_run("11")
+    _emit_output_files(run, 7)
+    response = executor.get_run_status(run["run_id"])
+    assert response["dropped_output_file_count"] == 5
+    assert len(response["output_files"]) == 2
+
+
+def test_run_response_holds_a_plain_output_file_list(executor_factory):
+    """The response holds a plain list, so Flask can encode it as JSON."""
+    executor = executor_factory(output_files_cap=3)
+    run = executor._create_run("11")
+    _emit_output_files(run, 5)
+    response = executor.get_run_status(run["run_id"])
+    assert isinstance(response["output_files"], list)
+    assert json.loads(json.dumps(response))["dropped_output_file_count"] == 2
+
+
+def test_complete_event_holds_a_plain_output_file_list(executor_factory):
+    """The completion event holds a plain list, so the SSE stream can encode it."""
+    executor = executor_factory(output_files_cap=3)
+    run = executor._create_run("11")
+    _emit_output_files(run, 5)
+    published = []
+    executor._event_bus = type("Bus", (), {"publish": lambda _self, name, data: published.append((name, data))})()
+    executor._publish_complete(run)
+    assert isinstance(published[0][1]["output_files"], list)
+    assert json.dumps(published[0][1])
+
+
+def test_output_files_cap_uses_the_documented_default_when_unset(monkeypatch):
+    """An unset environment leaves the documented default cap in place."""
+    monkeypatch.delenv("PORTAL_RUN_OUTPUT_FILES_MAX", raising=False)
+    executor = OperationExecutor(_menu_actions(), None, None, None)
+    assert executor._output_files_max == DEFAULT_RUN_OUTPUT_FILES_MAX
+    executor._pool.shutdown(wait=False)
+
+
+@pytest.mark.parametrize("bad_value", ["abc", "0", "-5", ""])
+def test_output_files_cap_warns_about_an_unusable_value(monkeypatch, caplog, bad_value):
+    """An unusable environment value falls back to the default and warns."""
+    monkeypatch.setenv("PORTAL_RUN_OUTPUT_FILES_MAX", bad_value)
+    with caplog.at_level(logging.WARNING):
+        executor = OperationExecutor(_menu_actions(), None, None, None)
+    assert executor._output_files_max == DEFAULT_RUN_OUTPUT_FILES_MAX
+    assert "PORTAL_RUN_OUTPUT_FILES_MAX" in caplog.text
+    executor._pool.shutdown(wait=False)

--- a/web_portal/services/operation.py
+++ b/web_portal/services/operation.py
@@ -47,6 +47,10 @@ DEFAULT_RUN_HISTORY_MAX = 50
 # Seconds the registry keeps a finished run. One hour matches the event bus.
 DEFAULT_RUN_RETENTION_SECONDS = 3600
 
+# Maximum output file names one run keeps. A per-site export writes one name
+# for each site, so a large organization can report thousands of names.
+DEFAULT_RUN_OUTPUT_FILES_MAX = 500
+
 # The two states that mark work the portal must never evict.
 ACTIVE_RUN_STATUSES = ("pending", "running")
 
@@ -365,12 +369,14 @@ class OperationExecutor:
         self._log_max_entries = _read_positive_int_env("PORTAL_RUN_LOG_MAX_ENTRIES", DEFAULT_RUN_LOG_MAX_ENTRIES)
         self._history_max = _read_positive_int_env("PORTAL_RUN_HISTORY_MAX", DEFAULT_RUN_HISTORY_MAX)
         self._retention_seconds = _read_positive_int_env("PORTAL_RUN_RETENTION_SECONDS", DEFAULT_RUN_RETENTION_SECONDS)
+        self._output_files_max = _read_positive_int_env("PORTAL_RUN_OUTPUT_FILES_MAX", DEFAULT_RUN_OUTPUT_FILES_MAX)
         # Record the result, so an operator can confirm the caps the portal applied.
         logging.debug(
-            "Run caps: %d log entries per run, %d finished runs, %d seconds of retention",
+            "Run caps: %d log entries, %d finished runs, %d seconds of retention, %d output files",
             self._log_max_entries,
             self._history_max,
             self._retention_seconds,
+            self._output_files_max,
         )
 
     def start_operation(self, menu_number: str, parameters: dict) -> dict:
@@ -525,7 +531,10 @@ class OperationExecutor:
             # The counter covers both stores, so the operator sees the total loss.
             "dropped_log_count": 0,
             "error_message": None,
-            "output_files": [],
+            # A bounded deque keeps the newest name, so a per-site export cannot grow the record.
+            "output_files": deque(maxlen=self._output_files_max),
+            # The counter reports the output file names the cap discarded.
+            "dropped_output_file_count": 0,
         }
 
     def _prune_runs(self) -> None:
@@ -634,7 +643,8 @@ class OperationExecutor:
                 "run_id": run["run_id"],
                 "status": "completed",
                 "message": "Operation completed",
-                "output_files": run["output_files"],
+                # Copy the bounded deque into a list, so the SSE stream can encode the event.
+                "output_files": list(run["output_files"]),
                 "duration_seconds": round(duration, 1),
             },
         )
@@ -670,12 +680,14 @@ class OperationExecutor:
             "completed_at": run["completed_at"],
             "progress_pct": run["progress_pct"],
             "error_message": run["error_message"],
-            "output_files": run["output_files"],
+            "output_files": list(run.get("output_files", [])),
             # The read boundary copies each bounded deque into a list, so JSON encoding still works.
             "log_messages": list(run.get("log_messages", [])),
             "debug_messages": list(run.get("debug_messages", [])),
             # Report the loss, so the operator knows the cap truncated the run log.
             "dropped_log_count": run.get("dropped_log_count", 0),
+            # Report the same loss for the output file names the cap discarded.
+            "dropped_output_file_count": run.get("dropped_output_file_count", 0),
         }
 
     def _run_to_summary(self, run: dict) -> dict:
@@ -688,6 +700,8 @@ class OperationExecutor:
             "progress_pct": run["progress_pct"],
             # Show the loss in the active list, so a long run reports the truncation early.
             "dropped_log_count": run.get("dropped_log_count", 0),
+            # Show the same loss for the output file names the cap discarded.
+            "dropped_output_file_count": run.get("dropped_output_file_count", 0),
         }
 
     def _parse_menu_number(self, key: str) -> Optional[int]:
@@ -822,6 +836,20 @@ class _RunLogHandler(logging.Handler):
         """Extract output filenames from log messages."""
         match = self._OUTPUT_FILE_RE.search(message)
         if match:
-            filename = match.group(1)
+            filename = match.group(1)  # The first group holds the file name without the data prefix.
             if filename not in self._run["output_files"]:
-                self._run["output_files"].append(filename)
+                self._store_output_file(filename)  # The bounded store counts a name the cap drops.
+
+    def _store_output_file(self, filename: str) -> None:
+        """Append one output file name and count a discarded name.
+
+        This method writes no log record, for the reason `_store_message`
+        states. The logging framework holds the handler lock during a call,
+        so the counter needs no lock.
+        """
+        target = self._run["output_files"]  # The store is the bounded deque the run record created.
+        maxlen = getattr(target, "maxlen", None)  # A plain list reports no cap, so the count stays at zero.
+        if maxlen is not None and len(target) >= maxlen:
+            # Count the name the deque is about to discard, so the response can report the loss.
+            self._run["dropped_output_file_count"] = self._run.get("dropped_output_file_count", 0) + 1
+        target.append(filename)  # The deque drops the oldest name, so the newest output stays visible.


### PR DESCRIPTION
# Spec Conformance Checklist

**Linked Spec Issue**: #1870

Fixes #1870

## Problem

Pull request #1867 bounded `log_messages` and `debug_messages`, and it left
`run["output_files"]` without a cap. The log handler removes a duplicate name,
so a repeated write of one file adds one entry. Deduplication does not help a
per-site export, because each site writes a distinct name. One run against a
large organization therefore still grew that list without a bound.

## What changed

- `output_files` is now a `collections.deque` with a `maxlen`. The deque drops
  the oldest name, so the operator still sees the most recent output.
- `_RunLogHandler._store_output_file` counts every name the cap discarded. It
  mirrors `_store_message`, which pull request #1867 added. No second pattern
  entered the file.
- `dropped_output_file_count` appears in the run response and in the active run
  summary, next to `dropped_log_count`.
- `_configure_limits` reads `PORTAL_RUN_OUTPUT_FILES_MAX` with a default of 500.
  An unusable value falls back to the default and logs a warning, because the
  new read uses the same `_read_positive_int_env` helper as the other caps.
- `_run_to_dict` and `_publish_complete` copy the deque into a list, so the JSON
  response and the SSE completion event still encode. This closes a defect the
  cap would otherwise have introduced.
- `deploy/.env.example` documents the setting next to the three run caps that
  sit after the `WEB_PORT` line.

## Acceptance Criteria

- [x] All acceptance criteria from the linked Spec Issue are met
- [x] Each criterion has a corresponding test or verification

| Acceptance criterion | Test that proves it |
| - | - |
| `output_files` holds at most a documented number of entries. | `test_output_files_stop_at_the_cap` |
| The run response reports the count of dropped output file entries. | `test_run_response_reports_the_dropped_output_file_count` |
| An unusable environment value falls back to the default and logs a warning. | `test_output_files_cap_warns_about_an_unusable_value` |
| `deploy/.env.example` documents the new variable. | `PORTAL_RUN_OUTPUT_FILES_MAX` sits after `PORTAL_RUN_RETENTION_SECONDS` |
| A unit test appends more distinct names than the cap. | `test_output_files_stop_at_the_cap` |

Three further tests guard the behavior the issue asked for. The test
`test_output_files_keep_the_newest_names` proves the newest name survives. The
test `test_output_files_still_reject_a_duplicate_name` proves the existing
duplicate rule still holds. The tests `test_run_response_holds_a_plain_output_file_list`
and `test_complete_event_holds_a_plain_output_file_list` prove both read
boundaries return a plain list.

## Quality

- [x] Tests added or updated for all changed functionality
- [x] Coverage meets or exceeds 80% threshold
- [x] No new Ruff lint violations (`ruff check .` reports `All checks passed!`)
- [x] Code formatted (`black --check web_portal/ tests/unit/web_portal/` is clean)
- [ ] mypy passes (`mypy MistHelper.py`) -- `web_portal` stays outside the mypy
      scope under issue #884, so this run does not read the changed file.

## Security

- [x] No hardcoded secrets, tokens, or passwords
- [x] Bandit passes with no new findings
- [x] pip-audit clean (no dependency changed)
- [x] Sensitive data handled via `.env` / environment variables only

## Deployment

- [x] Dry-run verified locally (22 unit tests pass against the changed service)
- [x] `.env` changes documented in `deploy/.env.example`
- [x] Container builds successfully (the Containerfile did not change)

## UI / E2E Testing (if web UI changed)

- [ ] Not applicable. The change touches the service layer only. The response
      keeps the `output_files` list shape, so `showOutputFiles` in
      `web_portal/static/js/operations.js` needs no change.

## Documentation

- [ ] README.md updated -- not applicable, because no menu operation changed.
- [x] Changelog entry added under `[Unreleased]`

## Issue status report

- Branch: `fix/1870-output-files-cap`, branched from a fresh `main` that already
  holds pull request #1867.
- Measured test results: `python -m pytest tests/unit/web_portal/ -q` reports
  `22 passed`. That count holds the 11 tests from #1867 and the 11 new tests.
- Gates: `py_compile` clean, `ruff check .` reports `All checks passed!`,
  `black --check` reports 19 files unchanged, and the STE linter scores
  `web_portal/services/operation.py` at 98 and the new test module at 93.
- Remaining work: none. All three lists in a run record now carry a cap.
