### PR TITLE
fix(security): bind the web portal to the loopback address outside a container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,32 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   for `sys.stdout.write()` instead of `print()`. This change keeps `print()` and
   blocks the issue #886 migration with an `ast` guard test. Spec 1034 is unbuilt
   at 0 of 67 tasks, and `CredentialConsole` does not exist yet.
+### Replace the obfuscated all-interfaces bind in the web portal launcher (issue #1711)
+
+Version 26.08.23.01.26
+
+- **Defect (Fixed)**: `_launch_web_portal()` built the bind address with
+  `".".join(("0",) * 4)`. The expression produced the string `0.0.0.0`, and the
+  only purpose of the expression was to hide that literal from bandit rule B104.
+  The project standard forbids a shortcut that silences a real finding. A
+  suppression comment records the decision and the reason. A join expression
+  records nothing.
+- **Bind address (Changed)**: the new function `_resolve_web_portal_host()` holds
+  the decision. It returns the value of `WEB_HOST` when the operator sets that
+  variable. Without that variable it returns `0.0.0.0` inside a container and
+  `127.0.0.1` on a workstation. The old code bound to all interfaces on every
+  platform, so a workstation run exposed the portal to the local network.
+- **Container test (Changed)**: the all-interfaces bind now depends on
+  `EnvironmentUtils.is_running_in_container()`. A container needs the external
+  bind, because the container network maps the port from outside. The container
+  port map controls the exposure.
+- **Suppression (Added)**: the assignment carries `# nosec B104`, and the three
+  comment lines above it state the container condition and the reason. Bandit
+  reports no issue and no warning for the file.
+- **Tests (Added)**: `tests/unit/test_web_portal_bind_address.py` holds 8 cases.
+  They prove the loopback default, the container all-interfaces bind, the
+  `WEB_HOST` override in both states, the fallback for an empty `WEB_HOST` value,
+  and that the join expression is gone from the script.
 
 ### Add a real readiness probe and keep the health endpoint cheap (issue #1863)
 

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -4845,6 +4845,30 @@ def _run_web_portal_server(app: Any, host: str, port: int, dev_debug: bool) -> N
         app.run(host=host, port=port, debug=dev_debug)  # Honor caller's debug flag locally
 
 
