### PR TITLE
security(device): print the ZTP password on a live terminal only (#1735)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 - **Terminal gate (Added)**: `_stdout_is_terminal()` calls `sys.stdout.isatty()`
   before the print. The value now reaches a live terminal only. A stream that
   lacks `isatty`, and a stream that raises on the call, both count as unsafe.
+- **Warning order (Added)**: the reveal path writes the warning first, the label
+  and the value second, and the copy guidance last. The operator reads the risk
+  before the screen holds the value. Clause C-4 of
+  `specs/1034-codeql-cleartext-logging/contracts/credential_console.md` states
+  that rule.
 - **Withheld notice (Added)**: a redirect, a pipe, and a recorded session now
   receive a four-line notice. The notice states the decision and the reason. The
   notice also gives two other sources for the value. The notice never holds the
@@ -29,11 +34,16 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 - **Migration rule (Added)**: `TestZtpCredentialMigrationRule` parses the source
   of the three helpers. The test fails when a `logging` call appears next to the
   credential. The rule now lives in a test, so a lost comment cannot drop it.
-- **Tests (Added)**: `tests/unit/test_device_utility_commands.py` gains 13 cases.
-  They prove that a terminal stdout prints the value. They prove that a pipe
-  stdout prints the value nowhere. They prove that no log record holds the value
-  in either mode. They also prove that the empty-payload path and the error path
+- **Tests (Added)**: `tests/unit/test_device_utility_commands.py` gains 17 cases.
+  They prove that a terminal stdout prints the value. They prove that the
+  warning reaches the screen before the value. They prove that a pipe stdout
+  prints the value nowhere. They prove that no log record holds the value in
+  either mode. They also prove that the empty-payload path and the error path
   keep their old behavior.
+- **Divergence from spec 1034 (Noted)**: clause C-2 of the console contract asks
+  for `sys.stdout.write()` instead of `print()`. This change keeps `print()` and
+  blocks the issue #886 migration with an `ast` guard test. Spec 1034 is unbuilt
+  at 0 of 67 tasks, and `CredentialConsole` does not exist yet.
 
 ### Add a real readiness probe and keep the health endpoint cheap (issue #1863)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Stop the ZTP password from reaching a stored stream (issue #1735)
+
+- **Defect (Fixed)**: `src/device/_utility_commands_action.py` printed the live
+  ZTP password to stdout on every call of menu 144. CodeQL alert 173 reported
+  clear-text logging of sensitive data. Three paths stored the value. The first
+  path is an SSH session transcript on container port 2200. The second path is a
+  shell redirect such as `MistHelper.py > run.txt`. The third path is a planned
+  print-to-logging migration under issue #886.
+- **Terminal gate (Added)**: `_stdout_is_terminal()` calls `sys.stdout.isatty()`
+  before the print. The value now reaches a live terminal only. A stream that
+  lacks `isatty`, and a stream that raises on the call, both count as unsafe.
+- **Withheld notice (Added)**: a redirect, a pipe, and a recorded session now
+  receive a four-line notice. The notice states the decision and the reason. The
+  notice also gives two other sources for the value. The notice never holds the
+  value.
+- **Comment (Changed)**: the old comment claimed the value could not reach a
+  file, and the code did not enforce that claim. The new docstring states the
+  review date 2026-08-22, the reason, the migration rule, and the next review
+  trigger.
+- **Migration rule (Added)**: `TestZtpCredentialMigrationRule` parses the source
+  of the three helpers. The test fails when a `logging` call appears next to the
+  credential. The rule now lives in a test, so a lost comment cannot drop it.
+- **Tests (Added)**: `tests/unit/test_device_utility_commands.py` gains 13 cases.
+  They prove that a terminal stdout prints the value. They prove that a pipe
+  stdout prints the value nowhere. They prove that no log record holds the value
+  in either mode. They also prove that the empty-payload path and the error path
+  keep their old behavior.
+
 ### Add a real readiness probe and keep the health endpoint cheap (issue #1863)
 
 - **Defect (Fixed)**: the `/health` endpoint returned the fixed text `healthy` on

--- a/src/device/_utility_commands_action.py
+++ b/src/device/_utility_commands_action.py
@@ -21,6 +21,7 @@ via its own ``__getattr__`` to sibling clusters when needed.
 from __future__ import annotations  # WHY: postponed evaluation for forward-ref type hints
 
 import logging  # WHY: exception-level logging when API calls fail
+import sys  # WHY: the terminal check keeps the ZTP credential off a stored stream
 from typing import Any  # WHY: Any narrows the SDK response type
 
 import mistapi  # WHY: direct SDK access mirrors parent module's usage
@@ -264,24 +265,80 @@ class _UtilityCommandsAction(_ClusterBase):  # WHY: cluster wrapper mirroring ea
                 site_id,
                 device_id,
             )  # WHY: fetch one-time ZTP credential
