### PR TITLE
chore(dev-env): report one clear message when a worktree has no dependencies

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -183,10 +183,18 @@ chmod -R 777 data/   # Required before first container run
 ### Running Tests
 ```powershell
 # Local development (Windows 11 + venv required - standard environment)
+# A new worktree holds no .venv, so create the environment one time first.
+python scripts/bootstrap_worktree.py   # Creates .venv and installs the requirements
 .venv\Scripts\Activate.ps1
 python MistHelper.py --test
 ```
 **Skip List**: `OperationRegistry` decides. `--test` runs only `safe`, and `--testinteractive` adds `interactive_safe`. Every other category is skipped, which covers `resource_intensive` (14, 18-19, 59, 97-101, 153), `destructive` (154-187, 189-191, 194, 206-208), `interactive`, `websocket`, and `continuous_loop`.
+
+**Warning**: `git worktree add` copies the tracked files only. `.venv` is not tracked, so a new
+worktree has no virtual environment. The activation line then fails, and the tests run against the
+global interpreter. `python -m pytest` stops with one message that names the bootstrap command,
+instead of one import error for each test module. Run `python scripts/bootstrap_worktree.py` in the
+new worktree, activate the environment, then run the tests again. See issue #1866.
 
 ---
 
@@ -413,6 +421,16 @@ See `git-workflow.instructions.md` § Agent Coordination for general rules. Mist
 MistHelper/                    # main checkout (human or merge agent only)
 ../MistHelper-agent-1/         # worktree for Agent 1 (feat/101-new-menu)
 ../MistHelper-agent-2/         # worktree for Agent 2 (fix/102-rate-limit)
+```
+
+Each worktree needs its own virtual environment. Run the bootstrap one time after
+`git worktree add`:
+
+```powershell
+git worktree add ../MistHelper-agent-1 -b feat/101-new-menu main
+cd ../MistHelper-agent-1
+python scripts/bootstrap_worktree.py   # Creates .venv and installs the requirements
+.venv\Scripts\Activate.ps1
 ```
 
 ### Copilot Coding Agent, Spaces & Scratchpads

--- a/README.md
+++ b/README.md
@@ -363,6 +363,18 @@ python -m venv .venv
 .venv\Scripts\Activate.ps1
 ```
 
+**Note for a git worktree**: `git worktree add` copies the tracked files only, so a new
+worktree holds no `.venv` directory. Run the bootstrap one time in the new worktree. The
+script creates `.venv` and installs `requirements.txt` and `requirements-dev.txt`:
+
+```powershell
+python scripts/bootstrap_worktree.py   # Windows or Linux
+.\scripts\bootstrap_worktree.ps1       # Windows entry point
+```
+
+If the environment is absent, `python -m pytest` stops with one message that names this
+command. See issue #1866.
+
 ### Step 3: Install Dependencies
 
 **Option A: Using UV (Faster, Recommended)**

--- a/agents.md
+++ b/agents.md
@@ -16,6 +16,11 @@ When refactoring, restructure into classes per project conventions. No wrappers.
 ## Local Development Quick Reference
 
 ```powershell
+# Prepare a new worktree. "git worktree add" does not copy .venv, so a new
+# worktree has no virtual environment until you run this script.
+.\scripts\bootstrap_worktree.ps1        # Windows
+python scripts/bootstrap_worktree.py    # Windows or Linux
+
 # Activate venv
 .venv\Scripts\Activate.ps1
 
@@ -32,12 +37,20 @@ python MistHelper.py --test
 # Worktree setup for feature work
 git worktree add ../MistHelper-<slug> -b <type>/<issue>-<slug> main
 cd ../MistHelper-<slug>
+python scripts/bootstrap_worktree.py   # Required. The new worktree has no .venv.
+.venv\Scripts\Activate.ps1
 
 # Worktree teardown after merge
 cd ../MistHelper
 git worktree remove ../MistHelper-<slug>
 git checkout main && git pull origin main
 ```
+
+**Warning**: A new worktree holds the tracked files only. `.venv` is not tracked, so
+`.venv\Scripts\Activate.ps1` fails there and the tests then run against the global
+interpreter. `python -m pytest` stops with one message that names the bootstrap
+command. Run `python scripts/bootstrap_worktree.py`, activate the environment, then
+run the tests again. See issue #1866.
 
 ## VS Code Chat-Specific Notes
 

