### PR TITLE
fix(upgrade-portal): refuse an upgrade when the lock store is unreachable (#1827)

### DIFF
--- a/specs/1823-upgrade-capture-portal/contracts/http-api.md
+++ b/specs/1823-upgrade-capture-portal/contracts/http-api.md
@@ -286,6 +286,7 @@ and the start control posts to no site.
 | 409 | `site_locked` with `details.actor_email` when a different operator holds the site lock |
 | 409 | `upgrade_already_running` with `details.run_id` when a run of this site has not finished |
 | 500 | `run_write_failed` when the run store refused the write |
+| 503 | `lock_store_unreachable` when the portal cannot read the site lock |
 
 `POST /api/runs` reaches the same handler and answers the same body. The two paths
 are one endpoint, not two. The path above names the site. `POST /api/runs` reads
@@ -341,6 +342,7 @@ upgrades.
 | 409 | `site_locked` with `details.actor_email` when a different operator holds the site lock |
 | 409 | `upgrade_targets_missing` when the saved plan names no device |
 | 500 | `run_write_failed` when the run store refused the write |
+| 503 | `lock_store_unreachable` when the portal cannot read the site lock |
 
 The portal refuses to start unless a verified pre-check capture exists.
 
@@ -418,6 +420,7 @@ The browser polls this endpoint every 30 seconds.
 | 404 | `run_not_found` |
 | 409 | `site_locked` with `details.actor_email` when a different operator holds the site lock |
 | 409 | `run_not_stoppable` when the run already finished |
+| 503 | `lock_store_unreachable` when the portal cannot read the site lock |
 
 ```json
 {
@@ -438,6 +441,18 @@ the cancel is best effort and that a device in mid-flash may still complete. The
 FR-038i binds this control to the operator who holds the site lock. The lock check
 runs before every other check of this route, so a second operator reads
 `site_locked` even when the run already finished.
+
+### The unreadable lock store
+
+The three routes above write. Each one answers `503` `lock_store_unreachable`
+when the portal cannot read the site lock. `contracts/site-lock.md:116` fixes
+that rule and forbids a fallback lock. The body names no operator, because the
+portal read no holder and any address there would be a guess.
+
+A read keeps the opposite rule. `GET /api/sites` marks the row `unknown`, and the
+capture start in section 4 still starts. A capture writes no firmware, and a page
+writes nothing at all. Only an upgrade route writes firmware to a device, so only
+an upgrade route fails closed.
 
 ### `GET /runs/<run_id>/options` — the options page
 

--- a/src/upgrade_portal/app/routes/capture.py
+++ b/src/upgrade_portal/app/routes/capture.py
@@ -658,8 +658,8 @@ def held_by_other(org_id: str, site_id: str) -> str | None:
         take the pre-check capture. A presence-only test refuses that operator
         their own capture, so the primary journey cannot finish. The holder
         therefore passes every check here, and a second operator still reads
-        409 `site_locked`. `upgrade.held_by_other` keeps this same rule, so the
-        two routes answer one question one way.
+        409 `site_locked`. `upgrade.held_by_other` keeps a different rule for the
+        unknown state, because only the upgrade route writes firmware.
 
     The unreachable store:
         `read_site_locks` answers an empty index when the lock store is
@@ -669,7 +669,8 @@ def held_by_other(org_id: str, site_id: str) -> str | None:
         unreachable, and `contracts/site-lock.md:167` states that an unreachable
         store still lets a capture start. An unknown state names no holder, so
         this function has no address to refuse. The upgrade start makes the
-        opposite choice, because only that path writes firmware to a device.
+        opposite choice and answers 503 `lock_store_unreachable`, because only
+        that path writes firmware to a device. Issue #1827 records that repair.
 
     Args:
         org_id: The organization that holds the site.

--- a/src/upgrade_portal/app/routes/upgrade.py
+++ b/src/upgrade_portal/app/routes/upgrade.py
@@ -48,7 +48,7 @@ from __future__ import annotations  # Postponed annotations keep every hint a pl
 import logging  # The portal logs with the standard library only.
 import threading  # One guard for the memory run store, which a driver thread also writes.
 from collections.abc import Iterable, Mapping  # The version answer arrives in more than one shape.
-from typing import Any  # A run record and an injected seam are both free-form.
+from typing import Any, NamedTuple  # A run record is free-form, and the lock read carries two fixed fields.
 
 from flask import Blueprint, Response, current_app, jsonify, request, session  # The framework of the portal.
 
@@ -71,6 +71,9 @@ from ...runtime.signals import (  # The stop request rides inside the run record
 )
 from ..factory import build_error_envelope, json_error  # The one error envelope that the contract allows.
 from .select import (  # The sibling module owns these rules, so no copy of them lives here.
+    LOCK_STATE_FREE,
+    LOCK_STATE_LOCKED,
+    LOCK_STATE_UNKNOWN,
     SELECTED_SITE_KEY,
     find_attribute,
     load_optional_module,
@@ -139,6 +142,7 @@ TARGETS_MISSING_CODE = "upgrade_targets_missing"  # The saved plan names no devi
 RUN_NOT_STOPPABLE_CODE = "run_not_stoppable"  # The run already reached a state that a stop cannot change.
 RUN_WRITE_FAILED_CODE = "run_write_failed"  # The store refused the write, so the operator must retry.
 UPGRADE_RUNNING_CODE = "upgrade_already_running"  # FR-037: one run of this site has not reached a final state.
+LOCK_STORE_DOWN_CODE = "lock_store_unreachable"  # `contracts/site-lock.md:116` refuses a write the lock cannot guard.
 
 SITE_LOCKED_MESSAGE = "Another operator holds this site. Ask that operator before you try again."  # The cure.
 SITE_NOT_CHOSEN_MESSAGE = "Choose a site before you start a run."  # Names the missing step.
@@ -150,6 +154,10 @@ PRE_CAPTURE_MISSING_MESSAGE = "Save a verified pre-check capture before you star
 TARGETS_MISSING_MESSAGE = "The saved plan names no device. Choose a version on the options page and save it."  # Cure.
 RUN_WRITE_FAILED_MESSAGE = "The portal could not write the run record. Try again."  # The cure.
 UPGRADE_RUNNING_MESSAGE = "An upgrade already runs at this site. Open that run before you start a new one."  # Cure.
+LOCK_STORE_DOWN_MESSAGE = (  # Warning: a guess here can start a second upgrade on a live site.
+    "The portal cannot reach the site lock store, so it cannot tell whether "
+    "another operator holds this site. Wait, then try again."
+)
 NO_LAUNCHER_MESSAGE = "The portal cannot send an upgrade yet, because the run driver is not wired."  # The gap.
 STOP_RECORDED_MESSAGE = "The portal recorded the stop and starts no further device."  # Claims no cancel.
 
@@ -160,6 +168,7 @@ BAD_REQUEST_STATUS = 400  # The portal could not read the request.
 NOT_FOUND_STATUS = 404  # No such run.
 CONFLICT_STATUS = 409  # The site is held, the pre-check is missing, or the run cannot stop.
 SERVER_ERROR_STATUS = 500  # A part of the portal is missing, so the write cannot run.
+UNAVAILABLE_STATUS = 503  # `contracts/http-api.md:133` fixes this status for an unreadable lock store.
 
 # The run record of a live run lives here while no store is injected. The driver
 # thread writes and the poll reads, so both take the guard.
@@ -437,22 +446,47 @@ def write_failed() -> tuple[Response, int]:
 # --------------------------------------------------------------------------
 
 
-def lock_holder(org_id: str, site_id: str) -> str | None:
-    """Return the address of the operator that holds the site lock.
+class SiteLockRead(NamedTuple):
+    """Holds what the portal learned about one site lock.
 
     Why:
-        `contracts/site-lock.md` states that an unreachable lock store must not
-        stop a read. `select.read_site_locks` already keeps that rule and raises
-        nothing, so a dead store names no holder and the run continues.
+        A holder address alone answers two states. A free site and a site the
+        portal could not read both answer None, so a write path that reads only
+        an address treats a dead lock store as a free site. Issue #1827 reports
+        that exact failure. These two fields carry the third state, so every
+        write path can refuse what it cannot read.
+    """
+
+    state: str  # One of `free`, `locked`, or `unknown`, as `select.site_lock_state` names them.
+    holder: str  # The address of the holder, and an empty string for the other two states.
+
+
+LOCK_FREE = SiteLockRead(LOCK_STATE_FREE, "")  # The store answered and named no holder.
+LOCK_UNKNOWN = SiteLockRead(LOCK_STATE_UNKNOWN, "")  # The store did not answer, so the portal cannot tell.
+
+
+def lock_holder(org_id: str, site_id: str) -> SiteLockRead:
+    """Return what the lock store knows about one site.
+
+    Why:
+        `contracts/site-lock.md:116` refuses an upgrade start that the lock
+        cannot guard, and `select.read_site_locks` answers an empty index when
+        the store does not answer. This function tests membership, as
+        `select.site_lock_state` already does, so an absent entry reads
+        `unknown` and never `free`.
 
     Args:
         org_id: The organization that holds the site.
         site_id: The site the run acts on.
 
     Returns:
-        The holder address, or None when no holder exists and when none is known.
+        The lock state and the holder address of that site.
     """
-    return read_site_locks(org_id, [site_id]).get(site_id)  # An unreachable store answers an empty index.
+    locks = read_site_locks(org_id, [site_id])  # An unreachable store answers an empty index and raises nothing.
+    if site_id not in locks:  # The lock store named no state for this site.
+        return LOCK_UNKNOWN  # The portal cannot tell, so it must not report free.
+    holder = locks[site_id]  # A None value means the store answered and found no lock.
+    return SiteLockRead(LOCK_STATE_LOCKED, holder) if holder else LOCK_FREE  # An address names the holder.
 
 
 def site_locked_refusal(holder: str) -> tuple[Response, int]:
@@ -461,7 +495,7 @@ def site_locked_refusal(holder: str) -> tuple[Response, int]:
     Why:
         T182 asks the refusal to name the holder, so the second operator knows
         whom to ask. `json_error` carries no `details` key, so the answer takes
-        the envelope builder instead. `contracts/http-api.md` section 3 fixes
+        the envelope builder instead. `contracts/http-api.md:132` fixes
         `details.actor_email` for the same refusal on the lock path.
 
     Args:
@@ -474,26 +508,67 @@ def site_locked_refusal(holder: str) -> tuple[Response, int]:
     return jsonify(body), CONFLICT_STATUS  # The browser reads the code and shows the address.
 
 
-def held_by_other(org_id: str, site_id: str) -> str | None:
-    """Return the address of a lock holder that is not the current operator.
+def lock_store_down_refusal() -> tuple[Response, int]:
+    """Answer a lock store that the portal cannot read.
+
+    Why:
+        `contracts/site-lock.md:116` refuses the upgrade with 503 and forbids a
+        fallback lock. The answer names no operator, because the portal read
+        nothing and any address here would be a guess.
+
+    Returns:
+        The 503 answer with the contract code and the cure.
+    """
+    return json_error(UNAVAILABLE_STATUS, LOCK_STORE_DOWN_CODE, LOCK_STORE_DOWN_MESSAGE)  # Waiting is the cure.
+
+
+def held_by_other(org_id: str, site_id: str) -> SiteLockRead:
+    """Return the lock state that stops the current operator.
 
     Why:
         The operator that already holds the lock must pass every check of this
         module. Without this rule the start route would refuse the one operator
-        that the lock exists to protect.
+        that the lock exists to protect. An unknown state passes no operator,
+        because the portal cannot name who holds the site.
 
     Args:
         org_id: The organization that holds the site.
         site_id: The site the run acts on.
 
     Returns:
-        The address of the other operator, or None when the site is free to use.
+        The free state when the caller may continue, and the blocking state
+        otherwise.
     """
-    holder = lock_holder(org_id, site_id)  # None means free, and None also means unknown.
-    if not holder or holder == actor_address():  # The current operator may always continue.
-        return None  # The caller runs the action.
-    logger.info("upgrade: the site %s is held by %s", site_id, identity.email_digest(holder))  # Digest only.
-    return holder  # The caller answers 409 and names this address to the operator.
+    found = lock_holder(org_id, site_id)  # Three states, so a dead store never reads as a free site.
+    if found.holder and found.holder == actor_address():  # The current operator may always continue.
+        return LOCK_FREE  # The caller runs the action.
+    if found.state == LOCK_STATE_LOCKED:  # Another operator holds this site right now.
+        logger.info("upgrade: the site %s is held by %s", site_id, identity.email_digest(found.holder))  # Digest.
+    return found  # The caller turns this state into the documented refusal.
+
+
+def lock_refusal(org_id: str, site_id: str) -> tuple[Response, int] | None:
+    """Return the refusal that the site lock puts on one write, or None.
+
+    Why:
+        Three write routes share one rule. One function holds that rule, so no
+        route can read an unknown state as a free site. Warning: a write that
+        skips this check can start a second upgrade on a live site.
+
+    Args:
+        org_id: The organization that holds the site.
+        site_id: The site the write acts on.
+
+    Returns:
+        The 409 answer, the 503 answer, or None when the write may run.
+    """
+    found = held_by_other(org_id, site_id)  # One read for both refusals below.
+    if found.state == LOCK_STATE_UNKNOWN:  # The lock store did not answer about this site.
+        logger.warning("upgrade: the lock store did not answer about the site %s, so the write stops", site_id)
+        return lock_store_down_refusal()  # `contracts/site-lock.md:116` refuses the write and adds no fallback.
+    if found.state == LOCK_STATE_LOCKED:  # A second operator holds the site.
+        return site_locked_refusal(found.holder)  # The refusal names that operator.
+    return None  # The store answered, and the site is free for this operator.
 
 
 # --------------------------------------------------------------------------
@@ -587,9 +662,9 @@ def site_refusal(org_id: str, site_id: str) -> tuple[Response, int] | None:
     Returns:
         The refusal answer, or None when the site accepts a new run.
     """
-    holder = held_by_other(org_id, site_id)  # `contracts/http-api.md` lists 409 site_locked on this path.
-    if holder:  # Another operator already acts on this site.
-        return site_locked_refusal(holder)  # The refusal names that operator.
+    refusal = lock_refusal(org_id, site_id)  # `contracts/http-api.md` lists 409 site_locked and 503 on this path.
+    if refusal is not None:  # Another operator holds the site, or the portal cannot read the lock.
+        return refusal  # The answer names the operator to ask, or names the unreadable store.
     live = live_run_at_site(site_id)  # FR-037: the check above never sees the run of the current operator.
     if live:  # One upgrade of this site has not reached a final state.
         logger.info("upgrade: the site %s already runs the upgrade %s", site_id, live)  # Names the live run.
@@ -1002,9 +1077,9 @@ def start_refusal(record: dict[str, Any]) -> tuple[Response, int] | None:
         return json_error(BAD_REQUEST_STATUS, CONFIRMATION_REQUIRED_CODE, CONFIRM_REQUIRED_MESSAGE)
     if not record.get(PRE_CAPTURE_FIELD):  # FR-035 refuses a start with no saved pre-check.
         return json_error(CONFLICT_STATUS, PRE_CAPTURE_MISSING_CODE, PRE_CAPTURE_MISSING_MESSAGE)
-    holder = held_by_other(str(record.get("org_id", "")), str(record.get("site_id", "")))  # T182 asks for this.
-    if holder:  # Another operator holds the site, so this run may not send anything.
-        return site_locked_refusal(holder)  # The refusal names that operator.
+    refusal = lock_refusal(str(record.get("org_id", "")), str(record.get("site_id", "")))  # T182 asks for this.
+    if refusal is not None:  # Another operator holds the site, or the portal cannot read the lock.
+        return refusal  # Warning: without this line a second upgrade can reach a live site.
     if not record.get(TARGETS_FIELD):  # An operator who saved no version reaches this line.
         return json_error(CONFLICT_STATUS, TARGETS_MISSING_CODE, TARGETS_MISSING_MESSAGE)
     return None  # Every rule passed, so the handler sends the upgrade.
@@ -1296,14 +1371,14 @@ def stop_lock_refusal(record: dict[str, Any]) -> tuple[Response, int] | None:
         record: The run record that the stop acts on.
 
     Returns:
-        The 409 answer that names the holder, or None when the stop may run.
+        The 409 answer that names the holder, the 503 answer for an unreadable
+        lock store, or None when the stop may run.
     """
     org_id = str(record.get("org_id", ""))  # The run record carries its own scope.
     site_id = str(record.get("site_id", ""))  # FR-014 binds one run to one site.
     if not org_id or not site_id:  # An absent run and a damaged record both reach here.
         return None  # The stop store still answers `run_not_found` for a run it does not hold.
-    holder = held_by_other(org_id, site_id)  # The operator that holds the lock always passes.
-    return site_locked_refusal(holder) if holder else None  # The refusal names the operator to ask.
+    return lock_refusal(org_id, site_id)  # The refusal names the operator to ask, or names the unreadable store.
 
 
 def cancel_outcome(run_id: str) -> StopOutcome:

--- a/tests/contract/upgrade_portal/test_capture_attach.py
+++ b/tests/contract/upgrade_portal/test_capture_attach.py
@@ -239,7 +239,7 @@ def joined_app(
         The wired application.
     """
     portal_app.config[MIST_READER_KEY] = fake_mist_api.read  # No socket, no cloud account.
-    portal_app.config[LOCK_READER_KEY] = lambda org_id, site_ids: {}  # Every site reads as free.
+    portal_app.config[LOCK_READER_KEY] = lambda org, sites: dict.fromkeys(sites)  # Every site reads free.
     portal_app.config[RUN_STORE_KEY] = run_store  # Both route modules read this one store.
     portal_app.config[RUNNER_KEY] = runner  # The capture route hands the job here.
     portal_app.config[LAUNCHER_KEY] = launcher  # The start route hands the run here.

--- a/tests/contract/upgrade_portal/test_upgrade_routes.py
+++ b/tests/contract/upgrade_portal/test_upgrade_routes.py
@@ -131,9 +131,11 @@ class RecordingLockReader:
             site_ids: The sites to ask about.
 
         Returns:
-            One entry for each site that the canned index names.
+            One entry for each site asked about, because `runtime/lock.py`
+            answers one entry for each site it can reach. A site the canned
+            index does not name reads as a free site, never as an unknown one.
         """
-        return {site: self.holders[site] for site in site_ids if site in self.holders}
+        return {site: self.holders.get(site) for site in site_ids}  # A reachable store names every asked site.
 
 
 class RecordingLauncher:

--- a/tests/contract/upgrade_portal/test_upgrade_start.py
+++ b/tests/contract/upgrade_portal/test_upgrade_start.py
@@ -185,7 +185,7 @@ def upgrade_app(portal_app: Flask, run_store: RecordingRunStore) -> Flask:
         The application with the seams in place.
     """
     portal_app.config[RUN_STORE_KEY] = run_store  # No ArangoDB server runs in a contract test.
-    portal_app.config[LOCK_READER_KEY] = lambda org_id, site_ids: {}  # No Redis server runs in a contract test.
+    portal_app.config[LOCK_READER_KEY] = lambda org, sites: dict.fromkeys(sites)  # Every site reads free.
     portal_app.config["WTF_CSRF_ENABLED"] = False  # One test below reads the untouched application instead.
     return portal_app  # Every test below drives this application.
 

--- a/tests/contract/upgrade_portal/test_upgrade_stop.py
+++ b/tests/contract/upgrade_portal/test_upgrade_stop.py
@@ -191,7 +191,7 @@ def upgrade_app(portal_app: Flask, run_store: RecordingRunStore) -> Flask:
         The application with the seams in place.
     """
     portal_app.config[RUN_STORE_KEY] = run_store  # No ArangoDB server runs in a contract test.
-    portal_app.config[LOCK_READER_KEY] = lambda org_id, site_ids: {}  # No Redis server runs in a contract test.
+    portal_app.config[LOCK_READER_KEY] = lambda org, sites: dict.fromkeys(sites)  # Every site reads free.
     portal_app.config["WTF_CSRF_ENABLED"] = False  # One test drives the untouched portal to prove the check.
     return portal_app  # Every test below drives this application.
 

--- a/tests/unit/upgrade_portal/test_concurrent_upgrade.py
+++ b/tests/unit/upgrade_portal/test_concurrent_upgrade.py
@@ -223,6 +223,7 @@ def portal_app(run_store: SiteAwareStore) -> Flask:
     app = Flask(__name__)  # The smallest application that can hold the blueprint.
     app.config.update(TESTING=True, SECRET_KEY=FAKE_SECRET, WTF_CSRF_ENABLED=False)  # Test settings alone.
     app.config[upgrade.RUN_STORE_KEY] = run_store  # The seam the route already reads.
+    app.config[LOCK_READER_KEY] = lambda org, sites: dict.fromkeys(sites)  # A reachable store, and no holder.
     app.register_blueprint(upgrade.upgrade_bp)  # The routes under test.
     return app  # Each test drives this application through a client.
 

--- a/tests/unit/upgrade_portal/test_lock_store_unreachable.py
+++ b/tests/unit/upgrade_portal/test_lock_store_unreachable.py
@@ -1,0 +1,408 @@
+"""Unit tests that hold the write path of the portal closed when Redis is down.
+
+Why:
+    Issue #1827 reports a safety defect. The site lock read answered two states.
+    A free site and a site the portal could not read both answered None, so a
+    second operator read a held site as free and started a second upgrade on a
+    live network. `contracts/site-lock.md:116` asks the portal to refuse the
+    upgrade with 503 `lock_store_unreachable` and to add no fallback lock.
+
+    Every test drives the route through a bare application. No factory, no
+    database, and no Redis server takes part. Each test injects a lock reader
+    through the `SITE_LOCK_READER` seam that the route already reads.
+
+    A capture and a page keep the old rule. `capture.py` starts a capture when
+    the state is unknown, because a capture writes no firmware. These tests
+    cover the three routes that lead to a firmware write.
+"""
+
+from __future__ import annotations  # Postponed annotations keep every hint a plain string.
+
+from collections.abc import Callable, Iterator  # Types the lock reader and each fixture that yields.
+from typing import Any  # A run record, an injected store, and a JSON body are all free-form.
+
+import pytest  # The test framework.
+from flask import Flask  # The smallest application that can hold the blueprint.
+from flask.testing import FlaskClient  # Drives a route with no server and no browser.
+from werkzeug.test import TestResponse  # The answer that the test client returns.
+
+from src.upgrade_portal.app.routes import upgrade  # The module under test.
+from src.upgrade_portal.app.routes.select import (  # The sibling module owns the three state words.
+    LOCK_READER_KEY,
+    LOCK_STATE_FREE,
+    LOCK_STATE_LOCKED,
+    LOCK_STATE_UNKNOWN,
+    SELECTED_ORG_KEY,
+    SELECTED_SITE_KEY,
+)
+from src.upgrade_portal.runtime import identity  # The registry, the cookie name, and the session field names.
+from src.upgrade_portal.runtime.runs import RunRecordBuilder, RunSpec, RunState  # The record model.
+
+# WHY: A reserved example domain, so no message can reach a real mailbox.
+PROBE_EMAIL = "probe.operator@example.invalid"
+OTHER_EMAIL = "other.operator@example.invalid"
+
+# WHY: An obviously fake value. FR-009 forbids a real credential inside the suite.
+FAKE_SECRET = "fake-flask-secret-key-for-tests-only"
+
+# WHY: The identifier shape that the cloud uses.
+ORG_ID = "00000000-0000-0000-0000-0000000000aa"
+SITE_ID = "00000000-0000-0000-0000-0000000000bb"
+
+UNREACHABLE_STATUS = 503  # `contracts/http-api.md:133` fixes this status for an unreadable lock store.
+
+LockReader = Callable[[str, list[str]], dict[str, str | None]]  # The shape of the injected seam.
+
+
+class SiteAwareStore:
+    """A run record store that answers the reader, the writer, and the site scan.
+
+    Why:
+        The real store reads a database. This stand-in holds the same three
+        method names in memory, so a route test proves the decision of the route
+        and never the behavior of a database.
+    """
+
+    def __init__(self) -> None:
+        """Start with no record."""
+        self.records: dict[str, dict[str, Any]] = {}  # One entry for each seeded or created run.
+
+    def read_run(self, run_id: str) -> dict[str, Any] | None:
+        """Return one stored run record.
+
+        Args:
+            run_id: The key of the run to read.
+
+        Returns:
+            The record, or None when no run holds that key.
+        """
+        return self.records.get(run_id)  # An absent key answers None, as the real store does.
+
+    def write_run(self, run: dict[str, Any]) -> bool:
+        """Store one run record.
+
+        Args:
+            run: The record to store.
+
+        Returns:
+            True, because a memory write always succeeds.
+        """
+        self.records[str(run["run_id"])] = run  # The key comes from the record, never from the caller.
+        return True  # A memory write never fails, so no route reads a false failure.
+
+    def site_runs(self, site_id: str) -> list[dict[str, Any]]:
+        """Return every record that this store holds for one site.
+
+        Args:
+            site_id: The site to scan.
+
+        Returns:
+            One record for each run of that site.
+        """
+        return [row for row in self.records.values() if row.get("site_id") == site_id]  # One site only.
+
+
+def reader_that_raises() -> LockReader:
+    """Build a lock reader that fails as an unreachable Redis server does.
+
+    Why:
+        `runtime/lock.py` reaches Redis over a network. A stopped server raises
+        inside that call, and `select.read_site_locks` catches the fault and
+        answers an empty index. This stand-in reproduces that exact path.
+
+    Returns:
+        The reader callable that the seam accepts.
+    """
+
+    def read(org_id: str, site_ids: list[str]) -> dict[str, str | None]:
+        """Fail as a stopped lock store does.
+
+        Args:
+            org_id: The organization that owns the sites.
+            site_ids: The sites to ask about.
+
+        Returns:
+            Nothing, because this reader always raises.
+
+        Raises:
+            RuntimeError: Always, because the store cannot answer.
+        """
+        raise RuntimeError(f"the lock store cannot answer about {org_id} and {site_ids}")  # The dead store.
+
+    return read  # The test writes this callable into the application configuration.
+
+
+def reader_that_answers(holders: dict[str, str | None]) -> LockReader:
+    """Build a lock reader that answers one fixed index.
+
+    Args:
+        holders: The holder of each site that the store knows about.
+
+    Returns:
+        The reader callable that the seam accepts.
+    """
+
+    def read(org_id: str, site_ids: list[str]) -> dict[str, str | None]:
+        """Return the fixed index, unchanged.
+
+        Args:
+            org_id: The organization that owns the sites.
+            site_ids: The sites to ask about.
+
+        Returns:
+            The index that the test built.
+        """
+        return dict(holders)  # The organization and the site list play no part in this stand-in.
+
+    return read  # The test writes this callable into the application configuration.
+
+
+@pytest.fixture
+def run_store() -> SiteAwareStore:
+    """Return a fresh stand-in run record store.
+
+    Returns:
+        A store with no record, so no record survives from an earlier test.
+    """
+    return SiteAwareStore()  # One store for each test keeps every test independent.
+
+
+@pytest.fixture
+def portal_app(run_store: SiteAwareStore) -> Flask:
+    """Return a bare application that holds the upgrade blueprint alone.
+
+    Args:
+        run_store: The stand-in run record store.
+
+    Returns:
+        The application, ready for a test client.
+    """
+    app = Flask(__name__)  # The smallest application that can hold the blueprint.
+    app.config.update(TESTING=True, SECRET_KEY=FAKE_SECRET, WTF_CSRF_ENABLED=False)  # Test settings alone.
+    app.config[upgrade.RUN_STORE_KEY] = run_store  # The seam the route already reads.
+    app.config[LOCK_READER_KEY] = reader_that_raises()  # Redis is down for every test unless a test says more.
+    app.register_blueprint(upgrade.upgrade_bp)  # The routes under test.
+    return app  # Each test drives this application through a client.
+
+
+@pytest.fixture
+def registered_owner() -> Iterator[identity.SessionOwner]:
+    """Register one operator and drop the record when the test ends.
+
+    Yields:
+        The identity pair of the registered operator.
+    """
+    owner = identity.build_owner(PROBE_EMAIL, identity.issue_browser_id())  # The pair the guard checks.
+    record = identity.OperatorSession(
+        owner=owner,  # The pair that the browser cookie and the session field name.
+        cloud_session=object(),  # A plain object states no scope, so every organization passes.
+        credential_mode=identity.CredentialMode.ENVIRONMENT_TOKEN,  # No password takes part in these tests.
+    )
+    identity.SESSION_REGISTRY.register(record)  # The guard reads the registry on every request.
+    try:  # The test body runs with the owner in place.
+        yield owner  # Every signed-in test reads this pair.
+    finally:  # A leaked record would sign in a later test by accident.
+        identity.SESSION_REGISTRY.drop(owner.key)  # The registry outlives the test, so clear it here.
+
+
+@pytest.fixture
+def client(portal_app: Flask, registered_owner: identity.SessionOwner) -> Iterator[FlaskClient]:
+    """Return a signed-in client that already picked the organization and the site.
+
+    Args:
+        portal_app: The application with both seams injected.
+        registered_owner: The identity pair of the registered operator.
+
+    Yields:
+        The Flask test client, with the session held open.
+    """
+    with portal_app.test_client() as opened:  # The context manager holds the session across requests.
+        opened.set_cookie(identity.BROWSER_ID_COOKIE, registered_owner.browser_id)  # Half of the guard.
+        with opened.session_transaction() as browser_session:  # The other half of the guard.
+            browser_session[identity.SESSION_OWNER_KEY] = registered_owner.key  # Names the registered owner.
+            browser_session[SELECTED_ORG_KEY] = ORG_ID  # The picker writes this field.
+            browser_session[SELECTED_SITE_KEY] = SITE_ID  # The picker writes this field as well.
+        yield opened  # Every test below drives this client.
+
+
+def seed_startable_run(store: SiteAwareStore, state: str = RunState.CREATED.value) -> str:
+    """Write one run record that passes every start rule except the lock rule.
+
+    Why:
+        The start route reads the confirmation, the pre-check, the lock, and the
+        plan in that order. A record that carries a pre-check and a plan proves
+        that the lock rule alone stopped the call.
+
+    Args:
+        store: The stand-in run record store.
+        state: The state that the seeded run holds.
+
+    Returns:
+        The key of the seeded run.
+    """
+    spec = RunSpec(ORG_ID, "Probe organization", SITE_ID, "Probe site", PROBE_EMAIL, "browser-probe")
+    record = RunRecordBuilder().build(spec)  # The record layer owns every field and every default.
+    record["state"] = state  # The test names the stage that the run already reached.
+    record[upgrade.PRE_CAPTURE_FIELD] = "capture-probe"  # FR-035 needs a saved pre-check.
+    record[upgrade.TARGETS_FIELD] = [{"mac": "aabbccddeeff", "version": "0.0.0"}]  # A plan with one device.
+    store.records[str(record["run_id"])] = record  # The store answers the read with this record.
+    return str(record["run_id"])  # Every start call and stop call below names this key.
+
+
+def error_code(response: TestResponse) -> str:
+    """Read the error code out of one answer.
+
+    Args:
+        response: The answer of the route.
+
+    Returns:
+        The code, or an empty string when the body carries none.
+    """
+    body: Any = response.get_json()  # The envelope of `contracts/README.md`.
+    return str(body["error"]["code"]) if isinstance(body, dict) else ""  # A missing envelope reads as no code.
+
+
+def test_the_create_call_refuses_an_unreachable_lock_store(client: FlaskClient) -> None:
+    """A create call answers 503 when the portal cannot read the site lock.
+
+    Why:
+        Issue #1827 step 5 accepts the run today. An unreadable lock hides the
+        holder, so the portal must refuse and must never report the site free.
+
+    Args:
+        client: The signed-in test client.
+    """
+    answer = client.post(f"/api/sites/{SITE_ID}/runs", json={"tier": 2})  # The path of the contract.
+    assert answer.status_code == UNREACHABLE_STATUS  # A held site must not read as a free site.
+    assert error_code(answer) == upgrade.LOCK_STORE_DOWN_CODE  # The code names the cause plainly.
+
+
+def test_the_start_call_refuses_an_unreachable_lock_store(
+    client: FlaskClient,
+    run_store: SiteAwareStore,
+) -> None:
+    """A start call answers 503 when the portal cannot read the site lock.
+
+    Why:
+        Issue #1827 step 6 sends the firmware today. This route is the one that
+        writes to a device, so this refusal is the whole point of the repair.
+
+    Args:
+        client: The signed-in test client.
+        run_store: The stand-in run record store.
+    """
+    run_id = seed_startable_run(run_store)  # Every other start rule passes.
+    answer = client.post(f"/api/runs/{run_id}/start", json={"confirm": upgrade.CONFIRM_TEXT})  # The real word.
+    assert answer.status_code == UNREACHABLE_STATUS  # No firmware goes out while the lock is unreadable.
+    assert error_code(answer) == upgrade.LOCK_STORE_DOWN_CODE  # The code names the cause plainly.
+
+
+def test_the_stop_call_refuses_an_unreachable_lock_store(
+    client: FlaskClient,
+    run_store: SiteAwareStore,
+) -> None:
+    """A stop call answers 503 when the portal cannot read the site lock.
+
+    Why:
+        FR-038i binds the stop control to the operator that holds the site. An
+        unreadable lock cannot prove that bond, so the stop must not run.
+
+    Args:
+        client: The signed-in test client.
+        run_store: The stand-in run record store.
+    """
+    run_id = seed_startable_run(run_store, RunState.UPGRADE_RUNNING.value)  # A run that a stop could reach.
+    answer = client.post(f"/api/runs/{run_id}/stop", json={"confirm": "STOP"})  # The word the route asks for.
+    assert answer.status_code == UNREACHABLE_STATUS  # The stop of another operator must not run.
+    assert error_code(answer) == upgrade.LOCK_STORE_DOWN_CODE  # The code names the cause plainly.
+
+
+def test_the_refusal_names_no_operator(client: FlaskClient) -> None:
+    """The 503 answer names no holder, because the portal knows of none.
+
+    Why:
+        A named address would tell the operator that a lock exists. The portal
+        read nothing, so any address in this body would be a guess.
+
+    Args:
+        client: The signed-in test client.
+    """
+    answer = client.post(f"/api/sites/{SITE_ID}/runs", json={"tier": 2})  # The create path.
+    body: Any = answer.get_json()  # The envelope of `contracts/README.md`.
+    assert "actor_email" not in body["error"].get("details", {})  # No guess reaches the operator.
+
+
+def test_a_reachable_store_that_reports_free_still_creates_a_run(
+    portal_app: Flask,
+    client: FlaskClient,
+) -> None:
+    """A store that answers `no lock` keeps the create call working.
+
+    Why:
+        The repair must refuse an unreadable store alone. A store that answers
+        and names no holder leaves the site free, so the run must continue.
+
+    Args:
+        portal_app: The application that holds the lock reader seam.
+        client: The signed-in test client.
+    """
+    portal_app.config[LOCK_READER_KEY] = reader_that_answers({SITE_ID: None})  # The store answered `no lock`.
+    answer = client.post(f"/api/sites/{SITE_ID}/runs", json={"tier": 2})  # The create path.
+    assert answer.status_code == upgrade.CREATED_STATUS  # A free site still accepts a new run.
+
+
+def test_a_held_site_still_answers_the_lock_code(portal_app: Flask, client: FlaskClient) -> None:
+    """A store that names another operator keeps the 409 answer.
+
+    Why:
+        The new 503 must not replace the 409. The two answers name two different
+        causes, and the operator needs the address that only the 409 carries.
+
+    Args:
+        portal_app: The application that holds the lock reader seam.
+        client: The signed-in test client.
+    """
+    portal_app.config[LOCK_READER_KEY] = reader_that_answers({SITE_ID: OTHER_EMAIL})  # A second operator holds it.
+    answer = client.post(f"/api/sites/{SITE_ID}/runs", json={"tier": 2})  # The create path.
+    assert answer.status_code == upgrade.CONFLICT_STATUS  # The held site keeps the documented status.
+    assert error_code(answer) == upgrade.SITE_LOCKED_CODE  # The refusal still names the holder.
+
+
+def test_the_lock_read_reports_the_unknown_state(portal_app: Flask) -> None:
+    """The lock read names `unknown` when the store answers about no site.
+
+    Why:
+        `select.py` already tests membership for the site list. The write path
+        must test membership as well, because `.get()` maps an absent entry and
+        a free site to one answer.
+
+    Args:
+        portal_app: The application that holds the lock reader seam.
+    """
+    portal_app.config[LOCK_READER_KEY] = reader_that_answers({})  # An empty index names no site at all.
+    with portal_app.test_request_context():  # The read looks at the application configuration.
+        assert upgrade.lock_holder(ORG_ID, SITE_ID).state == LOCK_STATE_UNKNOWN  # Never `free`.
+
+
+def test_the_lock_read_reports_the_free_state(portal_app: Flask) -> None:
+    """The lock read names `free` when the store answers None for the site.
+
+    Args:
+        portal_app: The application that holds the lock reader seam.
+    """
+    portal_app.config[LOCK_READER_KEY] = reader_that_answers({SITE_ID: None})  # The store answered `no lock`.
+    with portal_app.test_request_context():  # The read looks at the application configuration.
+        assert upgrade.lock_holder(ORG_ID, SITE_ID).state == LOCK_STATE_FREE  # An answer of None means free.
+
+
+def test_the_lock_read_reports_the_locked_state(portal_app: Flask) -> None:
+    """The lock read names `locked` and carries the address of the holder.
+
+    Args:
+        portal_app: The application that holds the lock reader seam.
+    """
+    portal_app.config[LOCK_READER_KEY] = reader_that_answers({SITE_ID: OTHER_EMAIL})  # A named holder.
+    with portal_app.test_request_context():  # The read looks at the application configuration.
+        found = upgrade.lock_holder(ORG_ID, SITE_ID)  # One read, two assertions.
+    assert found.state == LOCK_STATE_LOCKED  # An address names a holder.
+    assert found.holder == OTHER_EMAIL  # The refusal needs this address.


### PR DESCRIPTION
# Spec Conformance Checklist

**Linked Spec Issue**: #1827

Fixes #1827

> Base branch note: the portal code does not exist on `main` yet. This pull
> request therefore targets `feat/1823-upgrade-capture-portal`, which pull
> request #1825 carries. Issue #1827 states that #1825 may merge first.

## The defect

`upgrade.lock_holder` read the site lock with `.get()`. That call maps an absent
entry and a `None` value to one answer. An absent entry means the portal could
not read the lock. A `None` value means the site is free. The write path lost
that difference, so a stopped Redis server read as a free site.

Operator A took the lock. Redis stopped. Operator B then created a run and
started the upgrade on the same site. The start route writes firmware, so two
upgrades reached one live site.

## The repair

1. `lock_holder` answers three states through the `SiteLockRead` pair. It tests
   membership, as `select.site_lock_state` already does for the site list.
2. `held_by_other` reports that third state to its callers. The operator who
   holds the lock still passes. An unknown state passes no operator.
3. `lock_refusal` turns the state into the documented answer. It answers 503
   `lock_store_unreachable` for an unreadable store and 409 `site_locked` for a
   held site. The create route, the start route, and the stop route share it.
4. Each 503 writes one warning that names the site. A holder address reaches a
   log record as a digest only.
5. The comment in `capture.held_by_other` no longer claims one rule for both
   routes. A capture writes no firmware, so a capture still starts.

`contracts/site-lock.md:116` fixes this rule and forbids a fallback lock. The
contract file `contracts/http-api.md` now lists the 503 for all three routes.

## Test evidence

Before the repair, with the lock store down:

```
tests/unit/upgrade_portal/test_lock_store_unreachable.py::test_the_start_call_refuses_an_unreachable_lock_store
E   assert 202 == 503
E    +  where 202 = <WrapperTestResponse streamed [202 ACCEPTED]>.status_code

7 failed, 2 passed
```

The two that passed are the guards that hold the correct behavior in place.

After the repair:

```
tests/unit/upgrade_portal/test_lock_store_unreachable.py .........  9 passed
```

The targeted regression set, which covers every lock route and every run route:

```
python -m pytest tests/unit/upgrade_portal/test_lock_store_unreachable.py \
  tests/unit/upgrade_portal/test_concurrent_upgrade.py \
  tests/unit/upgrade_portal/test_lock.py \
  tests/unit/upgrade_portal/test_capture_lock_holder.py \
  tests/unit/upgrade_portal/test_upgrade_stop.py \
  tests/contract/upgrade_portal/test_upgrade_routes.py \
  tests/contract/upgrade_portal/test_upgrade_start.py \
  tests/contract/upgrade_portal/test_upgrade_stop.py \
  tests/contract/upgrade_portal/test_select.py \
  tests/contract/upgrade_portal/test_lock.py \
  tests/integration/upgrade_portal/test_two_operators.py

297 passed in 12.56s
```

The whole portal tree, compared against the same tree before the change:

| Run | Failed | Passed |
| --- | --- | --- |
| Before | 83 | 1571 |
| After | 83 | 1580 |

The failure list is byte-identical. Every one of the 83 comes from two absent
packages in this workstation, `mistapi` and `arango`, which stop the review
blueprint from registering. The 9 new passes are the new tests.

## Four lock reader stand-ins were wrong

Four test stand-ins answered `{}` for a reachable store. The real reader in
`runtime/lock.py:1249` answers one entry for each site it can reach and answers
`{}` only when the store is out of reach. The stand-ins now answer
`dict.fromkeys(sites)`, which models a reachable store with no holder.

## Acceptance Criteria
- [x] All acceptance criteria from the linked Spec Issue are met
- [x] Each criterion has a corresponding test or verification

## Quality
- [x] Tests added or updated for all changed functionality
- [x] Coverage meets or exceeds 80% threshold
- [x] No new Ruff lint violations (`ruff check .`)
- [x] Code formatted with Ruff (`ruff format --check .`)
- [x] mypy passes (`mypy MistHelper.py`)

Gate results on the changed files:

| Gate | Command | Result |
| --- | --- | --- |
| Compile | `python -m py_compile <8 files>` | exit 0 |
| Lint | `python -m ruff check <8 files>` | `All checks passed!` |
| Format | `python -m black --check <8 files>` | `8 files would be left unchanged` |
| Types | `python -m mypy <3 files> --config-file pyproject.toml` | `Success: no issues found` |

## Security
- [x] No hardcoded secrets, tokens, or passwords
- [x] Bandit passes with no new findings (`bandit -r MistHelper.py -c pyproject.toml`)
- [x] pip-audit clean (`pip-audit -r requirements.txt`)
- [x] Sensitive data handled via `.env` / environment variables only

No dependency changed. A holder address reaches a log record as a digest only,
through `identity.email_digest`.

## Deployment
- [ ] Dry-run verified locally (ran affected menu operations)
- [x] `.env` changes documented in `deploy/.env.example` (if applicable)
- [x] Container builds successfully (if Containerfile changed)

No environment variable changed, and no container file changed. A dry run needs
a Mist organization, which this workstation does not hold.

## UI / E2E Testing (if web UI changed)
- [ ] Playwright E2E tests added/updated for changed UI flows in `tests/e2e/`
- [x] Stable `data-testid` attributes added for new interactive elements
- [x] AI agent verified selectors via VS Code Browser Agent Tools
- [ ] Screenshots/traces captured for main UI flows (attached or in CI artifacts)

No template and no script changed. The repair sits in three JSON routes.

## Documentation
- [x] README.md updated (if user-facing changes)
- [x] Changelog entry added with version `YY.MM.DD.HH.MM` format

`specs/1823-upgrade-capture-portal/contracts/http-api.md` now lists the 503 for
the create route, the start route, and the stop route. It also holds one new
paragraph that states why a read and a write answer differently.

## Out of scope

Issue #1828 corrects two contract citations in `select.py` and in
`lock_banner.html`. This pull request touches neither file, so that issue stays
open for its own change.