-            self._render_ztp_response(response)  # WHY: display on console only
+            self._render_ztp_response(response)  # WHY: show the value on a live terminal only
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
             error_msg = f"{type(error).__name__}: {str(error)}"  # WHY: qualify error type
             logging.error("ZTP password request failed: %s", error_msg)  # WHY: audit failure
             print(f"! ZTP password request failed: {error_msg}")  # WHY: surface error
 
     @staticmethod
-    def _render_ztp_response(response: Any) -> None:
-        """Render the ZTP password to the console, never to logs."""
+    def _stdout_is_terminal() -> bool:
+        """Report whether stdout is a live terminal.
+
+        A shell redirect, a pipe, and a recorded SSH session are not
+        terminals. Each one stores the bytes that the tool writes. Menu 144
+        uses this answer to decide whether the ZTP credential is safe to
+        print. Issue #1735 states the reason.
+        """
+        isatty = getattr(sys.stdout, "isatty", None)  # WHY: a replaced stdout can lack the method
+        if not callable(isatty):  # WHY: an unknown stream type is not a proven terminal
+            return False  # WHY: withhold the credential when the stream type is unclear
+        try:
+            return bool(isatty())  # WHY: True only for a live terminal
+        except (OSError, ValueError):  # WHY: a closed or detached stream raises here
+            return False  # WHY: withhold the credential when the check fails
+
+    @staticmethod
+    def _print_ztp_credential(ztp_credential: str) -> None:
+        """Print the ZTP credential on a live terminal.
+
+        Security review 2026-08-22. Issue #1735. CodeQL alert 173.
+
+        Reason: menu 144 exists so an operator can read the one-time ZTP
+        credential on screen. The caller prints the value only when stdout
+        is a live terminal. A shell redirect, a pipe, and a recorded SSH
+        session receive the withheld notice.
+
+        Rule: this function must never call the ``logging`` module, and no
+        caller may pass ``ztp_credential`` to a log record. Issue #886
+        migrates each ``print()`` call to a logger. This function is out of
+        scope for that migration. The test
+        ``TestZtpCredentialMigrationRule`` enforces the rule.
+
+        Next review: when issue #886 lands, when menu 144 changes how it
+        delivers the credential, or when CodeQL reopens alert 173.
+        """
+        print(f"\n-> ZTP Password: {ztp_credential}")  # noqa: T201
+        print("-> The value appears on this terminal only. Copy it now.")  # WHY: one-time value
+
+    @staticmethod
+    def _print_ztp_withheld() -> None:
+        """Print the withheld notice when stdout is not a live terminal.
+
+        The notice does not hold the value, because the stream that reads
+        the notice can store it. The notice tells the operator how to get
+        the value.
+        """
+        print("\n-> ZTP Password withheld. This output is not a live terminal.")  # WHY: state the decision
+        print("-> A redirect, a pipe, or a recorded SSH session would store the value.")  # WHY: state the reason
+        print("-> Run menu 144 again from an interactive terminal to read the value.")  # WHY: first alternate source
+        print("-> The Mist portal also shows the value on the device Utilities page.")  # WHY: second alternate source
+
+    @classmethod
+    def _render_ztp_response(cls, response: Any) -> None:
+        """Render the ZTP password result for the operator."""
         if not hasattr(response, "data"):  # WHY: no payload -> nothing to show
             print("! No password data returned.")  # WHY: signal empty payload
             return
         data = response.data if isinstance(response.data, dict) else {}  # WHY: guard shape
         ztp_credential = data.get("password", str(response.data))  # WHY: prefer dict field
