### PR TITLE
fix(ops-platform): bound the pagination loop and stop a repeated cursor

### DIFF
--- a/mist-ops-platform/src/shared/mist/endpoints.py
+++ b/mist-ops-platform/src/shared/mist/endpoints.py
@@ -18,6 +18,10 @@ from src.shared.mist.types import MistEndpoint, MistEntityRegistry
 
 logger = logging.getLogger(__name__)
 
+# WHY: bound the pagination loop so one endpoint cannot exhaust the worker heap.
+# A sync of a large organization stays well under this count. Issue #1903.
+MAX_PAGINATION_PAGES = 500
+
 
 @dataclass(frozen=True, slots=True)
 class ApiResult:
@@ -132,14 +136,40 @@ class MistEndpointService:
         return ApiResult(status_code=status, data=data)
 
     def _paginate(self, func: Any, args: dict[str, str]) -> list:
-        """Follow SDK pagination until all pages retrieved."""
+        """Follow SDK pagination until the last page, the page limit, or a repeat."""
         all_data: list = []
         response = func(self._session, **args)
         all_data.extend(self._extract_list(response))
-        while getattr(response, "next", None):
-            response = func(self._session, **args, next=response.next)
+        seen_cursors: set[str] = set()  # WHY: a repeated cursor means the API is looping.
+        pages = 1  # WHY: the first page is already in all_data.
+        while cursor := getattr(response, "next", None):
+            if not self._accept_cursor(cursor, seen_cursors, pages, func):
+                break  # WHY: the guard already logged the reason.
+            response = func(self._session, **args, next=cursor)
             all_data.extend(self._extract_list(response))
+            pages += 1  # WHY: count the page against MAX_PAGINATION_PAGES.
         return all_data
+
+    @staticmethod
+    def _accept_cursor(cursor: Any, seen: set[str], pages: int, func: Any) -> bool:
+        """Return True when the loop may fetch one more page."""
+        name = getattr(func, "__name__", "unknown")  # WHY: name the endpoint in the log.
+        if pages >= MAX_PAGINATION_PAGES:  # WHY: bound the heap and the run time.
+            logger.warning(
+                "Pagination for %s stopped at the %d page limit. The result is incomplete.",
+                name,
+                MAX_PAGINATION_PAGES,
+            )
+            return False
+        key = str(cursor)  # WHY: the cursor may be any type the SDK returns.
+        if key in seen:  # WHY: a repeat means the loop would never end.
+            logger.error(
+                "Pagination for %s repeated a cursor. Stopping to avoid an endless loop.",
+                name,
+            )
+            return False
+        seen.add(key)  # WHY: record the cursor before the next call.
+        return True
 
     @staticmethod
     def _extract_list(response: Any) -> list:

--- a/mist-ops-platform/tests/unit/mist/test_pagination_guards.py
+++ b/mist-ops-platform/tests/unit/mist/test_pagination_guards.py
@@ -1,0 +1,162 @@
+"""Tests for the pagination guards in ``MistEndpointService._paginate``.
+
+Issue #1903. The loop followed the ``next`` cursor with no page limit and no
+cycle guard. A repeated cursor made the loop run forever and grow the worker
+heap until the operating system stopped the process.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from src.shared.mist.endpoints import MAX_PAGINATION_PAGES, MistEndpointService
+from src.shared.mist.types import MistEndpoint, MistEntityRegistry
+
+_ENDPOINT = MistEndpoint(
+    entity_type="org_site_list",
+    api_module="orgs.sites",
+    read_method=None,
+    write_method=None,
+    id_params=("org_id",),
+    list_method="listOrgSites",
+)
+
+
+def _make_response(data: list, next_url: str | None = None) -> SimpleNamespace:
+    """Create a mock SDK response object."""
+    return SimpleNamespace(status_code=200, data=data, next=next_url)
+
+
+def _run(service: MistEndpointService, mock_func: MagicMock):
+    """Call list_all_entities with the registry and resolver patched out."""
+    with (
+        patch.object(service, "_resolve_func", return_value=mock_func),
+        patch.object(MistEntityRegistry, "get", return_value=_ENDPOINT),
+    ):
+        return service.list_all_entities("org_site_list", {"org_id": "test-org"})
+
+
+EXPECTED_CALLS_ON_REPEAT = 2
+EXPECTED_CALLS_ON_ALTERNATING_PAIR = 3
+EXPECTED_CALLS_FOR_THREE_PAGES = 3
+
+
+class TestPaginationCycleGuard:
+    """Verify a repeated cursor ends the loop instead of running forever."""
+
+    def test_a_repeated_cursor_stops_the_loop(self) -> None:
+        """A server that always returns the same cursor must not hang the worker."""
+        service = MistEndpointService(MagicMock())
+        # WHY: every page points back at the same cursor, so the old loop never ended.
+        mock_func = MagicMock(return_value=_make_response([{"id": "a"}], next_url="/same"))
+
+        result = _run(service, mock_func)
+
+        assert mock_func.call_count == EXPECTED_CALLS_ON_REPEAT
+        assert result.data == [{"id": "a"}, {"id": "a"}]
+
+    def test_the_repeat_is_logged_as_an_error(self, caplog) -> None:
+        """The operator needs the endpoint name when the loop stops early."""
+        service = MistEndpointService(MagicMock())
+        mock_func = MagicMock(return_value=_make_response([{"id": "a"}], next_url="/same"))
+
+        with caplog.at_level(logging.ERROR):
+            _run(service, mock_func)
+
+        assert "repeated a cursor" in caplog.text
+
+    def test_an_alternating_cursor_pair_stops_the_loop(self) -> None:
+        """Two cursors that point at each other must not run forever."""
+        service = MistEndpointService(MagicMock())
+        pages = [
+            _make_response([{"id": "a"}], next_url="/one"),
+            _make_response([{"id": "b"}], next_url="/two"),
+            _make_response([{"id": "c"}], next_url="/one"),
+            _make_response([{"id": "d"}], next_url="/two"),
+        ]
+        mock_func = MagicMock(side_effect=pages)
+
+        result = _run(service, mock_func)
+
+        # WHY: /one and /two are both seen, so the third repeat ends the loop.
+        assert mock_func.call_count == EXPECTED_CALLS_ON_ALTERNATING_PAIR
+        assert result.data == [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+
+
+class TestPaginationPageLimit:
+    """Verify the loop stops at the configured page limit."""
+
+    def test_the_loop_stops_at_the_page_limit(self) -> None:
+        """A stream of unique cursors must still stop at MAX_PAGINATION_PAGES."""
+        service = MistEndpointService(MagicMock())
+        counter = {"page": 0}
+
+        def _next_page(*_args, **_kwargs) -> SimpleNamespace:
+            counter["page"] += 1
+            return _make_response([{"id": counter["page"]}], next_url=f"/page{counter['page']}")
+
+        mock_func = MagicMock(side_effect=_next_page)
+
+        result = _run(service, mock_func)
+
+        assert mock_func.call_count == MAX_PAGINATION_PAGES
+        assert len(result.data) == MAX_PAGINATION_PAGES
+
+    def test_the_limit_is_logged_as_a_warning(self, caplog) -> None:
+        """An incomplete result must announce itself."""
+        service = MistEndpointService(MagicMock())
+        counter = {"page": 0}
+
+        def _next_page(*_args, **_kwargs) -> SimpleNamespace:
+            counter["page"] += 1
+            return _make_response([{"id": counter["page"]}], next_url=f"/page{counter['page']}")
+
+        with caplog.at_level(logging.WARNING):
+            _run(service, MagicMock(side_effect=_next_page))
+
+        assert "page limit" in caplog.text
+
+
+class TestPaginationNormalPathIsUnchanged:
+    """Verify the guards do not change a healthy pagination run."""
+
+    def test_a_single_page_still_returns_one_call(self) -> None:
+        """A response with no cursor must not trigger a second call."""
+        service = MistEndpointService(MagicMock())
+        mock_func = MagicMock(return_value=_make_response([{"id": "a"}]))
+
+        result = _run(service, mock_func)
+
+        assert mock_func.call_count == 1
+        assert result.data == [{"id": "a"}]
+
+    def test_three_distinct_pages_all_load(self) -> None:
+        """Distinct cursors must still walk to the last page."""
+        service = MistEndpointService(MagicMock())
+        pages = [
+            _make_response([{"id": "a"}], next_url="/page2"),
+            _make_response([{"id": "b"}], next_url="/page3"),
+            _make_response([{"id": "c"}]),
+        ]
+        mock_func = MagicMock(side_effect=pages)
+
+        result = _run(service, mock_func)
+
+        assert mock_func.call_count == EXPECTED_CALLS_FOR_THREE_PAGES
+        assert result.data == [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+
+
+class TestPaginationEmptyCursor:
+    """Verify an empty cursor ends the loop."""
+
+    def test_an_empty_cursor_ends_the_loop(self) -> None:
+        """An empty string cursor must end the loop as it did before."""
+        service = MistEndpointService(MagicMock())
+        mock_func = MagicMock(return_value=_make_response([{"id": "a"}], next_url=""))
+
+        result = _run(service, mock_func)
+
+        assert mock_func.call_count == 1
+        assert result.data == [{"id": "a"}]


### PR DESCRIPTION
Closes #1903

## What this changes

`MistEndpointService._paginate` followed the Mist `next` cursor with two
faults.

1. No page limit. The loop ran while the response carried a cursor.
2. No cycle guard. The loop kept no memory of the cursors it already read, so a
   repeated cursor made it run forever.

The method also collected every page in one list, so the heap grew with the
total result size.

This change adds `MAX_PAGINATION_PAGES = 500` and a `seen_cursors` set. The
loop now stops at the limit or at the first repeat, and it logs the endpoint
name with the reason.

## Proof the defect was real

A script called the pre-fix `_paginate` with an alternating cursor pair
(`/one` then `/two` then `/one` then `/two`).

Against the pre-fix code:

```text
RESULT: the loop exhausted all 5 pages and asked for one more.
VERDICT: no cycle guard. The loop would never end against a live server.
```

Against this branch:

```text
RESULT: the loop stopped after 3 calls and returned 3 rows.
VERDICT: a cycle guard stopped the loop.
Pagination for unknown repeated a cursor. Stopping to avoid an endless loop.
```

## Verification

| Check | Result |
| - | - |
| `python -m py_compile` | clean |
| `python -m ruff check` (both changed files) | no new finding |
| `python -m black --check` | 2 files unchanged |
| `pytest tests/unit/mist/test_pagination_guards.py` | 8 passed |
| `pytest tests/unit/mist/test_pagination.py` | 4 passed, unchanged |

The 8 new tests cover a repeated cursor, an alternating cursor pair, the page
limit, both log messages, and three healthy paths. The healthy paths assert the
call count and the row order, so the guards cannot silently truncate a normal
run. An empty string cursor still ends the loop, as it did before.

Ruff reports three findings in `endpoints.py` at lines 15 and 36. Both lines
predate this branch and neither is touched here.

## Notes on the test environment

`.github/workflows/ci.yml` does not reference `mist-ops-platform`, so no CI
gate runs this suite today. #1895 and PR #1898 add that gate. I ran the suite
locally instead.

`mistapi` would not install through the corporate proxy during this session,
so the local run used a stub for the SDK import. The pagination guards never
call the SDK. They read the `next` attribute of the response object, and the
tests supply that object, so the stub does not weaken the result. Once PR #1898
lands, this suite runs against the real package in CI.