### PR TITLE
fix(db): scan the Redis keyspace in batches instead of blocking it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,31 @@ Version 26.08.23.01.26
   `WEB_HOST` override in both states, the fallback for an empty `WEB_HOST` value,
   and that the join expression is gone from the script.
 
+### Scan the Redis keyspace in batches instead of blocking it (issue #1882)
+
+- **Defect (Fixed)**: `RetentionManager.check_redis_retention` ran the Redis
+  `KEYS` command with the pattern `*.avg_1h`. The pattern starts with a
+  wildcard, so Redis compared every key in the keyspace. Redis serves commands
+  on one thread, so the whole server stalled for the length of each scan. The
+  background sweep thread repeated the stall every 6 hours by default.
+- **`SCAN` loop (Added)**: the check now drives a cursor loop. Each round trip
+  sends `SCAN <cursor> MATCH *.avg_1h COUNT 500`. Redis returns one bounded
+  batch and then serves other clients, so no single command holds the thread.
+- **Memory (Changed)**: the loop adds the length of each batch to a running
+  total and drops the batch. The process never holds the whole key set. The old
+  code returned a list of every matching key only to read its length.
+- **Upper bound (Added)**: `REDIS_SCAN_MAX_KEYS` stops the loop after 100000
+  scanned keys. The sweep then logs the new `redis_retention_scan_capped`
+  warning with the partial count and returns it. The cost of one sweep stays
+  fixed as the keyspace grows.
+- **Contract (Unchanged)**: the method still returns an `int` key count. It
+  still logs a warning and returns 0 when the Redis call raises.
+- **Tests (Added)**: `tests/unit/db/test_retention_redis_scan.py` holds 10
+  cases. A fake client records every command it receives. The cases prove the
+  code issues `SCAN`, never issues `KEYS`, sends `MATCH` and a bounded `COUNT`,
+  follows the cursor until it returns to 0, accepts a cursor that arrives as
+  bytes, and stops at the upper bound against an endless keyspace.
+
 ### Add a real readiness probe and keep the health endpoint cheap (issue #1863)
 
 - **Defect (Fixed)**: the `/health` endpoint returned the fixed text `healthy` on

--- a/src/db/retention.py
+++ b/src/db/retention.py
@@ -23,6 +23,9 @@ BYTES_PER_GB = 1024**3  # WHY: convert dataSize (bytes) into GB units
 SECONDS_PER_HOUR = 3600  # WHY: hour -> seconds for sweep sleep interval
 STOP_JOIN_TIMEOUT_SEC = 5  # WHY: bounded join so shutdown never hangs
 REDIS_COMPACTION_PATTERN = "*.avg_1h"  # WHY: match compacted 1h-avg TS keys
+REDIS_SCAN_BATCH = 500  # WHY: COUNT per batch. Redis yields between batches
+REDIS_SCAN_MAX_KEYS = 100000  # WHY: cap the sweep cost as the keyspace grows
+REDIS_SCAN_START_CURSOR = 0  # WHY: the SCAN contract starts and ends at 0
 SWEEP_THREAD_NAME = "retention-sweep"  # WHY: identifiable name in ps/threads
 ENV_MAX_STORAGE_GB = "ARANGO_MAX_STORAGE_GB"  # WHY: override for ceiling GB
 ENV_CHECK_INTERVAL_HOURS = "RETENTION_CHECK_INTERVAL_HOURS"  # WHY: sweep hrs
@@ -32,7 +35,9 @@ EVT_STORAGE_FAIL = "storage_check_failed"  # WHY: log key: stats call failed
 EVT_SNAPSHOTS_PURGED = "arango_snapshots_purged"  # WHY: log key: purge done
 EVT_PURGE_FAIL = "purge_failed"  # WHY: log key: AQL REMOVE raised
 EVT_REDIS_CHECKED = "redis_retention_checked"  # WHY: log key: TS scan done