-        # Intentional: user-requested display of ZTP credential to console
-        # only. Not sent to logging framework.
-        print(f"\n-> ZTP Password: {ztp_credential}")  # noqa: T201
-        print("-> (Password displayed on console only - not logged or saved)")  # WHY: reassure operator
+        on_terminal = cls._stdout_is_terminal()  # WHY: a stored stream must not receive the value
+        logging.info("Rendering the ZTP password result, terminal=%s", on_terminal)  # WHY: audit, value excluded
+        if on_terminal:  # WHY: only a live terminal receives the credential
+            cls._print_ztp_credential(ztp_credential)  # WHY: operator reads the value on screen
+        else:  # WHY: a redirect, a pipe, or a recorded session must not store the value
+            cls._print_ztp_withheld()  # WHY: name the alternate sources instead
+        logging.debug("ZTP password render finished, terminal=%s", on_terminal)  # WHY: audit, value excluded
 
     def get_config_commands(self) -> None:
         """Menu 145: Get configuration CLI commands for switch."""

--- a/src/device/_utility_commands_action.py
+++ b/src/device/_utility_commands_action.py
@@ -39,6 +39,9 @@ _SUPPORT_FILE_TYPES: tuple[str, ...] = (
     "jma-logs",  # WHY: Juniper Mist Agent logs
 )
 
+# WHY: clause C-4 of the spec 1034 console contract puts the risk before the value.
+_ZTP_REVEAL_WARNING = "Warning: a session recording captures this screen. The next line holds a live credential."
+
 
 class _UtilityCommandsAction(_ClusterBase):  # WHY: cluster wrapper mirroring earlier phase clusters
     """Wrapper class holding the 10 device-management commands."""
@@ -294,6 +297,12 @@ class _UtilityCommandsAction(_ClusterBase):  # WHY: cluster wrapper mirroring ea
 
         Security review 2026-08-22. Issue #1735. CodeQL alert 173.
 
+        Order: the warning comes first, the label and the value come second,
+        and the copy guidance comes last. The operator reads the risk before
+        the screen holds the value. Clause C-4 of
+        ``specs/1034-codeql-cleartext-logging/contracts/credential_console.md``
+        states that rule.
+
         Reason: menu 144 exists so an operator can read the one-time ZTP
         credential on screen. The caller prints the value only when stdout
         is a live terminal. A shell redirect, a pipe, and a recorded SSH
