### PR TITLE
fix(ops-platform): run the real rollback when a post-check fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,35 @@ Version 26.08.23.01.26
   follows the cursor until it returns to 0, accepts a cursor that arrives as
   bytes, and stops at the upper bound against an endless keyspace.
 
+### Run the real rollback when a post-check fails (issue #1887)
+
+- **Defect (Fixed)**: `_execute_scheduled_job` set the job status to
+  `ROLLED_BACK` after a failed post-check, but no restore ran. The new
+  configuration stayed on the live network devices. The operator read the status,
+  believed the network held the previous configuration, and started no manual
+  repair. The audit trail recorded a rollback that never happened.
+- **Configuration backup (Added)**: the workflow now reads the live configuration
+  of every target before the push and keeps the snapshots for the whole job.
+- **Restore on a failed post-check (Added)**: a failed post-check now pushes the
+  captured snapshot back to each device through `RollbackService`.
+- **Install result (Fixed)**: the workflow now reads the install result. A failed
+  install stops the workflow and starts the restore. The post-check no longer
+  runs after a failed install.
+- **Honest job status (Changed)**: the status comes from the real restore
+  outcome. `rolled_back` means that every device holds the previous
+  configuration again. The new value `rollback_failed` means that one or more
+  devices did not restore.
+- **`auto_rollback_on_failure` (Fixed)**: the workflow now reads this payload
+  field. If the value is false, the status is `failed` and no restore runs. The
+  workflow never reports `rolled_back` when no restore ran.
+- **Tests (Added)**: `mist-ops-platform/tests/unit/worker/test_deploy_rollback.py`
+  covers the post-check failure, the failed install, the disabled rollback
+  switch, an incomplete restore, the happy path, and the pre-check failure.
+- **Test setup (Added)**: `mist-ops-platform/tests/conftest.py` supplies a
+  stand-in for `src.shared.config`, because the root `.gitignore` pattern
+  `config/` keeps that package out of git and every clean checkout fails to
+  import the worker modules.
+
 ### Add a real readiness probe and keep the health endpoint cheap (issue #1863)
 
 - **Defect (Fixed)**: the `/health` endpoint returned the fixed text `healthy` on

--- a/mist-ops-platform/src/worker/tasks/deploy_tasks.py
+++ b/mist-ops-platform/src/worker/tasks/deploy_tasks.py
@@ -8,7 +8,9 @@ Also includes the scheduled job poller for due maintenance windows.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import select
@@ -24,6 +26,12 @@ from src.worker.celeryconfig import app
 from src.worker.deploy.rollback import RollbackService, RollbackState
 
 logger = logging.getLogger(__name__)