-EVT_REDIS_FAIL = "redis_check_failed"  # WHY: log key: KEYS command raised
+EVT_REDIS_FAIL = "redis_check_failed"  # WHY: log key: SCAN command raised
+EVT_REDIS_SCAN_START = "redis_retention_scan_started"  # WHY: log key: pre-scan
+EVT_REDIS_SCAN_CAPPED = "redis_retention_scan_capped"  # WHY: log key: cap hit
 EVT_SWEEP_STARTED = "retention_sweep_started"  # WHY: log key: thread spawned
 EVT_SWEEP_STOPPED = "retention_sweep_stopped"  # WHY: log key: thread joined
 EVT_SWEEP_ERROR = "retention_sweep_error"  # WHY: log key: sweep raised
@@ -123,13 +128,20 @@ class RetentionManager:  # WHY: single owner of ArangoDB+Redis retention
         client = getattr(self._redis, "_client", None)  # WHY: writer duck-type
         if client is None:  # WHY: no client -> zero keys checked
             return 0  # WHY: zero signals "nothing to validate"
+        logger.info(
+            EVT_REDIS_SCAN_START,
+            pattern=REDIS_COMPACTION_PATTERN,
+            max_keys=REDIS_SCAN_MAX_KEYS,
+        )  # WHY: record the scan bounds before the first round trip
         try:
-            keys = client.execute_command("KEYS", REDIS_COMPACTION_PATTERN)  # WHY: list compacted 1h-avg TS keys
-            logger.info(EVT_REDIS_CHECKED, keys=len(keys))
-            return len(keys)  # WHY: callers want count, not the key list
-        except Exception as error:  # WHY: KEYS may error on unreachable redis
+            count, capped = _scan_key_count(client)  # WHY: helper keeps LoC low
+        except Exception as error:  # WHY: SCAN may error on unreachable redis
             logger.warning(EVT_REDIS_FAIL, error=str(error))
             return 0
+        if capped:  # WHY: a partial count must never look like a full count
+            logger.warning(EVT_REDIS_SCAN_CAPPED, keys=count)
+        logger.info(EVT_REDIS_CHECKED, keys=count, capped=capped)
+        return count  # WHY: callers want count, not the key list
 
     def start_periodic(self) -> None:
         """Start background retention sweep thread."""
@@ -165,6 +177,37 @@ class RetentionManager:  # WHY: single owner of ArangoDB+Redis retention
             except Exception as error:  # WHY: swallow so loop stays alive
                 logger.error(EVT_SWEEP_ERROR, error=str(error))
             self._stop_event.wait(interval)  # WHY: interruptible sleep
+
+
+def _normalize_cursor(cursor: Any) -> int:
+    """Convert a SCAN cursor reply into an int."""
+    if isinstance(cursor, (bytes, bytearray)):  # WHY: raw replies arrive as bytes
+        return int(cursor.decode("ascii"))  # WHY: a cursor is an ASCII digit run
+    return int(cursor)  # WHY: an int cursor or a str cursor converts directly
+
+
+def _scan_key_count(client: Any) -> tuple[int, bool]:
+    """Count matching Redis keys with a bounded SCAN loop.
+
+    Returns the key count and a flag that reports the upper bound was hit.
+    """
+    cursor = REDIS_SCAN_START_CURSOR  # WHY: the SCAN contract starts at 0
+    total = 0  # WHY: sum the batch sizes so no full key list is ever held
+    while True:  # WHY: SCAN needs repeat calls until the cursor returns to 0
+        cursor, batch = client.execute_command(
+            "SCAN",
+            cursor,
+            "MATCH",
+            REDIS_COMPACTION_PATTERN,
+            "COUNT",
+            REDIS_SCAN_BATCH,
+        )  # WHY: one bounded batch lets Redis serve other clients in between
+        total += len(batch)  # WHY: keep the count only. The batch is dropped
+        cursor = _normalize_cursor(cursor)  # WHY: bytes cursors must compare
+        if total >= REDIS_SCAN_MAX_KEYS:  # WHY: cap the cost of one sweep
+            return total, True  # WHY: report a partial count to the caller
+        if cursor == REDIS_SCAN_START_CURSOR:  # WHY: cursor 0 ends the scan
+            return total, False  # WHY: the full pass finished under the cap
 
 
 def _execute_purge(database: Any) -> int:

--- a/tests/unit/db/test_retention_redis_scan.py
+++ b/tests/unit/db/test_retention_redis_scan.py
@@ -1,0 +1,157 @@
+"""Unit tests for the bounded Redis SCAN loop in RetentionManager.
+
+The retention sweep must never run the Redis KEYS command. KEYS blocks the
+single Redis thread across the whole keyspace. These tests prove the sweep
+uses a cursor-driven SCAN loop and stops at a fixed upper bound.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.db import retention
+from src.db.retention import RetentionManager
+
+
+class FakeRedisClient:
+    """Record every command and reply with scripted SCAN batches."""
+
+    def __init__(self, replies: list[tuple[int, list[str]]]) -> None:
+        """Store the scripted replies and start an empty command log."""
+        self.commands: list[tuple[Any, ...]] = []  # WHY: assert on real traffic
+        self._replies = list(replies)  # WHY: copy so the test list stays intact
+
+    def execute_command(self, *args: Any) -> tuple[int, list[str]]:
+        """Log the command and pop the next scripted reply."""
+        self.commands.append(args)  # WHY: the tests assert the command names
+        if not self._replies:  # WHY: an unscripted call must end the loop
+            return 0, []  # WHY: cursor 0 tells the caller the scan finished
+        return self._replies.pop(0)  # WHY: replies run in the scripted order
+
+    @property
+    def command_names(self) -> list[str]:
+        """Return the first word of each recorded command."""
+        return [str(command[0]) for command in self.commands]  # WHY: name only
+
+
+class EndlessRedisClient:
+    """Reply with a full batch forever so the upper bound is the only exit."""
+
+    def __init__(self, batch_size: int) -> None:
+        """Store the batch size and start the call counter at zero."""
+        self.batch_size = batch_size  # WHY: each reply holds this many keys
+        self.calls = 0  # WHY: prove the bound stops the loop after few calls
+
+    def execute_command(self, *args: Any) -> tuple[int, list[str]]:
+        """Return a full batch and a non-zero cursor on every call."""
+        self.calls += 1  # WHY: count the round trips the sweep costs
+        keys = [f"device.{index}.avg_1h" for index in range(self.batch_size)]
+        return 1, keys  # WHY: cursor 1 means "more keys remain" to the caller
+
+
+def _manager(client: Any) -> RetentionManager:
+    """Build a RetentionManager whose Redis writer holds the given client."""
+    redis_writer = MagicMock()  # WHY: the writer is duck-typed in production
+    redis_writer._client = client  # WHY: the manager reads this attribute
+    return RetentionManager(  # WHY: ArangoDB is not used by these tests
+        arango_writer=MagicMock(),
+        redis_writer=redis_writer,
+    )
+
+
+class TestRedisScanReplacesKeys:
+    """Verify the sweep issues SCAN and never issues KEYS."""
+
+    def test_scan_is_used_and_keys_is_never_issued(self) -> None:
+        """The first command must be SCAN and KEYS must never appear."""
+        client = FakeRedisClient([(0, ["a.avg_1h", "b.avg_1h"])])
+        result = _manager(client).check_redis_retention()
+        assert result == 2  # WHY: the count must match the scripted batch
+        assert "KEYS" not in client.command_names  # WHY: KEYS stalls Redis
+        assert client.command_names == ["SCAN"]  # WHY: SCAN is the only command
+
+    def test_scan_passes_match_and_a_bounded_count(self) -> None:
+        """SCAN must carry MATCH with the pattern and a bounded COUNT."""
+        client = FakeRedisClient([(0, [])])
+        _manager(client).check_redis_retention()
+        command = client.commands[0]  # WHY: only one round trip is scripted
+        assert command[1] == 0  # WHY: the SCAN contract starts at cursor 0
+        assert "MATCH" in command  # WHY: the filter must stay server-side
+        assert retention.REDIS_COMPACTION_PATTERN in command  # WHY: same pattern
+        assert "COUNT" in command  # WHY: COUNT bounds the work per batch
+        assert command[-1] == retention.REDIS_SCAN_BATCH  # WHY: bounded batch
+
+    def test_scan_follows_the_cursor_until_it_returns_to_zero(self) -> None:
+        """The loop must sum every batch across all cursor round trips."""
+        client = FakeRedisClient(
+            [
+                (7, ["a.avg_1h", "b.avg_1h"]),
+                (9, ["c.avg_1h"]),
+                (0, ["d.avg_1h", "e.avg_1h", "f.avg_1h"]),
+            ]
+        )
+        result = _manager(client).check_redis_retention()
+        assert result == 6  # WHY: 2 + 1 + 3 keys across the three batches
+        assert client.command_names == ["SCAN", "SCAN", "SCAN"]  # WHY: 3 trips
+        assert client.commands[1][1] == 7  # WHY: cursor 7 feeds the next call
+        assert client.commands[2][1] == 9  # WHY: cursor 9 feeds the last call
+
+    def test_a_bytes_cursor_still_advances_the_loop(self) -> None:
+        """A raw protocol reply returns bytes, and the loop must accept it."""
+        client = FakeRedisClient([(b"4", ["a.avg_1h"]), (b"0", ["b.avg_1h"])])  # type: ignore[list-item]
+        result = _manager(client).check_redis_retention()
+        assert result == 2  # WHY: both batches count toward the total
+        assert client.commands[1][1] == 4  # WHY: the bytes cursor became an int
+
+
+class TestRedisScanUpperBound:
+    """Verify the sweep stops after a fixed number of scanned keys."""
+
+    def test_the_bound_stops_the_loop_and_returns_a_partial_count(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An endless keyspace must not produce an endless scan."""
+        monkeypatch.setattr(retention, "REDIS_SCAN_BATCH", 10)  # WHY: fast test
+        monkeypatch.setattr(retention, "REDIS_SCAN_MAX_KEYS", 30)  # WHY: low cap
+        client = EndlessRedisClient(batch_size=10)  # WHY: never returns cursor 0
+        result = _manager(client).check_redis_retention()
+        assert result == 30  # WHY: the partial count equals the upper bound
+        assert client.calls == 3  # WHY: 3 batches of 10 keys reach the bound
+
+    def test_the_default_bound_is_a_positive_integer(self) -> None:
+        """A missing or zero bound would let the loop run without a limit."""
+        assert isinstance(retention.REDIS_SCAN_MAX_KEYS, int)  # WHY: a real cap
+        assert retention.REDIS_SCAN_MAX_KEYS > 0  # WHY: zero disables the cap
+        assert isinstance(retention.REDIS_SCAN_BATCH, int)  # WHY: a real batch
+        assert retention.REDIS_SCAN_BATCH > 0  # WHY: COUNT must be positive
+
+
+class TestRedisScanContract:
+    """Verify the return contract and the error handling shape do not change."""
+
+    def test_a_missing_client_returns_zero(self) -> None:
+        """A writer without a client reports zero checked keys."""
+        redis_writer = MagicMock(spec=[])  # WHY: no _client attribute at all
+        manager = RetentionManager(
+            arango_writer=MagicMock(),
+            redis_writer=redis_writer,
+        )
+        assert manager.check_redis_retention() == 0  # WHY: nothing to validate
+
+    def test_a_redis_error_logs_a_warning_and_returns_zero(self) -> None:
+        """An unreachable Redis server must not stop the sweep thread."""
+        client = MagicMock()  # WHY: a client that raises on every command
+        client.execute_command.side_effect = Exception("connection refused")
+        assert _manager(client).check_redis_retention() == 0  # WHY: safe value
+
+    def test_a_malformed_reply_returns_zero(self) -> None:
+        """A reply that does not unpack must follow the same error path."""
+        client = MagicMock()  # WHY: a client that answers with the wrong shape
+        client.execute_command.return_value = []  # WHY: no cursor and no batch
+        assert _manager(client).check_redis_retention() == 0  # WHY: safe value
+
+    def test_the_result_is_always_an_int(self) -> None:
+        """Callers count keys, so the method must return an int every time."""
+        client = FakeRedisClient([(0, ["a.avg_1h"])])
+        assert isinstance(_manager(client).check_redis_retention(), int)