@@ -308,8 +317,9 @@ class _UtilityCommandsAction(_ClusterBase):  # WHY: cluster wrapper mirroring ea
         Next review: when issue #886 lands, when menu 144 changes how it
         delivers the credential, or when CodeQL reopens alert 173.
         """
-        print(f"\n-> ZTP Password: {ztp_credential}")  # noqa: T201
-        print("-> The value appears on this terminal only. Copy it now.")  # WHY: one-time value
+        print(f"\n{_ZTP_REVEAL_WARNING}")  # WHY: the risk reaches the screen before the value
+        print(f"-> ZTP Password: {ztp_credential}")  # noqa: T201
+        print("-> Copy the value now. The value is a one-time credential.")  # WHY: guidance after the risk
 
     @staticmethod
     def _print_ztp_withheld() -> None:

--- a/tests/unit/test_device_utility_commands.py
+++ b/tests/unit/test_device_utility_commands.py
@@ -9,8 +9,12 @@ Uses identity-checked teardown to avoid cross-test sys.modules contamination.
 
 from __future__ import annotations
 
+import ast
+import inspect
+import io
 import logging
 import sys
+import textwrap
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -23,6 +27,7 @@ _saved_mistapi = sys.modules.get("mistapi")
 _our_mock = MagicMock()
 sys.modules["mistapi"] = _our_mock
 try:
+    from src.device._utility_commands_action import _UtilityCommandsAction
     from src.device._utility_commands_websocket import ExportResultSpec, StreamWsSpec
     from src.device.utility_commands import DeviceUtilityCommands, UtilityCommandsDeps
 finally:
@@ -33,6 +38,21 @@ finally:
 
 _WS_LOGGER = "src.device._utility_commands_websocket"  # WHY: caplog target for #886 print-to-logger tests
 _SEL_LOGGER = "src.device._utility_commands_selection"  # WHY: caplog target for #886 print-to-logger tests
+_ZTP_SECRET = "secret123"  # WHY: one literal keeps every ZTP assertion on the same value
+
+
+class _FakeTerminalStdout(io.StringIO):
+    """Captured stream that reports itself as a live terminal."""
+
+    def isatty(self) -> bool:
+        return True  # WHY: drive the branch that prints the ZTP credential
+
+
+class _FakePipeStdout(io.StringIO):
+    """Captured stream that reports itself as a pipe or a redirect."""
+
+    def isatty(self) -> bool:
+        return False  # WHY: drive the branch that withholds the ZTP credential
 
 
 def setup_module() -> None:
@@ -2098,22 +2118,65 @@ class TestReadoptDevice:
 class TestGetZtpPassword:
     """Tests for get_ztp_password."""
 
+    @staticmethod
+    def _run_with_stdout(
+        duc: DeviceUtilityCommands,
+        mock_api: MagicMock,
+        stream: io.StringIO,
+    ) -> str:
+        """Run menu 144 against a stub stdout and return the captured text."""
+        resp = MagicMock()
+        resp.data = {"password": _ZTP_SECRET}
+        mock_api.api.v1.sites.devices.getSiteDeviceZtpPassword.return_value = resp
+        with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "switch")):
+            with patch.object(sys, "stdout", stream):
+                duc.get_ztp_password()
+        return stream.getvalue()
+
     def test_early_return(self, duc: DeviceUtilityCommands) -> None:
         with patch.object(duc, "_select_site_and_device", return_value=None):
             duc.get_ztp_password()
 
-    def test_success(
+    def test_success_on_terminal_prints_value(
+        self,
+        duc: DeviceUtilityCommands,
+        mock_api: MagicMock,
+    ) -> None:
+        output = self._run_with_stdout(duc, mock_api, _FakeTerminalStdout())
+        assert _ZTP_SECRET in output
+        assert "ZTP Password:" in output
+
+    def test_non_terminal_withholds_value(
         self,
         duc: DeviceUtilityCommands,
         mock_api: MagicMock,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        resp = MagicMock()
-        resp.data = {"password": "secret123"}
-        mock_api.api.v1.sites.devices.getSiteDeviceZtpPassword.return_value = resp
-        with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "switch")):
-            duc.get_ztp_password()
-            assert "secret123" in capsys.readouterr().out
+        output = self._run_with_stdout(duc, mock_api, _FakePipeStdout())
+        assert _ZTP_SECRET not in output
+        assert _ZTP_SECRET not in capsys.readouterr().out
+        assert "withheld" in output
+        assert "interactive terminal" in output
+
+    def test_non_terminal_never_logs_the_value(
+        self,
+        duc: DeviceUtilityCommands,
+        mock_api: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with caplog.at_level(logging.DEBUG):
+            self._run_with_stdout(duc, mock_api, _FakePipeStdout())
+        assert _ZTP_SECRET not in caplog.text
+
+    def test_terminal_never_logs_the_value(
+        self,
+        duc: DeviceUtilityCommands,
+        mock_api: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with caplog.at_level(logging.DEBUG):
+            self._run_with_stdout(duc, mock_api, _FakeTerminalStdout())
+        assert _ZTP_SECRET not in caplog.text
 
     def test_no_password_data(
         self,
@@ -2137,6 +2200,80 @@ class TestGetZtpPassword:
         with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "switch")):
             duc.get_ztp_password()
             assert "ztp boom" in capsys.readouterr().out
+
+
+class TestStdoutIsTerminal:
+    """Tests for the stdout terminal check that guards the ZTP credential."""
+
+    def test_true_for_a_terminal(self) -> None:
+        with patch.object(sys, "stdout", _FakeTerminalStdout()):
+            assert _UtilityCommandsAction._stdout_is_terminal() is True
+
+    def test_false_for_a_pipe(self) -> None:
+        with patch.object(sys, "stdout", _FakePipeStdout()):
+            assert _UtilityCommandsAction._stdout_is_terminal() is False
+
+    def test_false_when_the_stream_has_no_isatty(self) -> None:
+        with patch.object(sys, "stdout", MagicMock(spec=[])):
+            assert _UtilityCommandsAction._stdout_is_terminal() is False
+
+    def test_false_when_isatty_raises(self) -> None:
+        closed = MagicMock()
+        closed.isatty.side_effect = ValueError("stream closed")
+        with patch.object(sys, "stdout", closed):
+            assert _UtilityCommandsAction._stdout_is_terminal() is False
+
+
+class TestZtpCredentialMigrationRule:
+    """Blocks an issue #886 print-to-logging migration of the ZTP credential.
+
+    Issue #1735 and CodeQL alert 173 record the reason. A mechanical rewrite
+    of the credential print would write a live password into
+    ``data/script.log``. These tests state the rule in code, so the rule
+    survives a comment removal.
+    """
+
+    @staticmethod
+    def _parse(func: object) -> ast.Module:
+        """Return the parsed source tree of one function."""
+        return ast.parse(textwrap.dedent(inspect.getsource(func)))
+
+    @staticmethod
+    def _logging_calls(tree: ast.Module) -> list[ast.Call]:
+        """Return every call whose target is an attribute of ``logging``."""
+        calls = [node for node in ast.walk(tree) if isinstance(node, ast.Call)]
+        return [
+            call
+            for call in calls
+            if isinstance(call.func, ast.Attribute)
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id == "logging"
+        ]
+
+    def test_credential_print_has_no_logging_call(self) -> None:
+        tree = self._parse(_UtilityCommandsAction._print_ztp_credential)
+        assert self._logging_calls(tree) == []
+
+    def test_withheld_notice_has_no_logging_call(self) -> None:
+        tree = self._parse(_UtilityCommandsAction._print_ztp_withheld)
+        assert self._logging_calls(tree) == []
+
+    def test_renderer_never_passes_the_credential_to_a_log_record(self) -> None:
+        tree = self._parse(_UtilityCommandsAction._render_ztp_response.__func__)
+        for call in self._logging_calls(tree):
+            names = {node.id for node in ast.walk(call) if isinstance(node, ast.Name)}
+            assert "ztp_credential" not in names
+
+    def test_credential_print_stays_behind_the_terminal_check(self) -> None:
+        source = inspect.getsource(_UtilityCommandsAction._render_ztp_response.__func__)
+        assert "_stdout_is_terminal()" in source
+        assert "_print_ztp_credential(ztp_credential)" in source
+
+    def test_credential_print_carries_the_review_record(self) -> None:
+        doc = inspect.getdoc(_UtilityCommandsAction._print_ztp_credential) or ""
+        assert "2026-08-22" in doc
+        assert "#1735" in doc
+        assert "#886" in doc
 
 
 class TestGetConfigCommands:

--- a/tests/unit/test_device_utility_commands.py
+++ b/tests/unit/test_device_utility_commands.py
@@ -2146,6 +2146,37 @@ class TestGetZtpPassword:
         assert _ZTP_SECRET in output
         assert "ZTP Password:" in output
 
+    def test_terminal_warns_before_it_shows_the_value(
+        self,
+        duc: DeviceUtilityCommands,
+        mock_api: MagicMock,
+    ) -> None:
+        output = self._run_with_stdout(duc, mock_api, _FakeTerminalStdout())
+        warning_index = output.index("Warning:")
+        value_index = output.index(_ZTP_SECRET)
+        assert warning_index < value_index
+        assert "session recording" in output[:value_index]
+        assert "live credential" in output[:value_index]
+
+    def test_terminal_prints_the_copy_guidance_after_the_value(
+        self,
+        duc: DeviceUtilityCommands,
+        mock_api: MagicMock,
+    ) -> None:
+        output = self._run_with_stdout(duc, mock_api, _FakeTerminalStdout())
+        assert output.index("Copy the value now") > output.index(_ZTP_SECRET)
+
+    def test_terminal_output_keeps_the_contract_line_order(
+        self,
+        duc: DeviceUtilityCommands,
+        mock_api: MagicMock,
+    ) -> None:
+        lines = [line for line in self._run_with_stdout(duc, mock_api, _FakeTerminalStdout()).splitlines() if line]
+        assert lines[0].startswith("Warning:")
+        assert lines[1] == f"-> ZTP Password: {_ZTP_SECRET}"
+        assert lines[2].startswith("-> Copy the value now")
+        assert len(lines) == 3
+
     def test_non_terminal_withholds_value(
         self,
         duc: DeviceUtilityCommands,
@@ -2274,6 +2305,11 @@ class TestZtpCredentialMigrationRule:
         assert "2026-08-22" in doc
         assert "#1735" in doc
         assert "#886" in doc
+
+    def test_source_puts_the_warning_before_the_credential(self) -> None:
+        source = inspect.getsource(_UtilityCommandsAction._print_ztp_credential)
+        body = source.split('"""')[-1]
+        assert body.index("_ZTP_REVEAL_WARNING") < body.index("ztp_credential")
 
 
 class TestGetConfigCommands:


### PR DESCRIPTION
Fixes #1735

## Problem

`src/device/_utility_commands_action.py` printed the live ZTP password to
stdout on every call of menu 144. CodeQL alert 173 reported clear-text logging
of sensitive data.

The old comment claimed the value could not reach a file. The code did not
enforce that claim. Three paths stored the value.

1. An SSH session transcript. The container serves SSH on port 2200 with a
   `ForceCommand` launch, so a client that records the session keeps the value.
2. A shell redirect or a pipe, such as `MistHelper.py > run.txt`.
3. A future print-to-logging migration under issue #886. A mechanical rewrite
   would write the value into `data/script.log`. A support bundle carries that
   file.

## Change

This pull request implements option 3 from the issue.

- **Terminal gate**: `_stdout_is_terminal()` calls `sys.stdout.isatty()` before
  the print. The value reaches a live terminal only. A stream that lacks
  `isatty`, and a stream that raises on the call, both count as unsafe.
- **Warning first**: the reveal path writes three lines in a fixed order. The
  warning comes first, the label and the value come second, and the copy
  guidance comes last. The operator reads the risk before the screen holds the
  value.
- **Withheld notice**: a redirect, a pipe, and a recorded session receive a
  four-line notice. The notice states the decision and the reason. It also
  gives two other sources for the value, which are an interactive run of menu
  144 and the device Utilities page in the Mist portal. The notice never holds
  the value.