+
+# The shared JobStatus enum lives in `src/shared/config/constants.py`. The root
+# `.gitignore` pattern `config/` keeps that file out of git, so this module
+# cannot add an enum member to it. The literal below gives the job row a
+# distinct value for a restore that did not finish on every device.
+ROLLBACK_FAILED_STATUS = "rollback_failed"
 
 
 @app.task(
@@ -127,6 +135,14 @@ def _build_targets(
     return targets
 
 
+def _build_mist_service(org_id: str) -> MistEndpointService:
+    """Create a Mist endpoint service for one organization."""
+    factory = get_session_factory()  # Reuse the cached factory to avoid a new login per call.
+    api_session = factory.create_session(org_id)  # Bind the session to the caller organization.
+    limiter = factory.create_rate_limiter(org_id)  # Enforce the org API budget on every call. Fixes #1886.
+    return MistEndpointService(api_session, rate_limiter=limiter)  # Wrap the session in the typed facade.
+
+
 def _push_with_rollback(
     db: Session,
     org_id: str,
@@ -134,12 +150,7 @@ def _push_with_rollback(
     targets: list[dict[str, str]],
 ) -> RollbackState:
     """Execute push with saga-pattern rollback."""
-    factory = get_session_factory()  # WHY: reuse the cached session and token factory.
-    api_session = factory.create_session(org_id)  # WHY: build the org-scoped Mist SDK session.
-    # WHY: enforce the org API budget on every call. Fixes #1886.
-    limiter = factory.create_rate_limiter(org_id)
-    # WHY: wire the limiter into the shared client.
-    mist = MistEndpointService(api_session, rate_limiter=limiter)
+    mist = _build_mist_service(org_id)  # Share one Mist service builder with the restore path.
 
     service = RollbackService(db, mist)
     config_payload = revision.config_blob or {}
@@ -153,12 +164,13 @@ def _push_with_rollback(
 def _update_job_status(
     db: Session,
     job: ScheduledJob,
-    status: JobStatus,
+    status: JobStatus | str,
 ) -> None:
     """Update job status and timestamp."""
-    job.status = status.value
-    job.updated_at = datetime.now(UTC)
-    db.commit()
+    # A restore that did not finish has no enum member, so accept a plain string as well.
+    job.status = status.value if isinstance(status, JobStatus) else status
+    job.updated_at = datetime.now(UTC)  # Record the moment of the change for the audit trail.
+    db.commit()  # Persist at once so an operator reads the true state during the job.
 
 
 # -- T061: Scheduled job execution poller --------------------------------
@@ -198,38 +210,215 @@ def _find_due_jobs(db: Session) -> list[ScheduledJob]:
     return list(db.execute(stmt).scalars().all())
 
 
+@dataclass
+class _ConfigBackup:
+    """Previous configuration of every target, read before the push."""
+
+    entity_type: str = ""
+    snapshots: list[tuple[dict[str, str], dict[str, Any]]] = field(default_factory=list)
+
+
+@dataclass
+class _JobPlan:
+    """Everything the scheduled job workflow needs after it reads the payload."""
+
+    org_id: str
+    target_ids: list[str]
+    revision_id: int | None
+    auto_rollback: bool
+    backup: _ConfigBackup
+
+
+def _build_job_plan(job: ScheduledJob) -> _JobPlan:
+    """Read the job payload into a plan the workflow steps can share."""
+    payload = job.change_payload or {}  # An empty payload must not raise, so default to a dict.
+    return _JobPlan(
+        org_id=str(job.org_id),  # The Mist session factory needs the organization as a string.
+        target_ids=payload.get("target_entity_ids", []),  # No target means no device to change.
+        revision_id=payload.get("revision_id"),  # The revision holds the config to push.
+        # The operator can switch off the restore. Default to true, because a live network
+        # must return to the last known good state when the platform finds a fault.
+        auto_rollback=bool(payload.get("auto_rollback_on_failure", True)),
+        backup=_ConfigBackup(),  # Start empty. The capture step fills it before the push.
+    )
+
+
 def _execute_scheduled_job(db: Session, job: ScheduledJob) -> dict:
     """Execute a single scheduled job with pre/post checks.
 
-    Workflow: pre-check -> push -> post-check -> rollback-on-failure.
+    Workflow: pre-check -> backup -> push -> post-check -> rollback-on-failure.
     """
-    from src.worker.tasks.check_tasks import run_post_checks, run_pre_checks
+    plan = _build_job_plan(job)  # Parse the payload once and share it with every step.
+    pre_failure = _run_pre_check_phase(db, job, plan)  # Stop before the push if a device is sick.
+    if pre_failure is not None:
+        return pre_failure  # No push ran, so no restore is needed.
 
-    payload = job.change_payload or {}
-    org_id = str(job.org_id)
-    target_ids = payload.get("target_entity_ids", [])
-    revision_id = payload.get("revision_id")
+    _capture_job_backup(db, plan)  # Read the live config first, because the push overwrites it.
+    install_result = _run_install_phase(db, job, plan)
+    if not _install_succeeded(install_result):
+        # A failed install can leave a part of the fleet on the new config, so restore now.
+        return _handle_job_failure(db, job, plan, "install_failed", install_result)
 
+    post_result = _run_post_check_phase(db, job, plan)
+    if not post_result.get("passed", False):
+        # The push finished but the devices are unhealthy, so put the old config back.
+        return _handle_job_failure(db, job, plan, "post_check_failed", post_result)
+
+    _update_job_status(db, job, JobStatus.COMPLETED)  # Every step passed, so the job is done.
+    return {"status": "completed", "install": install_result}
+
+
+def _run_pre_check_phase(
+    db: Session,
+    job: ScheduledJob,
+    plan: _JobPlan,
+) -> dict | None:
+    """Run the pre-checks. Return a failure payload, or None when they pass."""
+    from src.worker.tasks.check_tasks import run_pre_checks
+
+    logger.info("Starting pre-checks for job %s", job.job_id)  # Log before the check runs.
     _update_job_status(db, job, JobStatus.PRE_CHECK)
-    pre_result = run_pre_checks(str(job.job_id), org_id, target_ids)
-    if not pre_result.get("passed", False):
-        _update_job_status(db, job, JobStatus.FAILED)
-        return {"status": "pre_check_failed", "details": pre_result}
+    result = run_pre_checks(str(job.job_id), plan.org_id, plan.target_ids)
+    passed = result.get("passed", False)  # A missing verdict counts as a failure, not a pass.
+    logger.debug("Pre-check result for job %s: passed=%s", job.job_id, passed)
+    if passed:
+        return None  # None tells the caller to continue with the push.
 
+    _update_job_status(db, job, JobStatus.FAILED)  # Nothing changed, so FAILED is the true state.
+    return {"status": "pre_check_failed", "details": result}
+
+
+def _capture_job_backup(db: Session, plan: _JobPlan) -> None:
+    """Read the live configuration of every target before the push."""
+    revision = _load_revision(db, plan.revision_id, plan.org_id) if plan.revision_id else None
+    if revision is None:
+        # Without the revision the workflow cannot map a target to an endpoint.
+        logger.error("No revision %s for job backup, a restore is not possible", plan.revision_id)
+        return
+
+    targets = _build_targets(revision, plan.target_ids)  # Same target map the push path builds.
+    plan.backup.entity_type = revision.entity_type  # The restore needs the same entity type.
+    logger.info("Capturing the previous config of %d targets", len(targets))
+    plan.backup.snapshots = _read_snapshots(plan.org_id, revision.entity_type, targets)
+    logger.debug("Captured %d config snapshots", len(plan.backup.snapshots))
+
+
+def _read_snapshots(
+    org_id: str,
+    entity_type: str,
+    targets: list[dict[str, str]],
+) -> list[tuple[dict[str, str], dict[str, Any]]]:
+    """Read the current config of each target from the Mist API."""
+    mist = _build_mist_service(org_id)  # One service serves every read in this loop.
+    snapshots: list[tuple[dict[str, str], dict[str, Any]]] = []
+    for entity_ids in targets:
+        result = mist.read_entity(entity_type=entity_type, ids=entity_ids)
+        if result.success and isinstance(result.data, dict):
+            snapshots.append((entity_ids, result.data))  # Keep the pair so the restore finds it.
+        else:
+            # A missing snapshot removes the restore option for that one device.
+            logger.error("Cannot read the current config of %s", entity_ids)
+    return snapshots
+
+
+def _run_install_phase(
+    db: Session,
+    job: ScheduledJob,
+    plan: _JobPlan,
+) -> dict:
+    """Push the revision to every target and return the install result."""
+    logger.info("Starting the install for job %s", job.job_id)  # Log before the push starts.
     _update_job_status(db, job, JobStatus.EXECUTING)
     async_result = install_from_revision.apply(
-        args=[str(job.job_id), revision_id, target_ids, org_id],
+        args=[str(job.job_id), plan.revision_id, plan.target_ids, plan.org_id],
     )
     install_result = async_result.result if async_result else {}
+    logger.debug("Install result for job %s: %s", job.job_id, install_result)
+    # A non-dict result means the task raised, so hand back an empty dict the caller can read.
+    return install_result if isinstance(install_result, dict) else {}
 
+
+def _install_succeeded(install_result: dict) -> bool:
+    """Report whether the install pushed the revision to every target."""
+    if install_result.get("error"):
+        return False  # The task reported an error, so treat the install as a failure.
+    # Only the exact "completed" status proves that every push finished.
+    return install_result.get("status") == "completed"
+
+
+def _run_post_check_phase(
+    db: Session,
+    job: ScheduledJob,
+    plan: _JobPlan,
+) -> dict:
+    """Run the post-checks and return the verdict."""
+    from src.worker.tasks.check_tasks import run_post_checks
+
+    logger.info("Starting post-checks for job %s", job.job_id)  # Log before the check runs.
     _update_job_status(db, job, JobStatus.POST_CHECK)
-    post_result = run_post_checks(str(job.job_id), org_id, target_ids)
-    if not post_result.get("passed", False):
-        _update_job_status(db, job, JobStatus.ROLLED_BACK)
-        return {"status": "post_check_failed_rollback", "details": post_result}
+    result = run_post_checks(str(job.job_id), plan.org_id, plan.target_ids)
+    logger.debug(
+        "Post-check result for job %s: passed=%s",
+        job.job_id,
+        result.get("passed", False),
+    )
+    return result
 
-    _update_job_status(db, job, JobStatus.COMPLETED)
-    return {"status": "completed", "install": install_result}
+
+def _handle_job_failure(
+    db: Session,
+    job: ScheduledJob,
+    plan: _JobPlan,
+    reason: str,
+    details: dict,
+) -> dict:
+    """Restore the previous config and set the status from the real outcome."""
+    if not plan.auto_rollback:
+        # Warning: the new configuration stays live, so an operator must repair it by hand.
+        logger.warning("Auto rollback is off for job %s, the new config stays live", job.job_id)
+        _update_job_status(db, job, JobStatus.FAILED)  # Never claim a restore that did not run.
+        return {"status": reason, "rollback": "skipped", "details": details}
+
+    restored = _restore_previous_config(db, plan)  # Push the captured config back to the devices.
+    # ROLLED_BACK must mean that every device holds the previous config again.
+    _update_job_status(db, job, JobStatus.ROLLED_BACK if restored else ROLLBACK_FAILED_STATUS)
+    outcome = "restored" if restored else "failed"
+    logger.warning("Job %s failed at %s, the rollback outcome is %s", job.job_id, reason, outcome)
+    return {"status": reason, "rollback": outcome, "details": details}
+
+
+def _restore_previous_config(db: Session, plan: _JobPlan) -> bool:
+    """Push every captured snapshot back. Return True when every target restored."""
+    backup = plan.backup
+    if not backup.snapshots:
+        # Warning: no snapshot exists, so the bad configuration stays on the devices.
+        logger.error("No config snapshot for job rollback, nothing was restored")
+        return False
+
+    service = RollbackService(db, _build_mist_service(plan.org_id))
+    logger.info("Restoring the previous config on %d targets", len(backup.snapshots))
+    restored = 0
+    for entity_ids, config in backup.snapshots:
+        if _restore_one_target(service, backup.entity_type, entity_ids, config):
+            restored += 1  # Count only a target that holds the previous config again.
+    logger.debug("Restore finished, %d of %d targets are back", restored, len(backup.snapshots))
+    return restored == len(backup.snapshots)
+
+
+def _restore_one_target(
+    service: RollbackService,
+    entity_type: str,
+    entity_ids: dict[str, str],
+    config: dict[str, Any],
+) -> bool:
+    """Push one captured snapshot back to one target."""
+    # Reuse the same saga helper the push failure branch uses, one target at a time,
+    # because each target carries its own previous configuration.
+    state = service.execute_with_rollback(entity_type, [entity_ids], config)
+    if state.status != "completed":
+        logger.error("Restore failed for %s: %s", entity_ids, state.error)
+        return False
+    return True
 
 
 # -- T082: Rollout wave execution tasks ----------------------------------

--- a/mist-ops-platform/tests/conftest.py
+++ b/mist-ops-platform/tests/conftest.py
@@ -1,0 +1,144 @@
+"""Shared test setup for the mist-ops-platform suite.
+
+The package `src.shared.config` is absent from the repository. The root
+`.gitignore` holds the pattern `config/`, so git never tracked the directory.
+Every clean checkout and every worktree therefore fails to import the worker
+modules. This file supplies a minimal stand-in so the suite can run.
+
+The stand-in loads only when the real package is absent. If a developer holds
+the real `src.shared.config` package, the real package wins.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from enum import StrEnum
+from importlib.util import find_spec
+
+
+def _real_config_package_exists() -> bool:
+    """Report whether the real `src.shared.config` package is importable."""
+    try:
+        return find_spec("src.shared.config.constants") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+class _JobStatus(StrEnum):
+    """Stand-in for the shared job lifecycle status enum."""
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    PRE_CHECK = "pre_check"
+    EXECUTING = "executing"
+    POST_CHECK = "post_check"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    ROLLED_BACK = "rolled_back"
+    ROLLBACK_FAILED = "rollback_failed"
+    CANCELLED = "cancelled"
+
+
+class _EntityType(StrEnum):
+    """Stand-in for the shared Mist entity type enum."""
+
+    DEVICE = "device"
+    SITE = "site"
+    SITE_SETTING = "site_setting"
+    SITE_INFO = "site_info"
+    WLAN = "wlan"
+    ORG = "org"
+
+
+class _DeviceType(StrEnum):
+    """Stand-in for the shared Mist device type enum."""
+
+    AP = "ap"
+    SWITCH = "switch"
+    GATEWAY = "gateway"
+
+
+class _AlertSeverity(StrEnum):
+    """Stand-in for the shared alert severity enum."""
+
+    CRITICAL = "critical"
+    WARNING = "warning"
+    INFO = "info"
+
+
+class _AlertType(StrEnum):
+    """Stand-in for the shared alert type enum."""
+
+    DRIFT = "drift"
+    JOB_FAILURE = "job_failure"
+    ROLLBACK = "rollback"
+
+
+class _WaveStatus(StrEnum):
+    """Stand-in for the shared rollout wave status enum."""
+
+    PENDING = "pending"
+    EXECUTING = "executing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class _GoldenImageStatus(StrEnum):
+    """Stand-in for the shared golden image status enum."""
+
+    CANDIDATE = "candidate"
+    APPROVED = "approved"
+    RETIRED = "retired"
+
+
+class _AppSettings:
+    """Stand-in for the application settings object."""
+
+    app_name = "mist-ops-platform"
+    app_version = "0.1.0"
+    environment = "test"
+    log_level = "INFO"
+    database_url = "postgresql+asyncpg://localhost/misthelper_test"
+    redis_url = "redis://localhost:6379/0"
+    sync_interval_seconds = 300
+    mist_api_host = "api.mist.com"
+    mist_api_token = ""
+    mist_webhook_secret = ""
+    vault_addr = ""
+    vault_token = ""
+
+
+def _build_constants_module() -> types.ModuleType:
+    """Build the stand-in `src.shared.config.constants` module."""
+    constants = types.ModuleType("src.shared.config.constants")
+    constants.JobStatus = _JobStatus  # type: ignore[attr-defined]
+    constants.EntityType = _EntityType  # type: ignore[attr-defined]
+    constants.DeviceType = _DeviceType  # type: ignore[attr-defined]
+    constants.AlertSeverity = _AlertSeverity  # type: ignore[attr-defined]
+    constants.AlertType = _AlertType  # type: ignore[attr-defined]
+    constants.WaveStatus = _WaveStatus  # type: ignore[attr-defined]
+    constants.GoldenImageStatus = _GoldenImageStatus  # type: ignore[attr-defined]
+    return constants
+
+
+def _build_settings_module() -> types.ModuleType:
+    """Build the stand-in `src.shared.config.settings` module."""
+    settings = types.ModuleType("src.shared.config.settings")
+    settings.AppSettings = _AppSettings  # type: ignore[attr-defined]
+    settings.get_settings = _AppSettings  # type: ignore[attr-defined]
+    return settings
+
+
+def _install_config_stand_in() -> None:
+    """Register the stand-in `src.shared.config` package in `sys.modules`."""
+    package = types.ModuleType("src.shared.config")
+    package.__path__ = []  # Mark the module as a package so the submodules resolve.
+
+    sys.modules["src.shared.config"] = package
+    sys.modules["src.shared.config.constants"] = _build_constants_module()
+    sys.modules["src.shared.config.settings"] = _build_settings_module()
+
+
+if not _real_config_package_exists():
+    _install_config_stand_in()

--- a/mist-ops-platform/tests/unit/worker/__init__.py
+++ b/mist-ops-platform/tests/unit/worker/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the worker deploy tasks."""

--- a/mist-ops-platform/tests/unit/worker/test_deploy_rollback.py
+++ b/mist-ops-platform/tests/unit/worker/test_deploy_rollback.py
@@ -1,0 +1,244 @@
+"""Tests for the rollback behavior of the scheduled job workflow (issue #1887).
+
+The scheduled job workflow pushes a configuration change to live network
+devices. A failure after the push must restore the previous configuration.
+The job status must report what the restore really did.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any, ClassVar
+
+import pytest
+
+from src.worker.deploy.rollback import RollbackState
+from src.worker.tasks import check_tasks, deploy_tasks
+
+PREVIOUS_CONFIG = {"radio_config": {"band_24": {"power": 8}}}
+NEW_CONFIG = {"radio_config": {"band_24": {"power": 14}}}
+
+
+class FakeSession:
+    """Stand-in for the SQLAlchemy session."""
+
+    def __init__(self) -> None:
+        self.commits = 0
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+class FakeJob:
+    """Stand-in for the ScheduledJob row."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.job_id = uuid.uuid4()
+        self.org_id = uuid.uuid4()
+        self.change_payload = payload
+        self.status = "approved"
+        self.updated_at = datetime.now(UTC)
+
+
+class FakeRevision:
+    """Stand-in for the ConfigRevision row."""
+
+    entity_type = "device"
+    config_blob = NEW_CONFIG
+
+
+class FakeReadResult:
+    """Stand-in for the Mist read result."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self.success = True
+        self.data = data
+
+
+class FakeMist:
+    """Stand-in for the Mist endpoint service."""
+
+    def read_entity(self, entity_type: str, ids: dict[str, str]) -> FakeReadResult:
+        return FakeReadResult(dict(PREVIOUS_CONFIG))
+
+
+class FakeRollbackService:
+    """Stand-in for RollbackService that records every restore call."""
+
+    calls: ClassVar[list[tuple[str, list[dict[str, str]], dict[str, Any]]]] = []
+    restore_status = "completed"
+
+    def __init__(self, db: Any, mist: Any) -> None:
+        self.db = db
+        self.mist = mist
+
+    def execute_with_rollback(
+        self,
+        entity_type: str,
+        targets: list[dict[str, str]],
+        new_config: dict[str, Any],
+    ) -> RollbackState:
+        FakeRollbackService.calls.append((entity_type, targets, new_config))
+        return RollbackState(status=FakeRollbackService.restore_status, error="push denied")
+
+
+class FakeAsyncResult:
+    """Stand-in for the Celery async result."""
+
+    def __init__(self, result: dict[str, Any]) -> None:
+        self.result = result
+
+
+class FakeInstallTask:
+    """Stand-in for the install_from_revision Celery task."""
+
+    def __init__(self, result: dict[str, Any]) -> None:
+        self._result = result
+        self.calls = 0
+
+    def apply(self, args: list[Any]) -> FakeAsyncResult:
+        self.calls += 1
+        return FakeAsyncResult(self._result)
+
+
+class CheckRecorder:
+    """Record every check call and return a fixed verdict."""
+
+    def __init__(self, passed: bool) -> None:
+        self.passed = passed
+        self.calls = 0
+
+    def __call__(self, job_id: str, org_id: str, target_ids: list[str]) -> dict[str, Any]:
+        self.calls += 1
+        return {"passed": self.passed}
+
+
+def _build_payload(auto_rollback: bool = True) -> dict[str, Any]:
+    """Build a job payload with one target device."""
+    return {
+        "target_entity_ids": [str(uuid.uuid4())],
+        "revision_id": 7,
+        "auto_rollback_on_failure": auto_rollback,
+    }
+
+
+@pytest.fixture()
+def workflow(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Replace every outside call of the scheduled job workflow."""
+    FakeRollbackService.calls = []
+    FakeRollbackService.restore_status = "completed"
+
+    pre_check = CheckRecorder(passed=True)
+    post_check = CheckRecorder(passed=True)
+    install = FakeInstallTask({"status": "completed", "pushed": 1, "error": None})
+
+    monkeypatch.setattr(check_tasks, "run_pre_checks", pre_check)
+    monkeypatch.setattr(check_tasks, "run_post_checks", post_check)
+    monkeypatch.setattr(deploy_tasks, "install_from_revision", install)
+    monkeypatch.setattr(deploy_tasks, "RollbackService", FakeRollbackService)
+    monkeypatch.setattr(deploy_tasks, "_build_mist_service", lambda org_id: FakeMist())
+    monkeypatch.setattr(
+        deploy_tasks,
+        "_load_revision",
+        lambda db, revision_id, org_id: FakeRevision(),
+    )
+    return {"pre_check": pre_check, "post_check": post_check, "install": install}
+
+
+class TestPostCheckRollback:
+    """Verify that a failure after the push restores the previous config."""
+
+    def test_post_check_failure_runs_the_restore(
+        self,
+        workflow: dict[str, Any],
+    ) -> None:
+        """A failed post-check must push the previous config back."""
+        workflow["post_check"].passed = False
+        db = FakeSession()
+        job = FakeJob(_build_payload())
+
+        result = deploy_tasks._execute_scheduled_job(db, job)
+
+        assert FakeRollbackService.calls, "The restore helper never ran"
+        assert FakeRollbackService.calls[0][2] == PREVIOUS_CONFIG
+        assert job.status == "rolled_back"
+        assert result["rollback"] == "restored"
+
+    def test_failed_install_skips_the_post_check_and_restores(
+        self,
+        workflow: dict[str, Any],
+    ) -> None:
+        """A failed install must stop the workflow and start the restore."""
+        workflow["install"]._result = {"status": "failed", "error": "push denied"}
+        db = FakeSession()
+        job = FakeJob(_build_payload())
+
+        result = deploy_tasks._execute_scheduled_job(db, job)
+
+        assert workflow["post_check"].calls == 0, "The post-check ran after a failed install"
+        assert FakeRollbackService.calls, "The restore helper never ran"
+        assert job.status == "rolled_back"
+        assert result["status"] == "install_failed"
+
+    def test_auto_rollback_off_marks_the_job_failed(
+        self,
+        workflow: dict[str, Any],
+    ) -> None:
+        """A job that switches off auto rollback must report FAILED."""
+        workflow["post_check"].passed = False
+        db = FakeSession()
+        job = FakeJob(_build_payload(auto_rollback=False))
+
+        result = deploy_tasks._execute_scheduled_job(db, job)
+
+        assert FakeRollbackService.calls == [], "The restore ran although the switch is off"
+        assert job.status == "failed"
+        assert job.status != "rolled_back"
+        assert result["rollback"] == "skipped"
+
+    def test_incomplete_restore_marks_rollback_failed(
+        self,
+        workflow: dict[str, Any],
+    ) -> None:
+        """A restore that does not finish must report ROLLBACK_FAILED."""
+        workflow["post_check"].passed = False
+        FakeRollbackService.restore_status = "partial_rollback"
+        db = FakeSession()
+        job = FakeJob(_build_payload())
+
+        result = deploy_tasks._execute_scheduled_job(db, job)
+
+        assert job.status == deploy_tasks.ROLLBACK_FAILED_STATUS
+        assert job.status != "rolled_back"
+        assert result["rollback"] == "failed"
+
+    def test_happy_path_keeps_the_new_config(
+        self,
+        workflow: dict[str, Any],
+    ) -> None:
+        """A job that passes every check must not restore anything."""
+        db = FakeSession()
+        job = FakeJob(_build_payload())
+
+        result = deploy_tasks._execute_scheduled_job(db, job)
+
+        assert FakeRollbackService.calls == [], "The restore ran on a healthy job"
+        assert job.status == "completed"
+        assert result["status"] == "completed"
+
+    def test_pre_check_failure_skips_the_install(
+        self,
+        workflow: dict[str, Any],
+    ) -> None:
+        """A failed pre-check must not push anything."""
+        workflow["pre_check"].passed = False
+        db = FakeSession()
+        job = FakeJob(_build_payload())
+
+        result = deploy_tasks._execute_scheduled_job(db, job)
+
+        assert workflow["install"].calls == 0, "The install ran after a failed pre-check"
+        assert FakeRollbackService.calls == [], "The restore ran without a push"
+        assert job.status == "failed"
+        assert result["status"] == "pre_check_failed"


### PR DESCRIPTION
Fixes #1887

## Safety impact

This change is on a destructive path. The scheduled job workflow pushes a configuration change to live network devices.

Before this change, a failed post-check set the job status to `ROLLED_BACK` and returned. No restore ran. The bad configuration stayed on the devices. The operator read the status, believed the network held the previous configuration, and started no manual repair. The outage continued and the audit trail recorded a rollback that never happened. A false safe state is worse than a plain failure.

After this change, the job status always reports what really happened.

## What changed

All changes are in `mist-ops-platform/src/worker/tasks/deploy_tasks.py`.

1. **Configuration backup before the push.** `_capture_job_backup` reads the live configuration of every target through the Mist endpoint service. The workflow keeps the snapshots in a `_JobPlan` object for the whole job.
2. **Real restore on a post-check failure.** `_restore_previous_config` pushes each captured snapshot back through `RollbackService.execute_with_rollback`. That is the same helper the push failure branch uses at `_push_with_rollback`. The restore runs one target at a time, because each target carries its own previous configuration.
3. **The install result is checked.** `_install_succeeded` reads the install result. A failed install stops the workflow and starts the restore. The post-check no longer runs after a failed install.
4. **The job status comes from the restore outcome.** `rolled_back` means every device holds the previous configuration again. The new value `rollback_failed` means one or more devices did not restore.
5. **`auto_rollback_on_failure` is read.** The field was declared in `src/api/schemas/deploy.py` and never read. If the value is false, the status is `failed` and no restore runs. The workflow never reports `rolled_back` when no restore ran.
6. **Function size.** The old 25-line function is split into small helpers. Every new function stays at or below 25 lines and 5 parameters.

## Tests added

New file `mist-ops-platform/tests/unit/worker/test_deploy_rollback.py`, 6 tests, all pass.

| Test | What it proves |
| - | - |
| `test_post_check_failure_runs_the_restore` | A failed post-check calls the restore helper with the captured previous configuration and sets `rolled_back`. |
| `test_failed_install_skips_the_post_check_and_restores` | A failed install runs no post-check and starts the restore. |
| `test_auto_rollback_off_marks_the_job_failed` | The switch set to false gives status `failed`, runs no restore, and never gives `rolled_back`. |
| `test_incomplete_restore_marks_rollback_failed` | A restore that does not finish gives status `rollback_failed`. |
| `test_happy_path_keeps_the_new_config` | A healthy job runs no restore. |
| `test_pre_check_failure_skips_the_install` | A failed pre-check runs no push and no restore. |

## Checks that ran

I created a virtual environment under `mist-ops-platform/.venv` and installed the sub-project dependencies from the public index.

| Check | Command | Result |
| - | - | - |
| Tests, new file | `python -m pytest tests/unit/worker -q` | 6 passed |
| Tests, full suite | `python -m pytest tests -q --ignore=tests/contract/test_api_contracts.py` | 187 passed, 32 skipped, 9 failed, 3 errors |
| Lint, changed files | `python -m ruff check src/worker/tasks/deploy_tasks.py tests/conftest.py tests/unit/worker` | All checks passed |
| Format, changed files | `python -m black --check` on the same paths | 4 files unchanged |

## Checks that did not pass, and why

I state these plainly. I did not repair them, because they sit in files that other agents hold right now.

- `python -m ruff check src` reports 286 findings across the whole sub-project. Every finding sits outside my four owned files. `ruff check` on my changed files passes.
- `python -m black --check src` passes for every file after my change.
- `tests/contract/test_api_contracts.py` cannot import. It asks for `InventoryStatsResponse` from `src/api/schemas/sync.py` and that name does not exist. PR #1891 holds the API files, so I left it alone and skipped that one module.
- 9 failures and 3 errors remain in `tests/unit/api/test_auth.py`, `tests/unit/shared/test_models_inventory.py`, `tests/unit/mist/test_consumer_registry_usage.py`, `tests/integration/test_drift.py`, and `tests/integration/test_e2e_smoke.py`. None of them import `deploy_tasks`. They fail on `src/api/middleware/auth.py`, `src/shared/models/inventory.py`, `src/shared/mist/endpoints.py`, `src/shared/services/diff.py`, and `src/api/main.py`, which other agents own.

## One point for the reviewer

The shared `JobStatus` enum lives in `mist-ops-platform/src/shared/config/constants.py`. The root `.gitignore` holds the pattern `config/` on line 244, so git never tracked that file. It is absent from every clean checkout and every worktree, and the whole sub-project fails to import without it.

Two results follow.

1. I could not add a `ROLLBACK_FAILED` member to the enum, because the file is not in the repository. The module constant `ROLLBACK_FAILED_STATUS = "rollback_failed"` gives the job row a distinct value instead, and `_update_job_status` now accepts an enum member or a plain string. If a later change tracks the enum file, move the value into the enum.
2. I added `mist-ops-platform/tests/conftest.py`. It registers a stand-in for `src.shared.config` only when the real package is absent, so the suite can run in a clean checkout. If the real package is present, the real package wins.

The `.gitignore` gap is a separate defect. I did not change `.gitignore`, because that file is outside my scope for this issue.

## Review note

Do not add the `auto-merge` label. This change is on a destructive path and needs human review.
