### PR TITLE
fix(portability,web-portal): set an explicit encoding and release SQLite handles

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -777,7 +777,7 @@ try:  # Try to load environment variables from a .env file before any dependency
 except Exception:  # If python-dotenv is not installed yet, fall back to a manual parser
     # Inline fallback: read .env manually so env vars are available
     try:  # Try a best-effort manual parse of the .env file
-        with open(".env") as _ef:  # Open .env in the current working directory
+        with open(".env", encoding="utf-8") as _ef:  # Open .env in the current working directory
             for _line in _ef:  # Process the file one line at a time
                 _line = _line.strip()  # Remove surrounding whitespace and the trailing newline
                 if (
@@ -1154,7 +1154,7 @@ def _apply_dotenv_line(line: str) -> None:  # Set one KEY=VALUE pair from a .env
 def _fallback_load_dotenv() -> None:  # Minimal .env parser used when python-dotenv is not installed
     """Fallback .env loader when python-dotenv package is not installed."""
     try:  # The .env file is optional. Handle its absence/errors gracefully
-        with open(".env") as dotenv_file:  # Open .env in the current working directory
+        with open(".env", encoding="utf-8") as dotenv_file:  # Open .env in the current working directory
             for line in dotenv_file:  # Process the file one line at a time
                 _apply_dotenv_line(line)  # Set this KEY=VALUE pair (skips blanks/comments internally)
     except FileNotFoundError:  # No .env file present

--- a/diag_rbo.py
+++ b/diag_rbo.py
@@ -4,7 +4,7 @@ import json
 
 from src.audit.renderer import AuditReportRenderer
 
-with open("data/orgaudit-filtered.json") as f:
+with open("data/orgaudit-filtered.json", encoding="utf-8") as f:
     raw = json.load(f)
 
 data = raw.get("results", raw) if isinstance(raw, dict) else raw

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,16 @@ target-version = "py313"
 extend-exclude = ["mist-ops-platform", "web_portal", "scripts", "src/maps"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP", "B", "G"]
+select = ["E", "F", "W", "I", "UP", "B", "G", "PLW1514"]
+# Issue #1795: PLW1514 (unspecified-encoding) is a preview rule. `preview` turns
+# preview rules on and `explicit-preview-rules` limits them to the codes named in
+# `select`, so no other preview rule reaches this gate. An `open()` call in text
+# mode without an explicit encoding uses the platform default. Windows returns
+# cp1252 and Linux returns utf-8. MistHelper writes state files on a Windows
+# workstation and reads them inside a Linux container, so a missing encoding
+# corrupts every character above code point 127.
+preview = true
+explicit-preview-rules = true
 # Phase 1 ignores (2026-03-12) -- tighten these incrementally:
 #   RESOLVED (2026-07-19, #886 slice): E402 moved from repo-wide ignore to
 #     scoped per-file-ignores; see the E402 block in [tool.ruff.lint.per-file-ignores]

--- a/specs/010-endpoint-usage-audit/_build_menu_map.py
+++ b/specs/010-endpoint-usage-audit/_build_menu_map.py
@@ -45,7 +45,7 @@ for i, line in enumerate(lines):
         func_ranges.append({"name": full_name, "start": i + 1, "class": current_class})
 
 # Load catalog
-with open("specs/010-endpoint-usage-audit/catalog_matched.json") as f:
+with open("specs/010-endpoint-usage-audit/catalog_matched.json", encoding="utf-8") as f:
     catalog = json.load(f)
 
 # For each MistHelper call site, find containing function
@@ -97,11 +97,11 @@ for cs in catalog:
     cs["menu_operations"] = matched_menus
 
 # Save
-with open("specs/010-endpoint-usage-audit/catalog_matched.json", "w") as f:
+with open("specs/010-endpoint-usage-audit/catalog_matched.json", "w", encoding="utf-8") as f:
     json.dump(catalog, f, indent=2)
 
 # Save menu map
-with open("specs/010-endpoint-usage-audit/menu_map.json", "w") as f:
+with open("specs/010-endpoint-usage-audit/menu_map.json", "w", encoding="utf-8") as f:
     json.dump({str(k): v for k, v in sorted(menu_map.items())}, f, indent=2)
 
 # Stats

--- a/specs/010-endpoint-usage-audit/_validate_report.py
+++ b/specs/010-endpoint-usage-audit/_validate_report.py
@@ -32,11 +32,11 @@ has_type = "type=" in ctx3
 print("F-005 OK: listSiteDevicesStats near L31810, type param=" + str(has_type))
 
 # T029: Verify catalog counts
-with open("specs/010-endpoint-usage-audit/catalog_misthelper.json") as f:
+with open("specs/010-endpoint-usage-audit/catalog_misthelper.json", encoding="utf-8") as f:
     mh = json.load(f)
-with open("specs/010-endpoint-usage-audit/catalog_maps_manager.json") as f:
+with open("specs/010-endpoint-usage-audit/catalog_maps_manager.json", encoding="utf-8") as f:
     mm = json.load(f)
-with open("specs/010-endpoint-usage-audit/catalog_wsgi.json") as f:
+with open("specs/010-endpoint-usage-audit/catalog_wsgi.json", encoding="utf-8") as f:
     ws = json.load(f)
 
 total_sites = len(mh) + len(mm) + len(ws)

--- a/src/config/config_utils.py
+++ b/src/config/config_utils.py
@@ -81,7 +81,7 @@ class ConfigUtils:
     def _resolve_org_id_from_dotenv() -> str | None:
         """Parse org_id from a sibling .env file. Return the value or None."""
         try:
-            with open(".env") as env_file:  # Fall back to the .env file.
+            with open(".env", encoding="utf-8") as env_file:  # Fall back to the .env file.
                 for line in env_file:  # Scan each line for org_id.
                     if line.strip().startswith("org_id="):  # Match the org_id assignment.
                         return line.strip().split("=", 1)[1].strip().strip('"')  # Extract and unquote.

--- a/src/refactors/data_directory_checker.py
+++ b/src/refactors/data_directory_checker.py
@@ -67,7 +67,7 @@ class DataDirectoryChecker:
     def _test_write_permission(self) -> bool:  # Validate data directory write access via test file
         """Create and remove a test file to verify write access."""
         with open(
-            self.test_file, "w"
+            self.test_file, "w", encoding="utf-8"
         ) as file_handle:  # Open test file for writing (will fail if directory not writable)
             file_handle.write("test")  # Write marker content to test file
         os.remove(self.test_file)  # Delete test file to clean up

--- a/src/utils/rate_limiting.py
+++ b/src/utils/rate_limiting.py
@@ -131,7 +131,7 @@ class RateLimitingUtils:  # WHY: static-method facade groups rate-limit helpers 
             return None  # WHY: signal cold-start to caller.
         try:  # WHY: any decode/read failure falls back to defaults.
             logging.debug("File I/O: Attempting to read PID tuning data from %s", tuning_data_file)  # WHY: entry log.
-            with open(tuning_data_file) as file_handle:  # WHY: text-mode read is fine for JSON payload.
+            with open(tuning_data_file, encoding="utf-8") as file_handle:  # WHY: UTF-8 keeps the JSON portable.
                 parsed: dict[str, Any] = json.load(file_handle)  # WHY: annotate result for downstream narrowing.
                 return parsed  # WHY: surface the decoded tuning-data dict.
         except (json.JSONDecodeError, OSError) as load_error:  # WHY: narrow to expected failure classes.
@@ -160,7 +160,7 @@ class RateLimitingUtils:  # WHY: static-method facade groups rate-limit helpers 
         keys = list(data.keys()) if data else []  # WHY: log summary avoids leaking full payload.
         logging.debug("ENTRY: RateLimitingUtils._save_pid_tuning_data(data_keys=%s)", keys)  # WHY: entry trace.
         try:  # WHY: caller expects OSError on unwritable paths. Keep raise.
-            with open(tuning_data_file, "w") as file_handle:  # WHY: overwrite prior tuning snapshot atomically.
+            with open(tuning_data_file, "w", encoding="utf-8") as file_handle:  # WHY: overwrite the prior snapshot.
                 json.dump(data, file_handle, indent=2)  # WHY: indent keeps file diff-friendly.
             logging.debug("File I/O: Successfully wrote PID tuning data to %s", tuning_data_file)  # WHY: success log.
         except OSError as write_error:  # WHY: narrow catch. Upstream re-raise preserved.

--- a/tests/run_audit_integration.py
+++ b/tests/run_audit_integration.py
@@ -10,7 +10,7 @@ from src.audit.analyzer import AuditLogAnalyzer
 from src.audit.filter import AuditLogFilter
 from src.audit.renderer import AuditReportRenderer
 
-with open("data/orgaudit-filtered.json") as f:
+with open("data/orgaudit-filtered.json", encoding="utf-8") as f:
     data = json.load(f)
 
 entries = data["results"]

--- a/tests/unit/test_config_utils.py
+++ b/tests/unit/test_config_utils.py
@@ -135,13 +135,13 @@ class TestCheckStopSignal:
         assert ConfigUtils.check_stop_signal() is False
 
     def test_file_present_returns_true_and_deletes(self):
-        with open("stop_loop.txt", "w") as handle:
+        with open("stop_loop.txt", "w", encoding="utf-8") as handle:
             handle.write("")
         assert ConfigUtils.check_stop_signal() is True
         assert not os.path.exists("stop_loop.txt")
 
     def test_consumed_signal_returns_false_next_call(self):
-        with open("stop_loop.txt", "w") as handle:
+        with open("stop_loop.txt", "w", encoding="utf-8") as handle:
             handle.write("")
         ConfigUtils.check_stop_signal()
         assert ConfigUtils.check_stop_signal() is False
@@ -149,7 +149,7 @@ class TestCheckStopSignal:
     def test_loop_breaks_on_signal(self):
         sites = ["site_a", "site_b", "site_c"]
         processed = []
-        with open("stop_loop.txt", "w") as handle:
+        with open("stop_loop.txt", "w", encoding="utf-8") as handle:
             handle.write("")
         for site in sites:
             if ConfigUtils.check_stop_signal():

--- a/tests/unit/test_csv_comparator.py
+++ b/tests/unit/test_csv_comparator.py
@@ -882,7 +882,7 @@ class TestDataLoading:
         """List available CSV files excluding source."""
         with tempfile.TemporaryDirectory() as tmpdir:
             for name in ["test1.csv", "test2.csv", "AllDevicesWithSiteInfo.csv"]:
-                with open(os.path.join(tmpdir, name), "w") as fh:
+                with open(os.path.join(tmpdir, name), "w", encoding="utf-8") as fh:
                     fh.write("header\n")
             comp = _make_comparator()
             with patch("src.inventory.csv_comparator.glob.glob") as mock_glob:

--- a/tests/unit/test_data_browser_sqlite_handles.py
+++ b/tests/unit/test_data_browser_sqlite_handles.py
@@ -1,6 +1,6 @@
 """Regression tests for the SQLite handle release in the data browser service.
 
-Issue #1900. Each helper opened a SQLite connection and closed it on the success
+issue #1901. Each helper opened a SQLite connection and closed it on the success
 path only. An exception between the open call and the close call leaked the
 handle. A long-lived Gunicorn worker then reached the per-process descriptor
 limit and every later preview failed.

--- a/tests/unit/test_data_browser_sqlite_handles.py
+++ b/tests/unit/test_data_browser_sqlite_handles.py
@@ -1,0 +1,91 @@
+"""Regression tests for the SQLite handle release in the data browser service.
+
+Issue #1900. Each helper opened a SQLite connection and closed it on the success
+path only. An exception between the open call and the close call leaked the
+handle. A long-lived Gunicorn worker then reached the per-process descriptor
+limit and every later preview failed.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from web_portal.services.data_browser import DataBrowserService  # noqa: E402
+
+
+@pytest.fixture(name="service")
+def _service(tmp_path) -> DataBrowserService:
+    """Return a data browser service rooted at an empty temporary directory."""
+    return DataBrowserService(str(tmp_path))
+
+
+def _failing_connection() -> MagicMock:
+    """Return a connection mock that raises when the caller asks for a cursor."""
+    connection = MagicMock(name="sqlite_connection")
+    connection.cursor.side_effect = sqlite3.DatabaseError("database disk image is malformed")
+    return connection
+
+
+@pytest.mark.parametrize(
+    ("method_name", "arguments"),
+    [
+        ("_list_sqlite_tables", ("some.db",)),
+        ("_is_valid_table_name", ("some.db", "devices")),
+        ("_preview_sqlite", ("some.db", "devices", 1, 50, "")),
+    ],
+)
+def test_sqlite_handle_closes_when_the_query_fails(
+    service: DataBrowserService,
+    method_name: str,
+    arguments: tuple,
+) -> None:
+    """Verify each helper closes the connection after a query error."""
+    connection = _failing_connection()
+    with patch("web_portal.services.data_browser.sqlite3.connect", return_value=connection):
+        getattr(service, method_name)(*arguments)
+
+    connection.close.assert_called_once()
+
+
+def test_list_sqlite_tables_reports_the_error_instead_of_raising(service: DataBrowserService) -> None:
+    """Verify the caller still receives an error payload after a query error."""
+    with patch("web_portal.services.data_browser.sqlite3.connect", return_value=_failing_connection()):
+        result = service._list_sqlite_tables("some.db")
+
+    assert "error" in result
+
+
+def test_preview_sqlite_closes_the_handle_when_the_table_is_absent(tmp_path) -> None:
+    """Verify the empty-table early return still releases the connection."""
+    service = DataBrowserService(str(tmp_path))
+    connection = MagicMock(name="sqlite_connection")
+    connection.cursor.return_value.fetchall.return_value = []
+
+    with patch("web_portal.services.data_browser.sqlite3.connect", return_value=connection):
+        result = service._preview_sqlite("some.db", "missing", 1, 50, "")
+
+    assert result == {"error": "Table not found"}
+    connection.close.assert_called_once()
+
+
+def test_sqlite_helpers_close_the_handle_on_the_success_path(tmp_path) -> None:
+    """Verify a real database file still opens, answers, and closes."""
+    database_path = tmp_path / "sample.db"
+    with sqlite3.connect(database_path) as setup_connection:
+        setup_connection.execute("CREATE TABLE devices (id INTEGER PRIMARY KEY, name TEXT)")
+        setup_connection.execute("INSERT INTO devices (name) VALUES ('ap-01')")
+    setup_connection.close()
+
+    service = DataBrowserService(str(tmp_path))
+    listing = service._list_sqlite_tables(str(database_path))
+
+    assert [table["table_name"] for table in listing["tables"]] == ["devices"]
+    assert service._is_valid_table_name(str(database_path), "devices") is True
+    assert service._is_valid_table_name(str(database_path), "absent") is False

--- a/tests/unit/test_e911_bssid.py
+++ b/tests/unit/test_e911_bssid.py
@@ -511,7 +511,7 @@ class TestCheckpoint:
 
     def test_load_corrupt_json(self):
         """Corrupt JSON returns None."""
-        with open(E911BSSIDReportGenerator.CHECKPOINT_FILE, "w") as handle:
+        with open(E911BSSIDReportGenerator.CHECKPOINT_FILE, "w", encoding="utf-8") as handle:
             handle.write("not json{{{")
         assert E911BSSIDReportGenerator._load_checkpoint("org-1") is None
 

--- a/tests/unit/test_rate_limiting.py
+++ b/tests/unit/test_rate_limiting.py
@@ -100,7 +100,7 @@ class TestLoadPidTuningData:
 
         filepath = os.path.join("data", "tuning_data.json")
         test_data = {"k_p": 0.2, "k_i": 0.001, "error": [1.0, 2.0], "integral": 0.5}
-        with open(filepath, "w") as fh:
+        with open(filepath, "w", encoding="utf-8") as fh:
             json.dump(test_data, fh)
 
         original = rl.tuning_data_file
@@ -117,7 +117,7 @@ class TestLoadPidTuningData:
         import src.utils.rate_limiting as rl
 
         filepath = os.path.join("data", "tuning_data.json")
-        with open(filepath, "w") as fh:
+        with open(filepath, "w", encoding="utf-8") as fh:
             fh.write("{corrupt")
 
         original = rl.tuning_data_file
@@ -134,7 +134,7 @@ class TestLoadPidTuningData:
 
         filepath = os.path.join("data", "tuning_data.json")
         test_data = {"k_p": 0.1, "k_i": 0.001, "error": [1.0, None, 3.0], "integral": 0.0}
-        with open(filepath, "w") as fh:
+        with open(filepath, "w", encoding="utf-8") as fh:
             json.dump(test_data, fh)
 
         original = rl.tuning_data_file
@@ -162,7 +162,7 @@ class TestSavePidTuningData:
         try:
             test_data = {"k_p": 0.15, "k_i": 0.002, "error": [1.0], "integral": 0.3}
             RateLimitingUtils._save_pid_tuning_data(test_data)
-            with open(filepath) as fh:
+            with open(filepath, encoding="utf-8") as fh:
                 loaded = json.load(fh)
             assert loaded["k_p"] == 0.15
         finally:
@@ -277,7 +277,7 @@ class TestReadExistingEntries:
     def test_reads_jsonl_entries(self):
         """Reads JSONL entries correctly."""
         filepath = os.path.join("data", "test.jsonl")
-        with open(filepath, "w") as fh:
+        with open(filepath, "w", encoding="utf-8") as fh:
             fh.write('{"a": 1}\n{"b": 2}\n')
         result = RateLimitingUtils._read_existing_entries(filepath)
         assert len(result) == 2
@@ -286,7 +286,7 @@ class TestReadExistingEntries:
     def test_handles_corrupt_jsonl(self):
         """Returns empty list on corrupt JSONL."""
         filepath = os.path.join("data", "bad.jsonl")
-        with open(filepath, "w") as fh:
+        with open(filepath, "w", encoding="utf-8") as fh:
             fh.write("{corrupt\n")
         result = RateLimitingUtils._read_existing_entries(filepath)
         assert result == []
@@ -303,7 +303,7 @@ class TestAppendDelayMetricsLog:
         RateLimitingUtils._append_delay_metrics_log({"delay": 0.5}, {"used": 100}, {"k_p": 0.1})
         filepath = os.path.join("data", "delay_metrics.json")
         assert os.path.exists(filepath)
-        with open(filepath) as fh:
+        with open(filepath, encoding="utf-8") as fh:
             lines = [line.strip() for line in fh if line.strip()]
         assert len(lines) == 1
         entry = json.loads(lines[0])
@@ -315,7 +315,7 @@ class TestAppendDelayMetricsLog:
         filepath = os.path.join("data", "delay_metrics.json")
         for i in range(5):
             RateLimitingUtils._append_delay_metrics_log({"i": i}, {}, {}, max_entries=3)
-        with open(filepath) as fh:
+        with open(filepath, encoding="utf-8") as fh:
             lines = [line.strip() for line in fh if line.strip()]
         assert len(lines) == 3
 
@@ -551,7 +551,7 @@ class TestEdgeCases:
         import src.utils.rate_limiting as rl
 
         filepath = os.path.join("data", "tuning_data.json")
-        with open(filepath, "w") as fh:
+        with open(filepath, "w", encoding="utf-8") as fh:
             json.dump({"k_p": 0.1, "k_i": 0.001}, fh)
 
         original = rl.tuning_data_file
@@ -567,7 +567,7 @@ class TestEdgeCases:
         import src.utils.rate_limiting as rl
 
         filepath = os.path.join("data", "tuning_data.json")
-        with open(filepath, "w") as fh:
+        with open(filepath, "w", encoding="utf-8") as fh:
             json.dump({"k_p": 0.1, "k_i": 0.001, "error": "bad"}, fh)
 
         original = rl.tuning_data_file

--- a/tests/unit/test_ssid_template_consolidation.py
+++ b/tests/unit/test_ssid_template_consolidation.py
@@ -2429,7 +2429,7 @@ class TestCachePersistence:
         data = {"collected_at": "2025-01-01T00:00:00+00:00", "matrix": []}
         manager._save_cache(data)
         assert os.path.exists(cache_file)
-        with open(cache_file) as fh:
+        with open(cache_file, encoding="utf-8") as fh:
             loaded = json.load(fh)
         assert loaded["matrix"] == []
 
@@ -2444,7 +2444,7 @@ class TestCachePersistence:
         cache_file = os.path.join(str(tmp_path), "cache.json")
         manager.CACHE_FILE = cache_file
         data = {"collected_at": "2025-01-01T00:00:00+00:00", "matrix": []}
-        with open(cache_file, "w") as fh:
+        with open(cache_file, "w", encoding="utf-8") as fh:
             json.dump(data, fh)
         result = manager._load_cache()
         assert result is not None

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -364,7 +364,7 @@ class TestTelemetryEmitterRetention:
         data_dir = str(tmp_path / "data")
         os.makedirs(data_dir)
         for i in range(15):
-            with open(os.path.join(data_dir, f"test_events_{i:04d}.jsonl"), "w") as handle:
+            with open(os.path.join(data_dir, f"test_events_{i:04d}.jsonl"), "w", encoding="utf-8") as handle:
                 handle.write("{}\n")
         emitter = TelemetryEmitter(os.path.join(data_dir, "current.jsonl"))
         emitter.enforce_retention(directory=data_dir, limit=10)
@@ -385,7 +385,7 @@ class TestTelemetryEmitterRetention:
         data_dir = str(tmp_path / "data")
         os.makedirs(data_dir)
         for i in range(3):
-            with open(os.path.join(data_dir, f"test_events_{i:04d}.jsonl"), "w") as handle:
+            with open(os.path.join(data_dir, f"test_events_{i:04d}.jsonl"), "w", encoding="utf-8") as handle:
                 handle.write("{}\n")
         emitter = TelemetryEmitter(os.path.join(data_dir, "current.jsonl"))
         emitter.enforce_retention(directory=data_dir, limit=10)

--- a/web_portal/services/data_browser.py
+++ b/web_portal/services/data_browser.py
@@ -189,7 +189,7 @@ class DataBrowserService:
     def _list_sqlite_tables(self, filepath: str) -> dict:
         """List tables and metadata in a SQLite database."""
         try:
-            # WHY: closing() releases the handle on the error path too (issue #1900).
+            # WHY: closing() releases the handle on the error path too (issue #1901).
             with closing(sqlite3.connect(f"file:{filepath}?mode=ro", uri=True)) as conn:
                 cursor = conn.cursor()
                 cursor.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
@@ -221,7 +221,7 @@ class DataBrowserService:
     def _is_valid_table_name(self, filepath: str, table_name: str) -> bool:
         """Validate table_name exists in the database to prevent SQL injection."""
         try:
-            # WHY: closing() releases the handle on the error path too (issue #1900).
+            # WHY: closing() releases the handle on the error path too (issue #1901).
             with closing(sqlite3.connect(f"file:{filepath}?mode=ro", uri=True)) as conn:
                 cursor = conn.cursor()
                 cursor.execute(
@@ -235,7 +235,7 @@ class DataBrowserService:
     def _preview_sqlite(self, filepath: str, table_name: str, page: int, per_page: int, search: str) -> dict:
         """Read and paginate rows from a SQLite table."""
         try:
-            # WHY: closing() releases the handle on the error path too (issue #1900).
+            # WHY: closing() releases the handle on the error path too (issue #1901).
             with closing(sqlite3.connect(f"file:{filepath}?mode=ro", uri=True)) as conn:
                 cursor = conn.cursor()
                 cursor.execute(f'PRAGMA table_info("{table_name}")')  # nosec B608 — validated

--- a/web_portal/services/data_browser.py
+++ b/web_portal/services/data_browser.py
@@ -8,6 +8,7 @@ import csv
 import math
 import os
 import sqlite3
+from contextlib import closing
 
 ALLOWED_EXTENSIONS = {".csv", ".db", ".sqlite", ".log", ".json"}
 
@@ -188,15 +189,15 @@ class DataBrowserService:
     def _list_sqlite_tables(self, filepath: str) -> dict:
         """List tables and metadata in a SQLite database."""
         try:
-            conn = sqlite3.connect(f"file:{filepath}?mode=ro", uri=True)
-            cursor = conn.cursor()
-            cursor.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
-            tables = []
-            for (name,) in cursor.fetchall():
-                info = self._get_table_info(conn, name)
-                tables.append(info)
-            conn.close()
-            return {"tables": tables}
+            # WHY: closing() releases the handle on the error path too (issue #1900).
+            with closing(sqlite3.connect(f"file:{filepath}?mode=ro", uri=True)) as conn:
+                cursor = conn.cursor()
+                cursor.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+                tables = []
+                for (name,) in cursor.fetchall():
+                    info = self._get_table_info(conn, name)
+                    tables.append(info)
+                return {"tables": tables}
         except Exception as exc:
             return {"error": f"Failed to read SQLite: {exc}"}
 
@@ -220,32 +221,29 @@ class DataBrowserService:
     def _is_valid_table_name(self, filepath: str, table_name: str) -> bool:
         """Validate table_name exists in the database to prevent SQL injection."""
         try:
-            conn = sqlite3.connect(f"file:{filepath}?mode=ro", uri=True)
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
-                (table_name,),
-            )
-            exists = cursor.fetchone() is not None
-            conn.close()
-            return exists
+            # WHY: closing() releases the handle on the error path too (issue #1900).
+            with closing(sqlite3.connect(f"file:{filepath}?mode=ro", uri=True)) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                    (table_name,),
+                )
+                return cursor.fetchone() is not None
         except Exception:
             return False
 
     def _preview_sqlite(self, filepath: str, table_name: str, page: int, per_page: int, search: str) -> dict:
         """Read and paginate rows from a SQLite table."""
         try:
-            conn = sqlite3.connect(f"file:{filepath}?mode=ro", uri=True)
-            cursor = conn.cursor()
-            cursor.execute(f'PRAGMA table_info("{table_name}")')  # nosec B608 — validated
-            col_info = cursor.fetchall()
-            if not col_info:
-                conn.close()
-                return {"error": "Table not found"}
-            columns = [row[1] for row in col_info]
-            result = self._query_sqlite_page(conn, table_name, columns, page, per_page, search)
-            conn.close()
-            return result
+            # WHY: closing() releases the handle on the error path too (issue #1900).
+            with closing(sqlite3.connect(f"file:{filepath}?mode=ro", uri=True)) as conn:
+                cursor = conn.cursor()
+                cursor.execute(f'PRAGMA table_info("{table_name}")')  # nosec B608 — validated
+                col_info = cursor.fetchall()
+                if not col_info:
+                    return {"error": "Table not found"}
+                columns = [row[1] for row in col_info]
+                return self._query_sqlite_page(conn, table_name, columns, page, per_page, search)
         except Exception as exc:
             return {"error": f"Failed to read SQLite table: {exc}"}
 


### PR DESCRIPTION
Closes #1901
Part of #1795

## What this changes

Two production defects, both about a resource that the code does not control
explicitly.

### 1. Text-mode `open()` used the platform default encoding

33 call sites opened a file in text mode with no `encoding` argument. Python
then uses the platform default. Windows returns `cp1252`. Linux returns
`utf-8`.

MistHelper runs on a Windows workstation and inside a Linux container. The
adaptive delay metrics in `src/utils/rate_limiting.py` and the project
configuration in `src/config/config_utils.py` move between the two hosts. A
file written under `cp1252` does not read back the same under `utf-8`. Every
character above code point 127 changes or raises a decode error.

This change adds `encoding="utf-8"` to all 33 sites and enables ruff
`PLW1514` so a bare `open()` cannot return. `PLW1514` is a preview rule, so
the config sets `preview` together with `explicit-preview-rules`. That pair
enables only the codes named in `select`, so no other preview rule reaches the
gate.

This clears the `W1514` family that issue #1795 lists. The other four families
in #1795 stay open.

### 2. Three SQLite helpers leaked the connection on the error path

`web_portal/services/data_browser.py` closed each connection on the success
path only. An error between `sqlite3.connect` and `close` skipped the close.
The web portal runs under Gunicorn, so a worker accumulated descriptors until it
reached the per-process limit.

`contextlib.closing` now releases the handle on both paths.

## Verification

| Check | Result |
| - | - |
| `python -m ruff check .` | All checks passed |
| `python -m black --check` | 14 files unchanged |
| `python -m py_compile` | clean |
| `python -m tools.symbol_diff --base HEAD` | 0 lost names |
| `pytest` on the touched modules | 86 passed |
| `pytest tests/unit/test_data_browser_sqlite_handles.py` | 6 passed |

The new test proves the defect. Against the pre-fix `data_browser.py` three of
the six tests fail. All six pass after the fix.

The encoding change is mechanical. Every one of the 33 changed lines gained
`encoding="utf-8"` and nothing else. Two lines in `rate_limiting.py` then
passed 120 columns, so their inline comments are shorter.

## Notes

No `CHANGELOG.md` entry. Issue #1899 records that every concurrent pull
request collides on the changelog head. Ask and I will add one.