- **Comment**: the new docstring on `_print_ztp_credential` states the review
  date 2026-08-22, the reason, the print order, the migration rule, and the
  next review trigger. It makes no claim that the code does not enforce.
- **Migration rule in a test**: `TestZtpCredentialMigrationRule` parses the
  source of the three helpers with `ast`. The test fails when a `logging` call
  appears in the credential print path, and it fails when the renderer passes
  `ztp_credential` to a log record. The rule lives in a test, so a lost comment
  cannot drop it.

The interactive workflow does not change. An operator on a terminal still reads
the value on screen.

### Terminal output

```text
Warning: a session recording captures this screen. The next line holds a live credential.
-> ZTP Password: <value>
-> Copy the value now. The value is a one-time credential.
```

### Non-terminal output

```text
-> ZTP Password withheld. This output is not a live terminal.
-> A redirect, a pipe, or a recorded SSH session would store the value.
-> Run menu 144 again from an interactive terminal to read the value.
-> The Mist portal also shows the value on the device Utilities page.
```

## Tests

`tests/unit/test_device_utility_commands.py` gains 17 cases.

- A terminal stdout prints the value.
- The warning reaches the screen before the value, and the copy guidance
  follows the value. The reveal path writes exactly three lines.
- A source guard fails when a refactor moves the warning after the credential.
- A pipe stdout prints the value nowhere in the captured output.
- No log record holds the value, in either mode.
- `_stdout_is_terminal()` returns `False` for a pipe, for a stream without
  `isatty`, and for a stream that raises.
- The empty-payload path and the error path keep their old behavior.