### PR DESCRIPTION
Fixes #1882

## Problem

`RetentionManager.check_redis_retention` ran the Redis `KEYS` command with the
pattern `*.avg_1h`. The pattern starts with a wildcard, so Redis compared every
key in the keyspace. Redis serves commands on one thread, so `KEYS` held that
thread for the whole scan and no other client got a reply.

The background sweep thread calls the method every `RETENTION_CHECK_INTERVAL_HOURS`,
which defaults to 6. The stall therefore repeated on a timer and grew longer as
the keyspace grew. The code used the result only for `len(keys)`, so the full key
list crossed the network and entered process memory for a count.

## Change

- **`SCAN` loop**: the check now drives a cursor loop in the new
  `_scan_key_count` helper. Each round trip sends
  `SCAN <cursor> MATCH *.avg_1h COUNT 500`. Redis returns one bounded batch and
  then serves other clients, so no single command holds the thread.
- **Memory**: the loop adds the length of each batch to a running total and
  drops the batch. The process never holds the whole key set.
- **Upper bound**: the new `REDIS_SCAN_MAX_KEYS` constant stops the loop after
  100000 scanned keys. The sweep logs the new `redis_retention_scan_capped`
  warning with the partial count and returns that count. The cost of one sweep
  stays fixed as the keyspace grows.