--- a/scripts/bootstrap_worktree.ps1
+++ b/scripts/bootstrap_worktree.ps1
@@ -1,0 +1,47 @@
+<#
+.SYNOPSIS
+    Prepare the virtual environment of a MistHelper worktree on Windows.
+
+.DESCRIPTION
+    The command "git worktree add" copies the tracked files only. The directory
+    .venv is not tracked, so a new worktree holds no virtual environment.
+    Without that environment, pytest runs against the global interpreter, and
+    every test module fails to import. Run this script one time in each new
+    worktree. See issue #1866.
+
+    The script starts scripts/bootstrap_worktree.py, which does the work on
+    Windows and on Linux.
+
+.PARAMETER Recreate
+    Delete the existing .venv directory before the script creates a new one.
+
+.EXAMPLE
+    .\scripts\bootstrap_worktree.ps1
+
+.EXAMPLE
+    .\scripts\bootstrap_worktree.ps1 -Recreate
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$Recreate
+)
+
+$ErrorActionPreference = "Stop"  # Stop on the first error, so the user sees one clear failure.
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path  # Find the scripts directory of this worktree.
+$bootstrap = Join-Path $scriptDir "bootstrap_worktree.py"  # Build the path of the Python bootstrap.
+
+$python = Get-Command python -ErrorAction SilentlyContinue  # Look for the interpreter on the PATH.
+if (-not $python) {  # A missing interpreter blocks every following step.
+    Write-Error "Python is not on the PATH. Install Python 3.13 or newer, then run this script again."
+    exit 1  # Report the failure to the shell.
+}
+
+$arguments = @($bootstrap)  # Start the argument list with the Python bootstrap.
+if ($Recreate) {  # Pass the option through, because the Python script owns the behavior.
+    $arguments += "--recreate"  # Add the recreate option to the argument list.
+}
+
+& $python.Source @arguments  # Run the Python bootstrap with the collected arguments.
+exit $LASTEXITCODE  # Give the exit code of the bootstrap to the shell.