## Gate results

| Gate | Result |
| - | - |
| `python -m py_compile src/device/_utility_commands_action.py` | PASS |
| `python -m ruff check .` | PASS, all checks passed |
| `python -m black --check .` | PASS, 1008 files unchanged |
| `python -m mypy src/device/_utility_commands_action.py` | PASS, no issues |
| `python -m pytest tests/unit/test_device_utility_commands.py -q` | PASS, 210 passed |
| `python -m pydocstyle src/device/_utility_commands_action.py` | PASS |
| `python -m vulture src/device/_utility_commands_action.py --min-confidence 70` | PASS |
| `python -m radon cc src/device/_utility_commands_action.py -a -nb` | PASS, no block above the limit |
| `python -m tools.ste_linter src/device/_utility_commands_action.py` | PASS, score 99 |

## Scope

The change touches three files.

- `src/device/_utility_commands_action.py`
- `tests/unit/test_device_utility_commands.py`
- `CHANGELOG.md`

It leaves every `# noqa` directive unchanged, because pull request #1850 owns
that cleanup.

## Relationship to spec 1034

`specs/1034-codeql-cleartext-logging/contracts/credential_console.md` is a
written contract for this exact display. It specifies a `CredentialConsole`
class with a `reveal()` method in `src/utils/console.py`. Clause C-10 names the
five tracking issues that spec 1034 owns, and issue #1735 is one of them.

Spec 1034 is unbuilt. `tasks.md` stands at 0 of 67 done. `CredentialConsole`
does not exist in `src/utils/console.py`. Neither
`tests/unit/test_credential_console_contract.py` nor
`specs/1034-codeql-cleartext-logging/verdict-register.md` exists. Only the
contract exists.

This pull request therefore solves issue #1735 ahead of that spec. A future
implementer of spec 1034 must read the two notes below.

1. **Issue #1735 is solved.** Do not treat it as open work. Task T008 of spec
   1034 targets a line that this pull request already replaced.
2. **Clause C-2 is not met.** The contract asks for `sys.stdout.write()` and
   forbids `print()` for the secret. The stated reason is that issue #886
   enables the `T20` rule family and converts every `print()` call across 5053
   sites, and a `sys.stdout.write()` call is invisible to that migration. This
   pull request keeps `print()` with the inert `# noqa: T201` marker, and it
   enforces the same outcome with the `ast` guard test
   `TestZtpCredentialMigrationRule`. That test fails a mechanical migration
   instead of shipping a regression. The enforcement differs from the contract.
   Do not assume the contract is fully satisfied.

Clause C-4 is met for the order of the three parts. The contract also says
"nothing else" after the label and the secret. This pull request adds one copy
guidance line after the value, because that line states guidance and not a risk.

Do not read this section as a request to build `CredentialConsole` here. That
work belongs to spec 1034 and to its own change.

## CodeQL verdict for alert 173

Alert 173 is **open** today. It closes as `fixed` only when this pull request
merges to `main`, because the scan on `main` still sees the old line.

CodeQL opened alert 198, and then alert 199, for the same finding on this
branch. Each push that moves the credential line gives the finding a new
fingerprint, so the scan reports a new alert number. Both alerts now carry the
dismissal reason `won't fix` with the rationale below. Alert 199 matches the
current head commit.

Verdict for the finding: `accepted_with_rationale`. Author: jmorrison-juniper.
Date: 2026-08-22.

Reason: menu 144 exists so a NOC engineer can read the one-time ZTP password on
screen. The display is the purpose of the operation. No code change can remove
the console sink while the operation exists, because the query treats every
console write of a password-named value as a sink.

What this pull request does remove is the pair of capture paths that made the
alert serious. A shell redirect, a pipe, and a recorded SSH session on container
port 2200 now receive the withheld notice. The value never reaches the logging
framework, and a test blocks the issue #886 migration that would send it there.

The `CodeQL` check reports `No new alerts in code changed by this pull
request`.

Next review: when issue #886 lands, when menu 144 changes how it delivers the
credential, or when the operation is removed.

## Review

Do not add the `auto-merge` label. A human reviews a security change.
