### PR TITLE
security(ops-platform): check organization membership on every org_id route (#1879)

### DIFF
--- a/mist-ops-platform/src/api/deps.py
+++ b/mist-ops-platform/src/api/deps.py
@@ -1,18 +1,26 @@
 """FastAPI dependency injection providers (T024).
 
-Provides ``get_db_session``, ``get_current_user``, and ``get_mist_session``
-for use in route function signatures.
+Provides ``get_db_session``, ``get_current_user``, ``get_scoped_org_id``, and
+``get_mist_session`` for use in route function signatures.
 """
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator
+from uuid import UUID
 
-from fastapi import Depends, Request
+from fastapi import Depends, HTTPException, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.api.middleware.auth import CurrentUser, get_current_user
+from src.api.middleware.auth import (
+    CurrentUser,
+    get_current_user,
+    require_org_access,
+)
 from sqlalchemy.ext.asyncio import async_sessionmaker
+
+logger = logging.getLogger(__name__)
 
 
 async def get_db_session(request: Request) -> AsyncIterator[AsyncSession]:
@@ -37,3 +45,29 @@ async def get_authenticated_user(
 ) -> CurrentUser:
     """Alias dependency — returns the validated current user."""
     return user
+
+
+async def get_scoped_org_id(
+    org_id: UUID = Query(...),
+    user: CurrentUser = Depends(get_authenticated_user),
+) -> UUID:
+    """Return the requested ``org_id`` only after the membership check passes.
+
+    Every route that accepts an ``org_id`` query parameter must read the value
+    through this dependency. The dependency authenticates the caller and then
+    confirms the caller belongs to the requested organization. A route that
+    reads ``org_id`` directly from ``Query`` exposes the data of every other
+    organization, so no route may do that.
+    """
+    logger.debug("Checking organization membership for %s", org_id)  # Record the check before it runs
+    try:
+        require_org_access(str(org_id), user)  # Raise 403 when the caller is outside the organization
+    except HTTPException:
+        logger.warning(  # Record the denial, because a denial is a security event
+            "Denied cross-organization access to %s for %s",
+            org_id,
+            user.email or "unknown caller",
+        )
+        raise  # Preserve the 403 status and the original detail text
+    logger.debug("Granted access to organization %s", org_id)  # Record the allow decision
+    return org_id  # Hand the checked value to the route

--- a/mist-ops-platform/src/api/routes/audit.py
+++ b/mist-ops-platform/src/api/routes/audit.py
@@ -19,7 +19,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.api.deps import get_authenticated_user, get_db_session
+from src.api.deps import (
+    get_authenticated_user,
+    get_db_session,
+    get_scoped_org_id,
+)
 from src.api.middleware.auth import CurrentUser
 from src.api.schemas.audit import (
     AuditRecordResponse,
@@ -46,7 +50,7 @@ router = APIRouter(prefix="/audit", tags=["audit"])
 
 @router.get("/records")
 async def list_audit_records(
-    org_id: UUID = Query(...),
+    org_id: UUID = Depends(get_scoped_org_id),
     entity_type: str | None = Query(None),
     entity_id: UUID | None = Query(None),
     actor: str | None = Query(None),
@@ -81,7 +85,7 @@ async def list_audit_records(
 @router.get("/records/{record_id}")
 async def get_audit_record(
     record_id: int,
-    org_id: UUID = Query(...),
+    org_id: UUID = Depends(get_scoped_org_id),
     db: AsyncSession = Depends(get_db_session),
     _user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[AuditRecordResponse]:
@@ -135,7 +139,7 @@ async def export_records(
 
 @router.get("/correlations")
 async def list_correlations(
-    org_id: UUID = Query(...),
+    org_id: UUID = Depends(get_scoped_org_id),
     incident_type: str | None = Query(None),
     min_confidence: float = Query(0.0, ge=0.0, le=1.0),
     page: int = Query(1, ge=1),

--- a/mist-ops-platform/src/api/routes/config.py
+++ b/mist-ops-platform/src/api/routes/config.py
@@ -18,7 +18,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.api.deps import get_authenticated_user, get_db_session
+from src.api.deps import (
+    get_authenticated_user,
+    get_db_session,
+    get_scoped_org_id,
+)
 from src.api.middleware.auth import CurrentUser
 from src.api.schemas.common import PaginationMeta, ResponseEnvelope
 from src.api.schemas.config import (
@@ -54,7 +58,7 @@ router = APIRouter(prefix="/config", tags=["config"])
 
 @router.get("/revisions", summary="List config revisions")
 async def list_revisions(
-    org_id: UUID = Query(...),
+    org_id: UUID = Depends(get_scoped_org_id),
     entity_id: UUID = Query(...),
     entity_type: str | None = Query(None),
     page: int = Query(1, ge=1),
@@ -96,7 +100,7 @@ async def list_revisions(
 @router.get("/revisions/{revision_id}", summary="Get revision detail")
 async def get_revision(
     revision_id: int,
-    org_id: UUID = Query(...),
+    org_id: UUID = Depends(get_scoped_org_id),
     db: AsyncSession = Depends(get_db_session),
 ) -> ResponseEnvelope[RevisionDetailResponse]:
     """Return a full config revision including its JSON payload."""
@@ -122,7 +126,7 @@ async def get_revision(
 
 @router.get("/time-travel", summary="Point-in-time config lookup")
 async def time_travel(
-    org_id: UUID = Query(...),
+    org_id: UUID = Depends(get_scoped_org_id),
     entity_id: UUID = Query(...),
     entity_type: str = Query(...),
     timestamp: datetime = Query(...),
@@ -367,7 +371,7 @@ async def _find_status_at(
 
 @router.get("/baselines")
 async def list_baselines(
-    org_id: UUID = Query(...),
+    org_id: UUID = Depends(get_scoped_org_id),
     entity_type: str | None = Query(None),
     page: int = Query(1, ge=1),
     per_page: int = Query(50, ge=1, le=200),

--- a/mist-ops-platform/src/api/routes/deploy.py
+++ b/mist-ops-platform/src/api/routes/deploy.py
@@ -20,7 +20,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.api.deps import get_authenticated_user, get_db_session
+from src.api.deps import (
+    get_authenticated_user,
+    get_db_session,
+    get_scoped_org_id,
+)
 from src.api.middleware.auth import CurrentUser
 from src.api.schemas.common import ResponseEnvelope
 from src.shared.config.settings import get_settings
@@ -87,7 +91,7 @@ def _target_count(job: ScheduledJob) -> int:
 
 @router.get("/jobs")
 async def list_jobs(
-    org_id: UUID = Query(...),
+    org_id: UUID = Depends(get_scoped_org_id),
     status: str | None = Query(None),
     page: int = Query(1, ge=1),
     per_page: int = Query(50, ge=1, le=200),
@@ -366,7 +370,7 @@ def _to_summary(job: ScheduledJob) -> JobSummary:
 
 @router.get("/rollouts")
 async def list_rollouts(
-    org_id: UUID = Query(...),
+    org_id: UUID = Depends(get_scoped_org_id),
     status: str | None = Query(None),
     page: int = Query(1, ge=1),
     per_page: int = Query(50, ge=1, le=200),
@@ -530,7 +534,7 @@ async def rollback_wave(
 
 @router.get("/golden-images")
 async def list_golden_images(
-    org_id: UUID = Query(...),
+    org_id: UUID = Depends(get_scoped_org_id),
     image_type: str | None = Query(None),
     device_model: str | None = Query(None),
     lifecycle_state: str | None = Query(None),
@@ -675,7 +679,7 @@ def _plan_to_summary(
 
 @router.get("/templates")
 async def list_templates(
-    org_id: UUID = Query(...),
+    org_id: UUID = Depends(get_scoped_org_id),
     category: str | None = Query(None),
     page: int = Query(1, ge=1),
     per_page: int = Query(50, ge=1, le=200),

--- a/mist-ops-platform/src/api/routes/health.py
+++ b/mist-ops-platform/src/api/routes/health.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.api.deps import get_db_session
+from src.api.deps import get_db_session, get_scoped_org_id
 from src.api.schemas.common import ResponseEnvelope
 from src.shared.models.operations import NotificationChannel
 
@@ -81,7 +81,7 @@ class ChannelResponse(BaseModel):
 
 @router.get("/notifications/channels")
 async def list_channels(
-    org_id: UUID = Query(...),
+    org_id: UUID = Depends(get_scoped_org_id),
     db: AsyncSession = Depends(get_db_session),
 ) -> ResponseEnvelope[list[ChannelResponse]]:
     """List notification channels for an org."""

--- a/mist-ops-platform/src/api/routes/sync.py
+++ b/mist-ops-platform/src/api/routes/sync.py
@@ -24,7 +24,12 @@ from uuid import UUID  # Used in route signatures and DB filters
 from fastapi import APIRouter, Depends, HTTPException, Query  # FastAPI route plumbing
 from sqlalchemy import select  # Build typed SQLAlchemy SELECTs
 
-from src.api.deps import get_authenticated_user, get_db_session  # DI for auth + DB session
+from src.api.deps import (  # DI for auth, DB session, and the org scope check
+    get_authenticated_user,
+    get_db_session,
+    get_scoped_org_id,
+)
+from src.api.middleware.auth import require_org_access  # Org membership check
 from src.api.schemas.common import ResponseEnvelope  # Uniform response wrapper
 from src.api.schemas.sync import (  # Public response/request models
     DeviceResponse,
@@ -61,8 +66,13 @@ def _resolve_org_ids(
     explicit: UUID | None,
     user: CurrentUser,
 ) -> list[UUID]:
-    """Return org_ids to query — explicit param or user's orgs."""
+    """Return org_ids to query — explicit param or user's orgs.
+
+    An explicit organization must pass the membership check. Without the
+    check, any caller reads the data of any organization.
+    """
     if explicit:  # Caller supplied a specific org filter
+        require_org_access(str(explicit), user)  # Raise 403 when the caller is outside that org
         return [explicit]
     return [UUID(oid) for oid in user.org_ids] if user.org_ids else []  # User's accessible orgs
 
@@ -193,7 +203,7 @@ def _orgs_query_for_user(user: CurrentUser):
 
 @inv_router.get("/sites")
 async def list_sites(
-    org_id: UUID = Query(...),
+    org_id: UUID = Depends(get_scoped_org_id),
     db: AsyncSession = Depends(get_db_session),
 ) -> ResponseEnvelope[list[SiteResponse]]:
     """List sites for an organization."""
@@ -249,9 +259,12 @@ async def list_devices(
     site_id: UUID | None = Query(None),
     search: str | None = Query(None),
     db: AsyncSession = Depends(get_db_session),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[list[DeviceResponse]]:
     """List devices (filtered by org, site, and/or name/MAC search)."""
+    org_ids = _resolve_org_ids(org_id, user)  # Check membership and compute the org scope
     stmt = _device_search_query(org_id, site_id, search)  # Build SELECT with filters
+    stmt = stmt.where(Device.org_id.in_(org_ids))  # Never return a device outside the caller scope
     rows = (await db.execute(stmt)).scalars().all()  # Materialize device rows
     items = [_device_to_response(d) for d in rows]  # Project rows to response shape
     return ResponseEnvelope(data=items)
@@ -294,8 +307,11 @@ def _drift_alert_filters(
     status: str | None = Query(None),
     page: int = Query(1, ge=1),
     per_page: int = Query(50, ge=1, le=200),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> DriftAlertFilters:
     """FastAPI dependency that groups drift-alert filter query params into one object."""
+    if org_id is not None:  # Only an explicit organization needs the membership check
+        require_org_access(str(org_id), user)  # Raise 403 when the caller is outside that org
     return DriftAlertFilters(
         org_id=org_id,
         acknowledged=acknowledged,
@@ -383,7 +399,7 @@ class PolicyListFilters:
 
 
 def _policy_list_filters(
-    org_id: UUID = Query(...),
+    org_id: UUID = Depends(get_scoped_org_id),
     lifecycle_state: str | None = Query(None),
     page: int = Query(1, ge=1),
     per_page: int = Query(50, ge=1, le=200),

--- a/mist-ops-platform/tests/unit/api/test_org_scope_dependency.py
+++ b/mist-ops-platform/tests/unit/api/test_org_scope_dependency.py
@@ -1,0 +1,172 @@
+"""Tests for the organization scope dependency (issue #1879).
+
+The platform is multi-tenant. Every route that accepts an ``org_id`` query
+parameter must confirm that the caller belongs to that organization. Without
+the check, any caller with a valid token reads the data of any organization.
+
+This module holds two kinds of test. The first kind drives the dependency
+through a live request and asserts the status code. The second kind reads the
+route source and asserts that no route takes ``org_id`` straight from
+``Query``. The source test needs no web framework, so it runs in every
+environment.
+"""
+
+from __future__ import annotations
+
+import ast  # Parse the route modules without an import, so the test needs no dependency
+import pathlib  # Locate the route modules on disk
+import sys  # Extend the import path so "src" resolves during a direct run
+
+import pytest  # Test framework and skip helper
+
+ROUTES_DIR = (  # Directory that holds every API route module
+    pathlib.Path(__file__).resolve().parents[3] / "src" / "api" / "routes"
+)
+PLATFORM_ROOT = pathlib.Path(__file__).resolve().parents[3]  # Sub-project root
+
+if str(PLATFORM_ROOT) not in sys.path:  # Only extend the path once
+    sys.path.insert(0, str(PLATFORM_ROOT))  # Make "src.api" importable
+
+ORG_IN_SCOPE = "11111111-1111-1111-1111-111111111111"  # Organization the caller owns
+ORG_OUT_OF_SCOPE = "22222222-2222-2222-2222-222222222222"  # Organization the caller must not read
+
+
+# -- Static guard -------------------------------------------------------
+
+
+def _bare_query_org_params(path: pathlib.Path) -> list[str]:
+    """Return the name of every function that reads ``org_id`` from ``Query``."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))  # Parse the module source
+    offenders: list[str] = []  # Collect the offending function names
+    for node in ast.walk(tree):  # Visit every node, so nested routes count too
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue  # Only a function can declare a route parameter
+        if _reads_org_id_from_query(node):  # Check this function's defaults
+            offenders.append(node.name)  # Record the function for the failure message
+    return offenders
+
+
+def _reads_org_id_from_query(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Return True when ``org_id`` takes its default from a ``Query`` call.
+
+    A function that calls ``_resolve_org_ids`` or ``require_org_access`` runs
+    the membership check itself, so that shape passes.
+    """
+    if _calls_a_scope_check(node):  # The function checks the membership by hand
+        return False
+    args = node.args  # Positional and keyword arguments of the function
+    named = args.args + args.kwonlyargs  # Every argument that can carry a default
+    defaults = ([None] * (len(args.args) - len(args.defaults))) + list(args.defaults)
+    defaults += list(args.kw_defaults)  # Align the defaults with the argument names
+    for arg, default in zip(named, defaults):  # Walk the aligned pairs
+        if arg.arg != "org_id" or default is None:  # Only the org_id argument matters
+            continue
+        if isinstance(default, ast.Call) and getattr(default.func, "id", "") == "Query":
+            return True  # A bare Query default skips the membership check
+    return False
+
+
+def _calls_a_scope_check(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Return True when the function body calls a known scope check helper."""
+    checks = {"_resolve_org_ids", "require_org_access"}  # Helpers that raise 403 on a bad scope
+    for child in ast.walk(node):  # Visit every node in the function body
+        if isinstance(child, ast.Call) and getattr(child.func, "id", "") in checks:
+            return True  # The function performs its own membership check
+    return False
+
+
+def test_no_route_reads_org_id_from_query() -> None:
+    """Assert that every route reads ``org_id`` through the scope dependency.
+
+    A route that keeps ``org_id: UUID = Query(...)`` exposes the data of every
+    other organization. This test fails the build when a new route reintroduces
+    that shape.
+    """
+    offenders: dict[str, list[str]] = {}  # Map a module name to its offending functions
+    for module in sorted(ROUTES_DIR.glob("*.py")):  # Read every route module
+        found = _bare_query_org_params(module)  # Collect the offenders in this module
+        if found:  # Only record a module that holds an offender
+            offenders[module.name] = found
+    assert offenders == {}, (  # Report every offender at once, so one run shows all the work
+        "These routes read org_id straight from Query and skip the membership "
+        f"check. Use Depends(get_scoped_org_id) instead: {offenders}"
+    )
+
+
+# -- Live request behavior ----------------------------------------------
+
+
+def _build_probe_app(org_ids: list[str], *, is_msp: bool = False):
+    """Return a small app whose single route uses the scope dependency."""
+    fastapi = pytest.importorskip("fastapi")  # Skip when the web framework is absent
+    pytest.importorskip("httpx")  # The test client needs httpx
+    from uuid import UUID  # Match the type the real routes declare
+
+    from src.api.deps import get_authenticated_user, get_scoped_org_id
+    from src.api.middleware.auth import CurrentUser
+
+    app = fastapi.FastAPI()  # Minimal app, so the test needs no database
+
+    @app.get("/probe")  # One route is enough to exercise the dependency
+    async def probe(org_id: UUID = fastapi.Depends(get_scoped_org_id)) -> dict:
+        """Return the organization the dependency approved."""
+        return {"org_id": str(org_id)}  # Echo the value, so a pass is visible
+
+    async def fake_user() -> CurrentUser:
+        """Return a caller whose scope the test controls."""
+        return CurrentUser(token="test-token", email="tester@example.com", org_ids=org_ids, is_msp=is_msp)
+
+    app.dependency_overrides[get_authenticated_user] = fake_user  # Skip the live Mist lookup
+    return app
+
+
+def _get(app, org_id: str):
+    """Send one probe request and return the response."""
+    from fastapi.testclient import TestClient  # Imported late, so the skip above applies
+
+    with TestClient(app) as client:  # Context manager runs the app lifespan
+        return client.get("/probe", params={"org_id": org_id})
+
+
+def test_caller_reads_its_own_organization() -> None:
+    """A caller inside the organization gets the data."""
+    app = _build_probe_app([ORG_IN_SCOPE])  # Caller owns one organization
+    response = _get(app, ORG_IN_SCOPE)  # Request that same organization
+    assert response.status_code == 200  # The membership check passes
+    assert response.json()["org_id"] == ORG_IN_SCOPE  # The dependency returns the value
+
+
+def test_caller_cannot_read_another_organization() -> None:
+    """A caller outside the organization gets 403, not the data."""
+    app = _build_probe_app([ORG_IN_SCOPE])  # Caller owns one organization
+    response = _get(app, ORG_OUT_OF_SCOPE)  # Request a different organization
+    assert response.status_code == 403  # The membership check refuses the request
+    assert "Insufficient privileges" in response.text  # The refusal names the cause
+
+
+def test_msp_caller_reads_any_organization() -> None:
+    """An MSP caller keeps cross-organization access."""
+    app = _build_probe_app([], is_msp=True)  # MSP caller holds no explicit org list
+    response = _get(app, ORG_OUT_OF_SCOPE)  # Request any organization
+    assert response.status_code == 200  # The MSP branch allows the request
+
+
+def test_caller_without_a_token_is_refused() -> None:
+    """An unauthenticated caller never reaches the data."""
+    fastapi = pytest.importorskip("fastapi")  # Skip when the web framework is absent
+    pytest.importorskip("httpx")  # The test client needs httpx
+    from uuid import UUID  # Match the type the real routes declare
+
+    from fastapi.testclient import TestClient
+    from src.api.deps import get_scoped_org_id
+
+    app = fastapi.FastAPI()  # No dependency override, so the real auth path runs
+
+    @app.get("/probe")  # One route is enough to exercise the dependency
+    async def probe(org_id: UUID = fastapi.Depends(get_scoped_org_id)) -> dict:
+        """Return the organization the dependency approved."""
+        return {"org_id": str(org_id)}  # Never reached without a token
+
+    with TestClient(app) as client:  # Context manager runs the app lifespan
+        response = client.get("/probe", params={"org_id": ORG_IN_SCOPE})
+    assert response.status_code == 401  # The dependency refuses a missing token

--- a/mist-ops-platform/tests/unit/api/test_org_scope_dependency.py
+++ b/mist-ops-platform/tests/unit/api/test_org_scope_dependency.py
@@ -100,6 +100,7 @@ def _build_probe_app(org_ids: list[str], *, is_msp: bool = False):
     """Return a small app whose single route uses the scope dependency."""
     fastapi = pytest.importorskip("fastapi")  # Skip when the web framework is absent
     pytest.importorskip("httpx")  # The test client needs httpx
+    pytest.importorskip("sqlalchemy")  # deps.py imports sqlalchemy at module load
     from uuid import UUID  # Match the type the real routes declare
 
     from src.api.deps import get_authenticated_user, get_scoped_org_id
@@ -155,6 +156,7 @@ def test_caller_without_a_token_is_refused() -> None:
     """An unauthenticated caller never reaches the data."""
     fastapi = pytest.importorskip("fastapi")  # Skip when the web framework is absent
     pytest.importorskip("httpx")  # The test client needs httpx
+    pytest.importorskip("sqlalchemy")  # deps.py imports sqlalchemy at module load
     from uuid import UUID  # Match the type the real routes declare
 
     from fastapi.testclient import TestClient


### PR DESCRIPTION
Fixes #1879

## Problem

`require_org_access` had no caller. Every route that accepted an `org_id`
query parameter queried the database with the caller-supplied value and never
compared it against `CurrentUser.org_ids`.

The audit found the defect is worse than the issue reported. The app factory
sets no router-level or app-level auth dependency. Several routes that accept
`org_id` also declared **no user dependency at all**, so those routes were
unauthenticated as well as unscoped.

`sync.list_devices` is the worst case. It took no user dependency, and an
omitted `org_id` returned every device row of every organization to an
anonymous caller.

## Impact

Any caller with a valid Mist API token read the audit trail, the configuration
revisions, the baselines, and the scheduled deploy jobs of any other
organization. On `list_devices`, a caller needed no token at all.

## Fix

1. Add `get_scoped_org_id` to `src/api/deps.py`. The dependency
   authenticates the caller, calls `require_org_access`, logs a denial at
   warning level, and returns the value only after the check passes.
2. Route all 14 required `org_id` parameters through the dependency, across
   audit.py (3), config.py (4), deploy.py (4), sync.py (2), and health.py (1).
3. Check the explicit organization inside `_resolve_org_ids`.
4. Add the authenticated user and an org scope filter to `list_devices`.
5. Check an explicit organization in `_drift_alert_filters`.

The dependency approach removes the chance that a new route forgets the check.

## Tests

`mist-ops-platform/tests/unit/api/test_org_scope_dependency.py`

- `test_no_route_reads_org_id_from_query` parses every route module with
  `ast` and fails when a route reads `org_id` from `Query` without a
  membership check. It needs no web framework. It found three offenders that
  the manual pass missed: `get_sync_status`, `list_devices`, and
  `_drift_alert_filters`.
- `test_caller_reads_its_own_organization` asserts 200 for an in-scope org.
- `test_caller_cannot_read_another_organization` asserts 403.
- `test_msp_caller_reads_any_organization` asserts the MSP branch works.
- `test_caller_without_a_token_is_refused` asserts 401 without a token.

## Validation performed

| Check | Result |
| - | - |
| py_compile on all 6 changed modules | Pass |
| pytest test_org_scope_dependency.py | 1 passed, 4 skipped |

Caution: the 4 skips are the live-request tests. This worktree has no .venv and
fastapi is not importable here, which is the condition issue #1866 describes.
The tests use pytest.importorskip, so they run in CI. The static guard test ran
and passed.

## Compatibility

Routes that were unauthenticated now return 401 without a token and 403 for an
organization outside the caller scope. That is the intended change.

## Review note

This change touches the auth path. It needs human review. I did not add the
auto-merge label.

`mist-ops-platform/src/api/middleware/auth.py` is owned by PR #1871 right now,
so this PR does not modify that file. The new dependency lives in deps.py.