--- a/scripts/bootstrap_worktree.py
+++ b/scripts/bootstrap_worktree.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Create the virtual environment that a new MistHelper worktree needs.
+
+The command `git worktree add` copies the tracked files only. The directory
+`.venv` is not tracked, so a new worktree holds no virtual environment. Without
+that environment, pytest runs against the global interpreter, and every test
+module fails to import. The reader then sees a source defect that does not
+exist. Run this script one time in each new worktree. See issue #1866.
+
+Usage:
+    python scripts/bootstrap_worktree.py
+    python scripts/bootstrap_worktree.py --recreate
+
+The script works on Windows and on Linux. The script prints the path of the
+interpreter that it created.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import shutil
+import subprocess  # nosec B404 - the script starts pip with a fixed argument list.
+import sys
+import venv
+from pathlib import Path
+
+LOGGER = logging.getLogger("bootstrap_worktree")
+
+# The requirement files that the script installs, in this order. The script
+# skips a file that the worktree does not hold.
+REQUIREMENT_FILES: tuple[str, ...] = ("requirements.txt", "requirements-dev.txt")
+
+
+class WorktreeBootstrapper:
+    """Create one virtual environment and install the project dependencies."""
+
+    def __init__(self, root: Path, venv_name: str = ".venv") -> None:
+        """Store the worktree root and the name of the environment directory."""
+        self.root = root  # Keep the worktree root, because every path starts here.
+        self.venv_dir = root / venv_name  # Build the environment path with pathlib, so both platforms work.
+
+    @property
+    def interpreter(self) -> Path:
+        """Return the interpreter path of the environment for this platform."""
+        if sys.platform == "win32":  # Windows puts the interpreter in the Scripts directory.
+            return self.venv_dir / "Scripts" / "python.exe"  # Return the Windows interpreter path.
+        return self.venv_dir / "bin" / "python"  # Return the Linux interpreter path.
+
+    def create_environment(self, recreate: bool = False) -> None:
+        """Create the virtual environment. If recreate is true, delete it first."""
+        if recreate and self.venv_dir.exists():  # A recreate request must start from an empty directory.
+            LOGGER.info("Deleting the existing environment at %s", self.venv_dir)
+            shutil.rmtree(self.venv_dir)  # Remove the old environment, so the new one holds no stale package.
+            LOGGER.debug("Deleted the existing environment")
+        if self.interpreter.exists():  # An existing interpreter shows that the environment is ready.
+            LOGGER.info("The environment exists at %s", self.venv_dir)
+            return  # Keep the existing environment, because a second creation adds no value.
+        LOGGER.info("Creating the virtual environment at %s", self.venv_dir)
+        venv.EnvBuilder(with_pip=True, upgrade_deps=False).create(self.venv_dir)  # Build the environment with pip.
+        LOGGER.debug("Created the virtual environment")
+
+    def install_requirements(self) -> list[str]:
+        """Install each requirement file that the worktree holds."""
+        installed: list[str] = []  # Record each file that the script installed, so the caller can report it.
+        for name in REQUIREMENT_FILES:  # Install the files in the declared order.
+            path = self.root / name  # Build the file path under the worktree root.
+            if not path.is_file():  # A worktree without the file needs no action.
+                LOGGER.info("Skipping %s, because the worktree does not hold this file", name)
+                continue  # Move to the next file in the list.
+            self._install_file(path)  # Install the packages that this file declares.
+            installed.append(name)  # Add the file to the report list.
+        return installed  # Give the caller the list of the installed files.
+
+    def _install_file(self, path: Path) -> None:
+        """Install one requirement file with pip."""
+        command = [str(self.interpreter), "-m", "pip", "install", "-r", str(path)]  # Use the new interpreter.
+        LOGGER.info("Installing the packages from %s", path.name)
+        result = subprocess.run(command, check=False)  # nosec B603 - the argument list holds no shell input.
+        LOGGER.debug("The install of %s returned code %d", path.name, result.returncode)
+        if result.returncode != 0:  # A failed install leaves an incomplete environment.
+            raise RuntimeError(f"The install of {path.name} failed with code {result.returncode}.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command line parser of the script."""
+    parser = argparse.ArgumentParser(description="Prepare the virtual environment of a MistHelper worktree.")
+    parser.add_argument(  # Give the user one option to rebuild a damaged environment.
+        "--recreate",
+        action="store_true",
+        help="Delete the existing .venv directory before the script creates a new one.",
+    )
+    return parser  # Give the caller the ready parser.
+
+
+def report_result(bootstrapper: WorktreeBootstrapper, installed: list[str]) -> None:
+    """Print the interpreter path and the activation command for this platform."""
+    activate = ".venv\\Scripts\\Activate.ps1" if sys.platform == "win32" else "source .venv/bin/activate"
+    LOGGER.info("The environment is ready.")
+    LOGGER.info("Installed requirement files: %s", ", ".join(installed) or "none")
+    LOGGER.info("Interpreter: %s", bootstrapper.interpreter)
+    LOGGER.info("To activate the environment, run: %s", activate)
+    LOGGER.info("To run the tests, run: python -m pytest -q")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the bootstrap and return the exit code of the script."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")  # Show one plain line for each step.
+    args = build_parser().parse_args(argv)  # Read the command line of the caller.
+    root = Path(__file__).resolve().parents[1]  # The worktree root holds the scripts directory.
+    LOGGER.info("Preparing the worktree at %s", root)
+    bootstrapper = WorktreeBootstrapper(root)  # Build the object that owns every step.
+    try:  # Report a failed step as one clear message, because the user reads the console.
+        bootstrapper.create_environment(recreate=args.recreate)  # Create the environment first.
+        installed = bootstrapper.install_requirements()  # Install the declared dependencies.
+    except (OSError, RuntimeError) as error:  # A file error or a failed install stops the script.
+        LOGGER.error("The bootstrap failed: %s", error)
+        return 1  # Report the failure to the shell.
+    report_result(bootstrapper, installed)  # Tell the user which interpreter to activate.
+    LOGGER.debug("The bootstrap completed for %s", root)
+    return 0  # Report the success to the shell.
+
+
+if __name__ == "__main__":  # Run the script only as a program, never as an import.
+    sys.exit(main())  # Give the exit code of the bootstrap to the shell.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,65 @@
 
 Provides test isolation: temp directories, no network, no .env loading.
 Unit tests must run offline with zero API credentials in under 30 seconds.
