### PR TITLE
fix(ops-platform): restore the missing shared constants module

### DIFF
--- a/mist-ops-platform/src/shared/config/constants.py
+++ b/mist-ops-platform/src/shared/config/constants.py
@@ -1,0 +1,118 @@
+"""Shared enumerations for the ops platform.
+
+Nine modules import a name from this module. The module holds the string
+constants that the API routes, the worker tasks, and the database rows share.
+
+Every class derives from `StrEnum`. A `StrEnum` member compares equal to a
+plain string, so a member passes straight into a SQLAlchemy column and into a
+JSON body. Each member also keeps a `.value` attribute, and the callers in
+this repository read that attribute.
+
+Warning: A value in this module is a stored database value. Do not rename a
+value. A rename orphans every row that already holds the old text.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = [
+    "AlertSeverity",
+    "AlertType",
+    "DeviceType",
+    "EntityType",
+    "GoldenImageStatus",
+    "JobStatus",
+    "WaveStatus",
+]
+
+
+class JobStatus(StrEnum):
+    """The lifecycle state of a scheduled deploy job.
+
+    The `scheduled_jobs.status` column stores the value. The column is a
+    `String(30)`, so every value here stays below 30 characters.
+
+    The happy path runs PENDING, APPROVED, PRE_CHECK, EXECUTING, POST_CHECK,
+    and then COMPLETED. A failure moves the job to FAILED, and a rollback then
+    moves the job to ROLLED_BACK. CANCELLED is a terminal state.
+    """
+
+    PENDING = "pending"  # The operator created the job, and nobody approved it yet.
+    APPROVED = "approved"  # An approver released the job, so the worker can claim it.
+    PRE_CHECK = "pre_check"  # The worker runs the pre-checks against the target devices.
+    EXECUTING = "executing"  # The worker pushes the change to the target devices.
+    POST_CHECK = "post_check"  # The worker verifies the change on the target devices.
+    COMPLETED = "completed"  # Every wave finished, and every post-check passed.
+    FAILED = "failed"  # A check failed or a push failed, so the job stopped.
+    ROLLED_BACK = "rolled_back"  # The worker restored the previous configuration.
+    CANCELLED = "cancelled"  # An operator stopped the job before the worker claimed it.
+
+
+class WaveStatus(StrEnum):
+    """The lifecycle state of one deployment wave inside a rollout plan.
+
+    The `deployment_waves.status` column stores the value. The column is a
+    `String(20)`, so every value here stays below 20 characters.
+    """
+
+    PENDING = "pending"  # The wave waits for the previous wave to complete.
+    EXECUTING = "executing"  # The worker pushes the change to the devices of this wave.
+    COMPLETED = "completed"  # Every device of this wave took the change.
+    FAILED = "failed"  # At least one device of this wave rejected the change.
+
+
+class GoldenImageStatus(StrEnum):
+    """The lifecycle state of a golden firmware image.
+
+    The `golden_images.lifecycle_state` column stores the value, and that
+    column carries the server default `draft`. A firmware deployment accepts
+    the APPROVED state only.
+    """
+
+    DRAFT = "draft"  # An operator registered the image, and nobody approved it yet.
+    APPROVED = "approved"  # An approver cleared the image for a firmware deployment.
+    RETIRED = "retired"  # The image is out of service, so no deployment may use it.
+
+
+class EntityType(StrEnum):
+    """The kind of Mist entity that a sync job or a config revision targets.
+
+    The `config_revisions.entity_type` column and the `sync_jobs.job_type`
+    column store the value. Both columns are a `String(30)`.
+    """
+
+    DEVICE = "device"  # One access point, switch, or gateway inside an organization.
+    SITE = "site"  # One physical location that holds a group of devices.
+    ORG = "org"  # The whole organization, which owns every site and every device.
+
+
+class DeviceType(StrEnum):
+    """The hardware class of one Mist device.
+
+    The `devices.device_type` column stores the value. The column is a
+    `String(20)`.
+    """
+
+    AP = "ap"  # A wireless access point.
+    SWITCH = "switch"  # A wired switch.
+    GATEWAY = "gateway"  # An edge gateway or a router.
+
+
+class AlertSeverity(StrEnum):
+    """The urgency of a drift alert or a notification.
+
+    A notification route reads the value and picks the delivery channel.
+    """
+
+    CRITICAL = "critical"  # The condition breaks service, so an operator must act now.
+    WARNING = "warning"  # The condition risks service, so an operator must act soon.
+    INFO = "info"  # The condition needs no action, and the record is for history only.
+
+
+class AlertType(StrEnum):
+    """The subject of an alert that the platform raises."""
+
+    DRIFT = "drift"  # A device configuration no longer matches its baseline.
+    DEPLOY = "deploy"  # A deploy job changed state, or a deploy job failed.
+    SYNC = "sync"  # A sync job could not read the Mist inventory.

--- a/mist-ops-platform/tests/unit/shared/test_constants.py
+++ b/mist-ops-platform/tests/unit/shared/test_constants.py
@@ -1,0 +1,148 @@
+"""Unit tests for the shared enumerations in `src.shared.config.constants`.
+
+The root `.gitignore` once hid the whole `src/shared/config/` package, so the
+module disappeared and nine importers broke. See issue #1900. These tests fail
+if the module disappears again, and they fail if a stored value changes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.shared.config.constants import (
+    AlertSeverity,
+    AlertType,
+    DeviceType,
+    EntityType,
+    GoldenImageStatus,
+    JobStatus,
+    WaveStatus,
+)
+
+# The `scheduled_jobs.status` column is a String(30), so a longer value truncates.
+JOB_STATUS_COLUMN_WIDTH = 30
+# The `deployment_waves.status` column is a String(20), so a longer value truncates.
+WAVE_STATUS_COLUMN_WIDTH = 20
+# The documented job lifecycle holds nine states, and a new state needs a migration.
+EXPECTED_JOB_STATUS_COUNT = 9
+
+
+class TestJobStatus:
+    """Pin the nine states of a scheduled deploy job."""
+
+    @pytest.mark.parametrize(
+        ("member", "expected"),
+        [
+            (JobStatus.PENDING, "pending"),
+            (JobStatus.APPROVED, "approved"),
+            (JobStatus.PRE_CHECK, "pre_check"),
+            (JobStatus.EXECUTING, "executing"),
+            (JobStatus.POST_CHECK, "post_check"),
+            (JobStatus.COMPLETED, "completed"),
+            (JobStatus.FAILED, "failed"),
+            (JobStatus.ROLLED_BACK, "rolled_back"),
+            (JobStatus.CANCELLED, "cancelled"),
+        ],
+    )
+    def test_value_matches_the_stored_text(self, member: JobStatus, expected: str) -> None:
+        """The database rows hold this text, so a rename orphans those rows."""
+        assert member.value == expected  # Compare the member value against the stored text.
+
+    def test_the_set_is_complete(self) -> None:
+        """A new state needs a migration, so the count guards an accidental addition."""
+        assert len(JobStatus) == EXPECTED_JOB_STATUS_COUNT  # Guard an accidental addition.
+
+    def test_every_value_fits_the_column(self) -> None:
+        """The `scheduled_jobs.status` column is a String(30)."""
+        for member in JobStatus:  # Walk every member of the enumeration.
+            assert len(member.value) <= JOB_STATUS_COLUMN_WIDTH  # Reject a truncated value.
+
+
+class TestWaveStatus:
+    """Pin the four states of one deployment wave."""
+
+    def test_values_match_the_stored_text(self) -> None:
+        """The rollout worker writes this text into `deployment_waves.status`."""
+        assert WaveStatus.PENDING.value == "pending"  # The wave waits for its turn.
+        assert WaveStatus.EXECUTING.value == "executing"  # The worker pushes the change.
+        assert WaveStatus.COMPLETED.value == "completed"  # Every device took the change.
+        assert WaveStatus.FAILED.value == "failed"  # At least one device rejected it.
+
+    def test_every_value_fits_the_column(self) -> None:
+        """The `deployment_waves.status` column is a String(20)."""
+        for member in WaveStatus:  # Walk every member of the enumeration.
+            assert len(member.value) <= WAVE_STATUS_COLUMN_WIDTH  # Reject a truncated value.
+
+
+class TestGoldenImageStatus:
+    """Pin the three states of a golden firmware image."""
+
+    def test_values_match_the_stored_text(self) -> None:
+        """The `golden_images.lifecycle_state` column holds this text."""
+        assert GoldenImageStatus.DRAFT.value == "draft"  # The server default is `draft`.
+        assert GoldenImageStatus.APPROVED.value == "approved"  # A deployment needs this.
+        assert GoldenImageStatus.RETIRED.value == "retired"  # The image is out of service.
+
+
+class TestEntityType:
+    """Pin the entity kinds that a sync job and a config revision use."""
+
+    def test_values_match_the_stored_text(self) -> None:
+        """The sync worker writes this text into `sync_jobs.job_type`."""
+        assert EntityType.DEVICE.value == "device"  # One access point, switch, or gateway.
+        assert EntityType.SITE.value == "site"  # One physical location.
+        assert EntityType.ORG.value == "org"  # The whole organization.
+
+
+class TestDeviceType:
+    """Pin the hardware classes that the inventory sync writes."""
+
+    def test_values_match_the_stored_text(self) -> None:
+        """The `devices.device_type` column holds this text."""
+        assert DeviceType.AP.value == "ap"  # A wireless access point.
+        assert DeviceType.SWITCH.value == "switch"  # A wired switch.
+        assert DeviceType.GATEWAY.value == "gateway"  # An edge gateway or a router.
+
+
+class TestAlertEnums:
+    """Pin the alert urgency values and the alert subject values."""
+
+    def test_severity_values(self) -> None:
+        """A notification route reads the urgency and picks a channel."""
+        assert AlertSeverity.CRITICAL.value == "critical"  # An operator must act now.
+        assert AlertSeverity.WARNING.value == "warning"  # An operator must act soon.
+        assert AlertSeverity.INFO.value == "info"  # The record is for history only.
+
+    def test_type_values(self) -> None:
+        """The alert subject tells the operator which subsystem raised the alert."""
+        assert AlertType.DRIFT.value == "drift"  # A device left its baseline.
+        assert AlertType.DEPLOY.value == "deploy"  # A deploy job changed state.
+        assert AlertType.SYNC.value == "sync"  # A sync job could not read the inventory.
+
+
+class TestStringSubclassContract:
+    """Prove that a member passes straight into a column and into a JSON body."""
+
+    def test_a_member_compares_equal_to_a_plain_string(self) -> None:
+        """The callers mix a member and a plain string in the same comparison."""
+        assert JobStatus.PENDING == "pending"  # A StrEnum member compares by its text.
+        assert DeviceType.AP == "ap"  # The same contract holds for every enumeration.
+
+    def test_str_returns_the_stored_text(self) -> None:
+        """A format call must not produce the `JobStatus.PENDING` repr text."""
+        assert str(JobStatus.PENDING) == "pending"  # StrEnum coerces to the stored text.
+        assert f"{DeviceType.AP}" == "ap"  # An f-string must yield the same stored text.
+
+    def test_every_member_is_a_string(self) -> None:
+        """A non-string member breaks the SQLAlchemy bind and the JSON encoder."""
+        for enumeration in (
+            AlertSeverity,
+            AlertType,
+            DeviceType,
+            EntityType,
+            GoldenImageStatus,
+            JobStatus,
+            WaveStatus,
+        ):  # Walk each enumeration that this module exports.
+            for member in enumeration:  # Walk every member of that enumeration.
+                assert isinstance(member.value, str)  # Reject a non-string value.