+def _resolve_web_portal_host() -> str:
+    """Return the address that the web portal binds to.
+
+    The WEB_HOST variable overrides every default. Without that
+    variable, a container binds to all interfaces, and a
+    workstation binds to the loopback address.
+    """
+    logging.info("WEB_PORTAL: resolving the bind address for the web portal")  # Log before the resolution starts
+    override_host = os.environ.get("WEB_HOST")  # An operator value must win over both defaults
+    if override_host:  # A set WEB_HOST value controls the bind on a container and on a workstation
+        logging.debug("WEB_PORTAL: bind address came from WEB_HOST: %s", override_host)  # Report the override result
+        return override_host  # Return the operator value and skip the container check
+    in_container = EnvironmentUtils.is_running_in_container()  # Only a container gets the all-interfaces bind
+    if not in_container:  # A workstation must keep the portal on the loopback interface
+        logging.debug("WEB_PORTAL: bind address is the loopback address on a workstation")  # Report the result
+        return "127.0.0.1"  # Keep the portal off every external interface of the workstation
+    # The next assignment runs only when is_running_in_container() returns True. A container needs the
+    # all-interfaces bind, because the container network maps the port from outside. The container port map
+    # controls the exposure, and a workstation returns the loopback address above.
+    all_interfaces_host = "0.0.0.0"  # nosec B104
+    logging.debug("WEB_PORTAL: bind address is %s inside a container", all_interfaces_host)  # Report the result
+    return all_interfaces_host  # Hand the container bind address to the launcher
+
+
 def _launch_web_portal(args: argparse.Namespace) -> None:
     """Launch the Flask web portal.
 
@@ -4859,7 +4883,7 @@ def _launch_web_portal(args: argparse.Namespace) -> None:
     loader = PortalConfigLoader()  # Read web_port + other portal settings from env/.env
     config = loader.load_config()
     port = config["web_port"]
-    host = os.environ.get("WEB_HOST") or ".".join(("0",) * 4)  # All-interfaces bind (env override wins) for containers.
+    host = _resolve_web_portal_host()  # Loopback on a workstation, all interfaces in a container, WEB_HOST wins
 
     app = WebPortalApp.create_app(  # Construct Flask app with shared API session + menu registry
         apisession=apisession,

--- a/tests/unit/test_web_portal_bind_address.py
+++ b/tests/unit/test_web_portal_bind_address.py
@@ -1,0 +1,79 @@
+"""Unit tests for the web portal bind address resolver in MistHelper.py (issue #1711).
+
+The resolver `_resolve_web_portal_host()` must return the loopback address on a
+workstation, the all-interfaces address inside a container, and the `WEB_HOST`
+value when an operator sets that variable. A guardrail test proves that the old
+join expression, which hid the literal address from the security scanner, is
+gone from the source file.
+"""
+
+from __future__ import annotations  # WHY: keep the annotation style equal to the rest of the suite.
+
+import inspect  # WHY: the guardrail test reads the source of the resolver function.
+from pathlib import Path  # WHY: the guardrail test locates MistHelper.py on disk.
+
+import pytest  # WHY: the tests use the monkeypatch fixture for the environment and the container probe.
+
+import MistHelper  # WHY: the resolver under test is a module-level function of the script.
+
+CONTAINER_PROBE = "MistHelper.EnvironmentUtils.is_running_in_container"  # WHY: one name for the patch target.
+
+
+def _force_container_state(monkeypatch: pytest.MonkeyPatch, in_container: bool) -> None:
+    """Force the container probe to report the given state for one test."""
+    monkeypatch.setattr(CONTAINER_PROBE, lambda: in_container)  # WHY: remove the real filesystem probe from the test.
+
+
+class TestResolveWebPortalHost:
+    """The resolver picks the bind address from the container state and the WEB_HOST variable."""
+
+    def test_workstation_binds_to_loopback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without WEB_HOST and outside a container the resolver returns the loopback address."""
+        monkeypatch.delenv("WEB_HOST", raising=False)  # WHY: an inherited value would mask the default.
+        _force_container_state(monkeypatch, False)  # WHY: model a workstation run.
+        assert MistHelper._resolve_web_portal_host() == "127.0.0.1"  # WHY: a workstation must not expose the port.
+
+    def test_container_binds_to_all_interfaces(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without WEB_HOST and inside a container the resolver returns the all-interfaces address."""
+        monkeypatch.delenv("WEB_HOST", raising=False)  # WHY: an inherited value would mask the default.
+        _force_container_state(monkeypatch, True)  # WHY: model a container run.
+        assert MistHelper._resolve_web_portal_host() == "0.0.0.0"  # WHY: a container needs an external bind.
+
+    def test_web_host_overrides_the_workstation_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A WEB_HOST value replaces the loopback default on a workstation."""
+        monkeypatch.setenv("WEB_HOST", "10.1.2.3")  # WHY: model an operator override.
+        _force_container_state(monkeypatch, False)  # WHY: model a workstation run.
+        assert MistHelper._resolve_web_portal_host() == "10.1.2.3"  # WHY: the override must win.
+
+    def test_web_host_overrides_the_container_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A WEB_HOST value replaces the all-interfaces default inside a container."""
+        monkeypatch.setenv("WEB_HOST", "192.0.2.10")  # WHY: model an operator override.
+        _force_container_state(monkeypatch, True)  # WHY: model a container run.
+        assert MistHelper._resolve_web_portal_host() == "192.0.2.10"  # WHY: the override must win.
+
+    def test_empty_web_host_falls_back_to_the_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An empty WEB_HOST value is not an address, so the resolver uses the default."""
+        monkeypatch.setenv("WEB_HOST", "")  # WHY: an empty value must not produce an empty bind address.
+        _force_container_state(monkeypatch, False)  # WHY: model a workstation run.
+        assert MistHelper._resolve_web_portal_host() == "127.0.0.1"  # WHY: the loopback default still applies.
+
+
+class TestBindAddressSourceGuardrail:
+    """The source states the bind address in plain form and carries the suppression comment."""
+
+    def test_resolver_states_the_literal_address(self) -> None:
+        """The resolver source contains the plain all-interfaces literal."""
+        source = inspect.getsource(MistHelper._resolve_web_portal_host)  # WHY: read the shipped implementation.
+        assert '"0.0.0.0"' in source  # WHY: the source must state the address in plain form for the scanner.
+
+    def test_resolver_carries_a_justified_suppression(self) -> None:
+        """The all-interfaces line carries a nosec B104 marker with a stated reason."""
+        source = inspect.getsource(MistHelper._resolve_web_portal_host)  # WHY: read the shipped implementation.
+        assert "# nosec B104" in source  # WHY: the project standard needs a recorded decision, not a hidden literal.
+        assert "is_running_in_container()" in source  # WHY: the comment must state the container condition.
+
+    def test_module_no_longer_builds_the_address_from_parts(self) -> None:
+        """The old join expression that hid the literal from the scanner is gone."""
+        script_path = Path(MistHelper.__file__)  # WHY: the guardrail reads the whole script, not one function.
+        script_text = script_path.read_text(encoding="utf-8")  # WHY: a text scan catches a moved copy of the pattern.
+        assert '".".join(("0",) * 4)' not in script_text  # WHY: an obfuscated address must never return.


### PR DESCRIPTION
Fixes #1711

## Problem

`_launch_web_portal()` built the bind address with `".".join(("0",) * 4)`. The expression produced the string `0.0.0.0`. Its only purpose was to hide that literal from bandit rule B104. The project standard forbids a shortcut that silences a real finding. A suppression comment records the decision and the reason. A join expression records nothing.

The old code also bound to all interfaces on every platform, so a workstation run exposed the portal to the local network.

## Change

- `MistHelper.py` gains `_resolve_web_portal_host()`. The function holds the whole decision, and `_launch_web_portal()` calls it.
- The resolver returns the value of `WEB_HOST` when the operator sets that variable.
- Without `WEB_HOST` the resolver returns `0.0.0.0` when `EnvironmentUtils.is_running_in_container()` returns True. A container needs the external bind, because the container network maps the port from outside.
- Without `WEB_HOST` the resolver returns `127.0.0.1` on a workstation.
- The assignment carries `# nosec B104`. Three comment lines above it state the container condition and the reason.

## Acceptance criteria

- [x] The code contains no expression that builds an address to avoid a scanner.
- [x] A local run binds to the loopback address by default.
- [x] A container run binds to all interfaces.
- [x] The `WEB_HOST` variable still overrides both cases.
- [x] `bandit` passes, and the `# nosec` carries a justification.
- [x] The existing unit tests pass.

## Tests

`tests/unit/test_web_portal_bind_address.py` holds 8 cases:

- The workstation default is `127.0.0.1`.
- The container default is `0.0.0.0`.
- `WEB_HOST` overrides the workstation default.
- `WEB_HOST` overrides the container default.
- An empty `WEB_HOST` value falls back to the default.
- The resolver source states the plain literal.
- The resolver carries `# nosec B104` and names the container condition.
- The script no longer contains the join expression.

## Gate results

| Gate | Command | Result |
| - | - | - |
| Compile | `python -m py_compile MistHelper.py` | pass |
| Lint | `python -m ruff check .` | pass, `All checks passed` |
| Format | `python -m black --check .` | pass, 1008 files unchanged |
| Security | `python -m bandit -c pyproject.toml -r MistHelper.py` | pass, no issues and no warnings |
| Dead code | `python -m vulture MistHelper.py --min-confidence 70` | pass, no findings |
| Complexity | `python -m radon cc -n C MistHelper.py` | pass, no block above C |
| Docstrings | `python -m interrogate -c pyproject.toml MistHelper.py` | pass, 97.9 percent |
| Tests | `python -m pytest tests/unit -q` | pass, 9172 tests |

The full-repo bandit run reports 42 LOW findings in `tools/test_quality_analyzer/fixtures`. That tree sits in `exclude_dirs`. The exclusion regex does not match a Windows path separator, so the finding set is a local artifact and it is not present in CI.

## Files not touched

The task reserved `web_portal/`, the container files, and several other trees for other agents. This change needs none of them.