+
+This file also guards the test environment. A new git worktree holds the tracked
+files only, so the worktree has no `.venv` directory. Without the runtime
+dependencies, pytest stops with one import error for each test module, and the
+reader sees a source defect that does not exist. The guard below replaces those
+errors with one message that names the bootstrap command. See issue #1866.
 """
 
 import importlib.util
+import logging
 import sys
 from pathlib import Path
 
 import pytest
+
+# Runtime packages that almost every test module imports through `src`. Keep the
+# list short, because the guard runs before every test session.
+_REQUIRED_RUNTIME_PACKAGES: tuple[str, ...] = ("mistapi", "structlog", "dotenv")
+
+# The documented command that creates `.venv` and installs the dependencies.
+_BOOTSTRAP_COMMAND = "python scripts/bootstrap_worktree.py"
+
+
+def _find_missing_packages(names: tuple[str, ...]) -> list[str]:
+    """Return each name in `names` that the active interpreter cannot import."""
+    missing: list[str] = []  # Collect every absent name, so one message lists all of them.
+    for name in names:  # Test each name on its own, because one gap breaks the collection.
+        try:  # Guard the lookup, because a broken module entry raises here.
+            available = importlib.util.find_spec(name) is not None  # Ask for the location only, so the import is cheap.
+        except (ImportError, ValueError):  # A broken or shadowed entry is not usable.
+            available = False  # Report the broken entry as an absent package.
+        if not available:  # Keep only the names that the interpreter cannot import.
+            missing.append(name)  # Add the name to the report list.
+    return missing  # Give the caller the full result of one scan.
+
+
+def _bootstrap_message(missing: list[str]) -> str:
+    """Build one actionable message that names the gap and the repair step."""
+    names = ", ".join(missing)  # Join the names, so the reader sees every gap on one line.
+    return (  # Return one block of text, because pytest prints a UsageError as a single record.
+        f"The active Python environment has no MistHelper runtime dependencies. "
+        f"Missing packages: {names}. "
+        f"Active interpreter: {sys.executable}. "
+        f"Caution: 'git worktree add' does not copy the .venv directory, so the tests "
+        f"ran against the global interpreter and every test module failed to import. "
+        f"To repair the environment, run '{_BOOTSTRAP_COMMAND}' in this worktree. "
+        f"Then activate the environment. On Windows, run '.venv\\Scripts\\Activate.ps1'. "
+        f"On Linux, run 'source .venv/bin/activate'. Then run the tests again."
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Stop the session with one message when a runtime dependency is absent."""
+    logging.info("Checking the test environment for the MistHelper runtime dependencies")
+    missing = _find_missing_packages(_REQUIRED_RUNTIME_PACKAGES)  # Scan the short required list once.
+    logging.debug("Environment check found %d missing runtime package(s)", len(missing))
+    if missing:  # Report the environment gap before pytest collects a single module.
+        raise pytest.UsageError(_bootstrap_message(missing))  # Raise one clear error instead of many import errors.
+
 
 # Pre-load MistHelper.py (the script) into sys.modules as "MistHelper".
 # The project root has an __init__.py which makes the root directory a Python


### PR DESCRIPTION
# Spec Conformance Checklist

**Linked Spec Issue**: #1866

Fixes #1866

## Problem

`git worktree add` copies the tracked files only. The directory `.venv` is not
tracked, so a new worktree holds no virtual environment. The documented
activation step then fails, pytest runs against the global interpreter, and the
run stops with one import error for each test module. The reader sees a source
defect that does not exist.

## Change

1. **One fast, clear failure.** `tests/conftest.py` holds a new `pytest_configure`
   guard. The guard asks `importlib.util.find_spec` for three runtime packages,
   which costs no import. If a package is absent, the guard raises one
   `pytest.UsageError`. The message names the missing packages, the active
   interpreter, and the repair command. A healthy environment pays for one
   `find_spec` call for each of the three names.