### PR DESCRIPTION
Fixes #1900

## Problem

`mist-ops-platform/src/shared/config/constants.py` was absent from the repository, and nine modules import a name from it. The service could not import, and eight tests could not collect.

The root `.gitignore` holds `config/` at line 244. That rule targets a build output directory, but it matches every `config/` directory at any depth. The rule therefore excluded the whole `src/shared/config/` package.

## Fix

This change adds `constants.py` with the seven enumerations that the importers need.

| Enumeration | Members |
| - | - |
| `JobStatus` | pending, approved, pre_check, executing, post_check, completed, failed, rolled_back, cancelled |
| `WaveStatus` | pending, executing, completed, failed |
| `GoldenImageStatus` | draft, approved, retired |
| `EntityType` | device, site, org |
| `DeviceType` | ap, switch, gateway |
| `AlertSeverity` | critical, warning, info |
| `AlertType` | drift, deploy, sync |

Every value comes from the code that already stores it. `GoldenImageStatus` matches the three literals in `src/api/routes/deploy.py` at lines 571, 599, and 621. The `JobStatus` values match the assertions in `tests/integration/test_deploy_jobs.py`. Each value also fits the column width that `src/shared/models/` declares.

The classes derive from `StrEnum`, so a member coerces to its stored text. Ruff rule `replace-str-enum` requires that base on this Python target.

The commit force-adds the file past the ignore rule. A tracked file stays tracked, so the rule cannot hide it again.

## Conflict avoidance

Pull request #1871 restores `settings.py` and `__init__.py` in the same package, and it adds the negation rule to `mist-ops-platform/.gitignore`. This change adds `constants.py` only and touches no ignore file, so the two changes do not conflict. Python resolves `src.shared.config.constants` through a namespace package until #1871 lands.

## Tests

New file `mist-ops-platform/tests/unit/shared/test_constants.py`, 21 tests. The tests pin every stored value, the member count of `JobStatus`, both column-width limits, and the `StrEnum` coercion contract. Every test fails before this change, because the import raises `ModuleNotFoundError`.

## Validation

| Command | Result |
| - | - |
| `python -m py_compile` on both files | exit 0 |
| `python -m ruff check` on both files | All checks passed |
| `python -m black --check` on both files | 2 files would be left unchanged |
| `python -m pytest tests/unit/shared/test_constants.py -q` | 21 passed |
| import of all seven names | all seven names import OK |

Note: `tests/unit/shared/test_models_inventory.py` still cannot collect in this local environment, because `sqlalchemy` is absent from the interpreter. The constants import in that module now resolves, and the collection error moved to the `sqlalchemy` import.
