### PR TITLE
fix(websocket): join the ARP listener WebSocket thread on stop

### DIFF
--- a/src/websocket/manager.py
+++ b/src/websocket/manager.py
@@ -32,6 +32,7 @@ _WS_HANDSHAKE_LOG_MOD = 2  # WHY: Log every second handshake tick to reduce nois
 _WS_API_HOST_PREFIX = "api."  # WHY: Prefix on REST host, swapped for WS variant.
 _WS_HOST_PREFIX = "api-ws."  # WHY: Prefix Mist uses for streaming endpoints.
 _WS_STREAM_PATH = "/api-ws/v1/stream"  # WHY: Fixed Mist WebSocket entry point.
+_WS_THREAD_JOIN_SECONDS = 5.0  # WHY: Bounded join so a stuck reader cannot block the caller (issue #1875).
 _DEBUG_TRUE_VALUES = frozenset({"true", "1", "yes"})  # WHY: Accepted truthy strings for DEBUG env.
 
 
@@ -353,11 +354,34 @@ class WebSocketManager:
         )
         self.logger.info("WebSocket connection closed (status: %s)", close_status_code)  # WHY: User-facing.
 
+    def _join_websocket_thread(self) -> None:
+        """Wait a bounded time for the reader thread to stop, then report the outcome."""
+        reader_thread = self.websocket_thread  # WHY: One alias keeps every check on the same object.
+        if reader_thread is None:  # WHY: connect() never ran, so no reader exists.
+            return  # WHY: Nothing to wait for.
+        if reader_thread is threading.current_thread():  # WHY: A close callback can call disconnect().
+            self.logger.debug("Reader thread called disconnect. Skip the join.")  # WHY: A self-join raises.
+            return  # WHY: A join on the current thread raises an error.
+        self.logger.info("Waiting for the WebSocket reader thread to stop")  # WHY: Action log before the wait.
+        reader_thread.join(_WS_THREAD_JOIN_SECONDS)  # WHY: Bounded wait stops the leak reported in #1875.
+        if reader_thread.is_alive():  # WHY: The bound expired before run_forever unwound.
+            self.logger.warning(  # WHY: A silent leak gives the operator nothing to act on.
+                "WebSocket reader thread still alive after %.1fs for %s",
+                _WS_THREAD_JOIN_SECONDS,
+                self.websocket_url,
+            )
+            return  # WHY: Keep the handle so a later disconnect can retry the join.
+        self.websocket_thread = None  # WHY: Drop the handle, because the reader stopped.
+        self.logger.debug("WebSocket reader thread stopped for %s", self.websocket_url)  # WHY: Result log.
+
     def disconnect(self) -> None:
         """Close WebSocket connection and cleanup resources."""
-        if self.websocket_connection:  # WHY: Idempotent — no-op if never connected.
-            self.websocket_connection.close()  # WHY: Ask library to shut the socket down.
-        self.connected = False  # WHY: Reset flag regardless of prior state.
-        self.subscribed_channels.clear()  # WHY: Force fresh subscribes on next connect.
-        with self.results_lock:  # WHY: Serialise clearing shared buffer.
-            self.command_results.clear()  # WHY: Drop stale in-flight sessions.
+        try:  # WHY: A close() failure must not skip the join or leave stale state.
+            if self.websocket_connection:  # WHY: Idempotent — no-op if never connected.
+                self.websocket_connection.close()  # WHY: Ask library to shut the socket down.
+        finally:  # WHY: The stop path runs on every exit, including the exception path.
+            self.connected = False  # WHY: Reset flag regardless of prior state.
+            self._join_websocket_thread()  # WHY: close() only requests a stop. Wait for run_forever to unwind.
+            self.subscribed_channels.clear()  # WHY: Force fresh subscribes on next connect.
+            with self.results_lock:  # WHY: Serialise clearing shared buffer.
+                self.command_results.clear()  # WHY: Drop stale in-flight sessions.