2. **A documented bootstrap.** `scripts/bootstrap_worktree.py` creates `.venv`
   and installs `requirements.txt` and `requirements-dev.txt`. The script runs on
   Windows and on Linux, and it prints the interpreter path and the activation
   command. `scripts/bootstrap_worktree.ps1` is the Windows entry point.
3. **Documentation.** `agents.md`, `.github/copilot-instructions.md`, and
   `README.md` name the bootstrap step next to the worktree commands. Each file
   states that a new worktree holds no `.venv`.

## Evidence

Both local runs used the same fresh worktree at
`C:\Users\jmorrison\mh-wt\issue-1866`, created with `git worktree add`, with no
`.venv` and with the global interpreter at
`C:\Users\jmorrison\AppData\Local\Programs\Python\Python313\python.exe`.

### Before

```
> python -m pytest -q
ERROR tests/unit/websocket/test_service_ping_manager.py
!!!!!!!!!!!!!!!!!! Interrupted: 111 errors during collection !!!!!!!!!!!!!!!!!!
====================== 2 warnings, 111 errors in 46.80s =======================
```

The first error names the true cause, but the reader must scroll through 111
records to find it:

```
src\db\__init__.py:15: in <module>
    import structlog
E   ModuleNotFoundError: No module named 'structlog'
```

### After, with the dependencies absent

```
> python -m pytest -q
ERROR: The active Python environment has no MistHelper runtime dependencies.
Missing packages: mistapi, structlog, dotenv.
Active interpreter: C:\Users\jmorrison\AppData\Local\Programs\Python\Python313\python.exe.
Caution: 'git worktree add' does not copy the .venv directory, so the tests ran
against the global interpreter and every test module failed to import.
To repair the environment, run 'python scripts/bootstrap_worktree.py' in this worktree.
Then activate the environment. On Windows, run '.venv\Scripts\Activate.ps1'.
On Linux, run 'source .venv/bin/activate'. Then run the tests again.
```

The run stops in under one second with exit code 4. The line breaks above are
added for this description. The console prints one record.

### After, with the dependencies present

The guard does not block a healthy environment. A local run of one module with
the three packages resolvable reports `5 passed in 1.55s`. The CI run of this
branch is the full proof, because CI installs `requirements.txt` and then runs
the whole suite. Every gate reports `SUCCESS`, and the `pytest (coverage gate)`
job holds the result of the complete collection.

## Acceptance Criteria
- [x] All acceptance criteria from the linked Spec Issue are met
- [x] Each criterion has a corresponding test or verification
- [x] `agents.md` documents the environment bootstrap step next to the worktree commands
- [x] A documented command prepares a new worktree
- [x] The test entry point reports one clear message when a runtime dependency is absent
- [x] `.github/copilot-instructions.md` and `agents.md` agree on the activation path

## Quality
- [x] Tests added or updated for all changed functionality — this change repairs the
      test entry point itself. The verification is the set of runs above.
- [x] Coverage meets or exceeds 80% threshold — the `pytest (coverage gate)` job passes.
- [x] No new Ruff lint violations (`ruff check .`) — `All checks passed!`
- [x] Code formatted (`black --check`) — `2 files would be left unchanged.`
- [x] mypy passes — the `mypy (strict)` job passes. The new code reports no error.
      CI runs mypy on `src/ MistHelper.py wsgi.py`.

## Security
- [x] No hardcoded secrets, tokens, or passwords
- [x] Bandit passes with no new findings — `[tool.bandit]` excludes `scripts` and `tests`.
      The one `subprocess.run` call uses a fixed argument list and no shell.
- [x] pip-audit clean — the change adds no dependency.
- [x] Sensitive data handled via `.env` / environment variables only

## Deployment
- [x] Dry-run verified locally — `python scripts/bootstrap_worktree.py` created
      `.venv` in the fresh worktree and started the install of the requirements.
- [x] `.env` changes documented in `deploy/.env.example` — not applicable.
- [x] Container builds successfully — the Containerfile does not change.

## UI / E2E Testing (if web UI changed)
- [x] Not applicable. This change holds no web UI code.

## Documentation
- [x] README.md updated
- [ ] Changelog entry added — not applicable. This change holds no product code
      and does not change the container image.