- **Cursor type**: the new `_normalize_cursor` helper accepts a cursor that
  arrives as `bytes`, as a raw protocol reply does, and converts it to an `int`.

## Contract kept

- The method still returns an `int` key count.
- The method still logs a warning through `EVT_REDIS_FAIL` and returns 0 when
  the Redis call raises.
- The existing event constants `EVT_REDIS_CHECKED` and `EVT_REDIS_FAIL` are
  unchanged. Two constants are new: `EVT_REDIS_SCAN_START` and
  `EVT_REDIS_SCAN_CAPPED`.

## Test added

`tests/unit/db/test_retention_redis_scan.py` holds 10 cases across three
classes. A `FakeRedisClient` records every command it receives, and an
`EndlessRedisClient` replies with a full batch forever. The cases prove:

- the code issues `SCAN` and the command log never contains `KEYS`,
- the command carries `MATCH` with `REDIS_COMPACTION_PATTERN` and a `COUNT` of
  `REDIS_SCAN_BATCH`, and starts at cursor 0,
- the loop follows the returned cursor across three batches and sums 2 + 1 + 3
  keys into 6,
- a cursor that arrives as `bytes` still advances the loop,
- the upper bound stops an endless keyspace after 3 calls and returns the
  partial count of 30, with the bound lowered by `monkeypatch`,
- a missing client, a raising client, and a malformed reply each return 0,
- the result is always an `int`.

The tests failed against the old code. 6 of the 10 cases failed, and the failures
named the missing `SCAN` command and the missing bound constants.

## Evidence

| Gate | Command | Result |
| - | - | - |
| Tests | `python -m pytest tests/unit/db -q` | 47 passed |
| Tests | `python -m pytest tests/unit/db tests/unit/test_retention.py -q` | 61 passed |
| Lint | `python -m ruff check src/db/retention.py tests/unit/db/test_retention_redis_scan.py` | All checks passed |
| Format | `python -m black --check src/db/retention.py tests/unit/db/test_retention_redis_scan.py` | 2 files unchanged |
| Types | `python -m mypy src/db/retention.py --config-file pyproject.toml` | Success, no issues |

The pre-existing suite `tests/unit/test_retention.py` still passes without a
change, which shows the public contract holds.

## Files changed

- `src/db/retention.py`
- `tests/unit/db/test_retention_redis_scan.py` (new)
- `CHANGELOG.md` (one entry under `[Unreleased]`)

## Notes

- The `structlog` package was missing from the ambient interpreter in this
  worktree. It was installed from `https://pypi.org/simple` so the tests could
  import `src.db.retention`. No dependency manifest changed.
- The `auto-merge` label is not applied, as the task states.