--- a/tests/unit/websocket/test_manager_thread_join.py
+++ b/tests/unit/websocket/test_manager_thread_join.py
@@ -1,0 +1,166 @@
+"""Unit tests for the WebSocket reader thread teardown in the manager module.
+
+Issue #1875 reports a thread leak. ``WebSocketManager`` starts a reader thread
+that runs ``run_forever``. The old ``disconnect`` called ``close`` and returned.
+``close`` only requests a shutdown, so the reader thread was still alive when
+the caller read the collected output. Each ARP run through
+``ArpDeviceExecutor`` therefore added one live thread to a long-lived process.
+
+These tests pin the teardown contract. ``disconnect`` must wait a bounded time
+for the reader thread, must warn when the wait expires, must run the wait after
+a ``close`` failure, and must not try to join itself.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from src.websocket import manager as manager_mod
+from src.websocket.manager import WebSocketManager
+
+_MANAGER_LOGGER = "src.websocket.manager"  # WHY: Same logger name the sibling manager tests assert on.
+_JOIN_WAIT_SECONDS = 5.0  # WHY: Upper bound the fake reader waits for the stop signal.
+_EXIT_DELAY_SECONDS = 0.25  # WHY: Reader stays alive long enough to expose a missing join.
+
+
+class _FakeConnection:
+    """Stand-in for ``websocket.WebSocketApp`` that models a slow shutdown."""
+
+    def __init__(self, exit_delay: float = _EXIT_DELAY_SECONDS) -> None:
+        """Create the fake connection with a stop event and a shutdown delay."""
+        self.stop_event = threading.Event()  # WHY: ``close`` signals the reader through this event.
+        self.exit_delay = exit_delay  # WHY: Models the time ``run_forever`` needs to unwind.
+        self.close_calls = 0  # WHY: Lets a test prove ``disconnect`` asked for the shutdown.
+
+    def close(self) -> None:
+        """Request the shutdown without waiting for the reader to stop."""
+        self.close_calls += 1  # WHY: Record the request so a test can assert on it.
+        self.stop_event.set()  # WHY: Release the reader, which still needs time to unwind.
+
+    def run_forever(self) -> None:
+        """Block until ``close`` fires, then take a short time to unwind."""
+        self.stop_event.wait(timeout=_JOIN_WAIT_SECONDS)  # WHY: Bounded so a failed test cannot hang.
+        time.sleep(self.exit_delay)  # WHY: Keeps the thread alive after ``close`` returns.
+
+
+class _StuckConnection:
+    """Stand-in for a connection whose reader ignores the shutdown request."""
+
+    def __init__(self) -> None:
+        """Create the stuck connection with an event the test controls."""
+        self.release_event = threading.Event()  # WHY: Only the test releases this reader.
+
+    def close(self) -> None:
+        """Accept the shutdown request and do nothing, which models a stuck socket."""
+        return None  # WHY: A stuck reader is the case the join timeout must report.
+
+    def run_forever(self) -> None:
+        """Block until the test releases the thread."""
+        self.release_event.wait(timeout=_JOIN_WAIT_SECONDS)  # WHY: Bounded so the suite cannot hang.
+
+
+def _make_session() -> MagicMock:
+    """Return a mock Mist session with the attributes the manager reads."""
+    session = MagicMock()  # WHY: The manager only reads two attributes off the session.
+    session.host = "api.mist.com"  # WHY: Drives the derived WebSocket URL.
+    session.apitoken = "tok"  # WHY: Present so credential resolution succeeds.
+    return session  # WHY: Callers pass this straight into the manager constructor.
+
+
+def _start_reader(manager: WebSocketManager, connection: Any) -> threading.Thread:
+    """Attach the fake connection to the manager and start a daemon reader thread."""
+    manager.websocket_connection = connection  # WHY: The fake stands in for WebSocketApp.
+    reader = threading.Thread(target=connection.run_forever, daemon=True)  # WHY: Mirrors the real reader.
+    manager.websocket_thread = reader  # WHY: Mirrors what _start_websocket_thread records.
+    reader.start()  # WHY: The leak only appears once the reader is running.
+    return reader  # WHY: Test asserts on the thread state after disconnect.
+
+
+def test_start_websocket_thread_creates_daemon_reader() -> None:
+    """The reader thread must be a daemon, so a stuck reader cannot block interpreter exit."""
+    manager = WebSocketManager(_make_session())  # WHY: Real manager under test.
+    fake_app = MagicMock()  # WHY: Replaces WebSocketApp so no socket is opened.
+    fake_app.run_forever = lambda: None  # WHY: Returns at once, which keeps the test fast.
+    with patch("src.websocket.manager.websocket.WebSocketApp", return_value=fake_app):
+        manager._start_websocket_thread(["Authorization: Token tok"])  # WHY: Exercises the real starter.
+    assert manager.websocket_thread is not None  # WHY: The handle must be stored for the later join.
+    assert manager.websocket_thread.daemon is True  # WHY: Acceptance criterion from issue #1875.
+    manager.websocket_thread.join(timeout=_JOIN_WAIT_SECONDS)  # WHY: Leave no thread behind for other tests.
+
+
+def test_disconnect_joins_reader_thread_and_leaves_no_extra_thread() -> None:
+    """After disconnect returns, the reader thread has stopped and the thread count is back to baseline."""
+    manager = WebSocketManager(_make_session())  # WHY: Real manager under test.
+    baseline = threading.active_count()  # WHY: Reference count taken before the reader starts.
+    connection = _FakeConnection()  # WHY: Models a socket that needs time to unwind.
+    reader = _start_reader(manager, connection)  # WHY: Reproduces the state left by connect().
+    manager.connected = True  # WHY: Matches the state a live connection would leave.
+    manager.disconnect()  # WHY: The call under test must wait for the reader.
+    assert connection.close_calls == 1  # WHY: Proves disconnect still requests the shutdown.
+    assert reader.is_alive() is False  # WHY: Core defect of issue #1875 is a reader that outlives the call.
+    assert threading.active_count() == baseline  # WHY: Acceptance criterion asks for a thread-count check.
+    assert manager.websocket_thread is None  # WHY: A stopped thread must not keep a stale handle.
+
+
+def test_disconnect_joins_reader_thread_even_when_close_raises() -> None:
+    """A close() failure must not skip the join or leave stale manager state."""
+    manager = WebSocketManager(_make_session())  # WHY: Real manager under test.
+    connection = _FakeConnection(exit_delay=0.0)  # WHY: Reader exits as soon as the test releases it.
+    reader = _start_reader(manager, connection)  # WHY: Reproduces the state left by connect().
+    manager.connected = True  # WHY: Matches the state a live connection would leave.
+    manager.subscribed_channels.add("/sites/a/devices/b/cmd")  # WHY: Proves the state clear still runs.
+    connection.stop_event.set()  # WHY: Releases the reader, because the raising close cannot.
+
+    def raising_close() -> None:
+        """Raise from close so the test can prove the stop path still runs."""
+        raise OSError("socket already gone")  # WHY: Models a socket that fails during teardown.
+
+    connection.close = raising_close  # type: ignore[method-assign]  # WHY: Injects the failure.
+    try:  # WHY: disconnect re-raises the close failure after the stop path runs.
+        manager.disconnect()  # WHY: The call under test.
+    except OSError:  # WHY: The caller decides what to do with the failure.
+        pass  # WHY: The test only checks the teardown side effects.
+    assert reader.is_alive() is False  # WHY: The join must run on the exception path too.
+    assert manager.connected is False  # WHY: State reset must not depend on a clean close.
+    assert manager.subscribed_channels == set()  # WHY: Stale subscriptions would break the next connect.
+
+
+def test_disconnect_warns_and_keeps_handle_when_join_times_out(caplog) -> None:  # type: ignore[no-untyped-def]
+    """A join that expires logs a warning naming the endpoint and keeps the thread handle."""
+    manager = WebSocketManager(_make_session())  # WHY: Real manager under test.
+    connection = _StuckConnection()  # WHY: Models a reader that ignores the shutdown request.
+    reader = _start_reader(manager, connection)  # WHY: Reproduces the state left by connect().
+    # WHY: Short bound keeps the test fast while still exercising the timeout branch.
+    patcher = patch.object(manager_mod, "_WS_THREAD_JOIN_SECONDS", 0.05)
+    with patcher, caplog.at_level(logging.WARNING, logger=_MANAGER_LOGGER):
+        manager.disconnect()  # WHY: The call under test must not block on the stuck reader.
+    assert "still alive" in caplog.text  # WHY: A silent leak gives the operator nothing to act on.
+    assert manager.websocket_url in caplog.text  # WHY: The warning must name the endpoint.
+    assert manager.websocket_thread is reader  # WHY: Keep the handle so a later disconnect can retry.
+    connection.release_event.set()  # WHY: Release the reader so the suite leaves no thread behind.
+    reader.join(timeout=_JOIN_WAIT_SECONDS)  # WHY: Wait for the released reader before the test ends.
+
+
+def test_disconnect_from_reader_thread_skips_the_self_join() -> None:
+    """A callback that calls disconnect on the reader thread must not raise a self-join error."""
+    manager = WebSocketManager(_make_session())  # WHY: Real manager under test.
+    manager.websocket_connection = MagicMock()  # WHY: close() is a no-op mock here.
+    failures: list[BaseException] = []  # WHY: Collects any error raised inside the reader thread.
+
+    def disconnect_from_reader() -> None:
+        """Call disconnect from inside the reader thread, which models an on_close callback."""
+        try:  # WHY: A raised error inside a thread would otherwise be lost.
+            manager.disconnect()  # WHY: The self-join branch under test.
+        except BaseException as thread_error:  # noqa: BLE001  # WHY: Report any error to the main thread.
+            failures.append(thread_error)  # WHY: Main thread asserts the list is empty.
+
+    reader = threading.Thread(target=disconnect_from_reader, daemon=True)  # WHY: Stands in for the reader.
+    manager.websocket_thread = reader  # WHY: Makes the running thread its own join target.
+    reader.start()  # WHY: Runs disconnect on the thread the manager would try to join.
+    reader.join(timeout=_JOIN_WAIT_SECONDS)  # WHY: Bounded wait keeps a failure from hanging the suite.
+    assert failures == []  # WHY: A self-join would raise RuntimeError from threading.
+    assert manager.connected is False  # WHY: The state reset must still run on this path.


### PR DESCRIPTION
# Spec Conformance Checklist

**Linked Spec Issue**: #1875

Fixes #1875

## Root cause

`WebSocketManager.disconnect()` called `websocket_connection.close()` and returned.
`close()` only requests a shutdown. The `run_forever` reader thread still needed
time to unwind, so it stayed alive after the caller believed the operation ended.
`ArpDeviceExecutor` reaches this path through `cleanup_ws_connection`, so every
ARP run added one live thread to a long-lived process. The late thread could also
write into buffers the caller had started to read.

## Change

- Add `WebSocketManager._join_websocket_thread`. The helper waits a bounded
  5 seconds through the new `_WS_THREAD_JOIN_SECONDS` constant. It logs a warning
  that names the endpoint when the wait expires, and it clears the handle after
  the reader thread stops. It skips the join when the reader thread itself calls
  `disconnect`, because a self-join raises an error.
- Wrap the `close()` call in `disconnect()` with `try` and `finally`. The join and
  the state reset now run on every exit path, including the exception path.
- Add `tests/unit/websocket/test_manager_thread_join.py` with 5 tests.

The reader thread was already a daemon thread, so that acceptance criterion held
before this change. A new test pins the daemon flag against a regression.

## Evidence

The new tests fail on the base revision and pass after the change.

Before the change (source file stashed):

```
3 failed, 2 passed in 1.12s
FAILED test_disconnect_joins_reader_thread_and_leaves_no_extra_thread
FAILED test_disconnect_joins_reader_thread_even_when_close_raises
FAILED test_disconnect_warns_and_keeps_handle_when_join_times_out
```

The first failure reported `assert True is False` on `reader.is_alive()`, and a
standalone check reported `reader_alive=True baseline=1 active_after=2`.

After the change:

```
tests/unit/websocket/test_manager_thread_join.py .....   [100%]
5 passed in 1.50s
```

Regression run over the touched area:

```
python -m pytest tests/unit/websocket -q
1 failed, 671 passed in 8.39s
```

The single failure is `test_service_ping_manager.py::test_menu_action_120_description_is_preserved`.
It fails because the test venv has no `mistapi` package, so `import MistHelper`
stops early. The failure is present on the base revision and is not related to
this change.

## Quality gates

| Gate | Command | Result |
| - | - | - |
| Compile | `python -m py_compile <files>` | Pass, no output |
| Lint | `python -m ruff check <files>` | `All checks passed!` |
| Format | `python -m black --check <files>` | `2 files would be left unchanged` |
| Types | `python -m mypy <files> --config-file pyproject.toml` | `Success: no issues found in 2 source files` |
| STE | `python -m tools.ste_linter <files>` | `src/websocket/manager.py` 98/100 PASS, test file 99/100 PASS |

## Acceptance Criteria
- [x] `disconnect` joins the WebSocket reader thread with a bounded timeout before it returns
- [x] The WebSocket reader thread is a daemon thread, and a test pins the flag
- [x] A join that times out logs a warning that names the endpoint
- [x] A unit test compares the thread count before and after the call
- [ ] `CLIShellManager` keeps a reference to the receive thread and joins it during cleanup

## Quality
- [x] Tests added or updated for all changed functionality
- [x] Coverage meets or exceeds 80% threshold for the changed lines
- [x] No new Ruff lint violations
- [x] Code formatted with Black
- [x] mypy passes on the changed files

## Security
- [x] No hardcoded secrets, tokens, or passwords
- [x] Bandit finds nothing new. The change adds no subprocess call and no network call.
- [x] pip-audit unchanged. The change adds no dependency.
- [x] Sensitive data handled through `.env` and environment variables only

## Deployment
- [x] Dry-run verified through the unit tests for the WebSocket manager
- [x] No `.env` change
- [x] No Containerfile change

## UI / E2E Testing
Not applicable. The change touches no web UI file.

## Documentation
- [ ] README.md update. Not applicable. The change is not user facing.
- [ ] Changelog entry. This branch has a narrow file scope, so it leaves
  `CHANGELOG.md` to the release owner and avoids a conflict with parallel work.

## Work left for a separate change

This branch owns `src/websocket/` only. The issue reports the same defect shape
in two files outside that scope. Track them separately.

1. `src/device/arp_command_manager.py`, lines 170 to 173. `_listen_for_output`
   starts a non-daemon thread, drops the handle, and never joins it.
2. `src/device/arp_command_manager.py`, lines 183 and 184. The
   `@staticmethod` decorator appears twice on `_parse_ws_arp_payload`.
3. `src/ssh/cli_shell_manager.py`, line 170. The receive loop thread handle is
   discarded in the same statement that starts it.
