### PR TITLE
fix(web-portal): stop the heartbeat thread and drain the operation pool on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,46 @@ Version 26.08.23.01.26
   `config/` keeps that package out of git and every clean checkout fails to
   import the worker modules.
 
+### Add a graceful shutdown path to the web portal (issue #1861)
+
+- **Defect (Fixed)**: nothing called `PortalEventBus.stop()` or shut down the
+  `OperationExecutor` thread pool. A restart sent `SIGTERM`, Gunicorn killed the
+  worker, an in-flight operation aborted mid-run, and the heartbeat thread
+  leaked past the worker exit.
+- **Heartbeat thread (Changed)**: `PortalEventBus._heartbeat_loop` now waits on
+  a `threading.Event` instead of `time.sleep(30)`. `stop()` sets the event, so
+  the thread exits within a bounded join instead of up to 30 seconds later.
+  A second `stop()` call is a no-op, so a duplicate shutdown signal is safe.
+- **Operation pool (Added)**: `OperationExecutor.shutdown()` waits for every
+  in-flight run's future, up to a bounded grace period, then closes the thread
+  pool. A second `shutdown()` call is a no-op.
+- **Shutdown wiring (Added)**: `WebPortalApp.create_app` registers one
+  `atexit` hook through `WebPortalApp._register_shutdown_hook`. Gunicorn never
+  runs `if __name__ == "__main__"`, so the hook calls the new
+  `WebPortalApp.shutdown_app` function, which stops the event bus and drains
+  the operation pool. `shutdown_app` is idempotent, so a duplicate call at
+  process exit does not raise.
+- **Grace period (Added)**: `PORTAL_OPERATION_SHUTDOWN_GRACE_SECONDS` defaults
+  to 30 seconds. `deploy/.env.example` documents it.
+  `container/scripts/start.sh` reads the same value for the Gunicorn
+  `--graceful-timeout` flag, so Python and Gunicorn agree on the drain time.
+- **Container cleanup (Changed)**: `container/scripts/start.sh` `cleanup()` now
+  waits for Gunicorn and sshd to exit, bounded by the grace period plus a
+  10-second margin, then sends `SIGKILL` if a process still runs. The old code
+  sent one `kill` signal and returned right away, so it never confirmed a
+  drain.
+- **Quadlet timeout (Changed)**: `deploy/misthelper.container` sets
+  `TimeoutStopSec=60`, so systemd waits long enough for the bounded shutdown
+  chain to finish before it forces a kill.
+- **Tests (Added)**: `tests/unit/web_portal/test_portal_graceful_shutdown.py`
+  holds 9 tests. They prove the heartbeat thread ends after `stop()`, that
+  `OperationExecutor.shutdown()` closes the pool and waits for a short
+  in-flight run, that `WebPortalApp.shutdown_app` stops both the event bus and
+  the operation executor for a real app, and that every shutdown path is safe
+  to call twice. `tests/e2e/conftest.py` now tears its session-scoped Flask app
+  down through `shutdown_app`, so the long-lived test fixture no longer leaks
+  its own heartbeat thread.
+
 ### Add a real readiness probe and keep the health endpoint cheap (issue #1863)
 
 - **Defect (Fixed)**: the `/health` endpoint returned the fixed text `healthy` on

--- a/container/scripts/start.sh
+++ b/container/scripts/start.sh
@@ -112,6 +112,11 @@ echo "[SSH] Use option 0 in MistHelper to disconnect." >> /app/data/ssh.log
 # Determine web portal port (default 8055)
 WEB_PORT="${WEB_PORT:-8055}"
 
+# Read the grace period, so bash and the Python shutdown path share one value.
+SHUTDOWN_GRACE_SECONDS="${PORTAL_OPERATION_SHUTDOWN_GRACE_SECONDS:-30}"
+# Add a margin past the grace period, so bash waits longer than Gunicorn before it forces a kill.
+CONTAINER_KILL_MARGIN_SECONDS=10
+
 # Start Gunicorn web portal in the background
 echo "[PORTAL] Starting web portal on port $WEB_PORT..." >> /app/data/ssh.log
 su - misthelper -c "cd /app && gunicorn wsgi:app \
@@ -120,17 +125,40 @@ su - misthelper -c "cd /app && gunicorn wsgi:app \
     --worker-class gthread \
     --threads 4 \
     --timeout 120 \
+    --graceful-timeout ${SHUTDOWN_GRACE_SECONDS} \
     --access-logfile /app/data/portal_access.log \
     --error-logfile /app/data/portal_error.log" &
 GUNICORN_PID=$!
 
+# Wait for one PID to exit on its own, then force it, so cleanup never hangs forever.
+_wait_for_pid_or_kill() {
+    local pid="$1"  # Process to wait for before a forced kill.
+    local grace_seconds="$2"  # Seconds to wait before SIGKILL.
+    local waited=0  # Counts the seconds already spent waiting.
+    while kill -0 "$pid" 2>/dev/null; do
+        if [ "$waited" -ge "$grace_seconds" ]; then
+            # Log the forced kill, so an operator can see the grace period ran out.
+            echo "[CONTAINER] PID $pid did not exit in ${grace_seconds}s, sending SIGKILL" >> /app/data/ssh.log
+            kill -9 "$pid" 2>/dev/null || true
+            break
+        fi
+        sleep 1  # Poll once a second, so the check stays cheap and still responsive.
+        waited=$((waited + 1))
+    done
+    wait "$pid" 2>/dev/null || true
+}
+
 # Trap signals to stop both processes
 cleanup() {
     echo "[CONTAINER] Shutting down..." >> /app/data/ssh.log
+    # Match the bash-side deadline to Gunicorn's own --graceful-timeout, plus a margin.
+    local kill_wait
+    kill_wait=$((SHUTDOWN_GRACE_SECONDS + CONTAINER_KILL_MARGIN_SECONDS))
     kill "$GUNICORN_PID" 2>/dev/null || true
     kill "$SSHD_PID" 2>/dev/null || true
-    wait "$GUNICORN_PID" 2>/dev/null || true
-    wait "$SSHD_PID" 2>/dev/null || true
+    # Wait for a clean exit within the bound, so an in-flight operation can finish first.
+    _wait_for_pid_or_kill "$GUNICORN_PID" "$kill_wait"
+    _wait_for_pid_or_kill "$SSHD_PID" "$kill_wait"
     exit 0
 }
 trap cleanup SIGTERM SIGINT

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -118,6 +118,11 @@ MIST_ORG_ID=your_org_id_here
 # PORTAL_ALLOWED_IPS.
 # PORTAL_TRUSTED_PROXIES=127.0.0.1,10.10.0.0/24
 
+# Web portal graceful shutdown grace period (issue #1861)
+# Seconds shutdown() waits for in-flight operations before it closes the pool.
+# Also sets Gunicorn's --graceful-timeout in container/scripts/start.sh (default: 30)
+# PORTAL_OPERATION_SHUTDOWN_GRACE_SECONDS=30
+
 # SSID Template Consolidation specific variables
 # Cache freshness window for SSID Template Consolidation collector (minutes, default: 60)
 # SSID_CONSOLIDATION_CACHE_MINUTES=60

--- a/deploy/misthelper.container
+++ b/deploy/misthelper.container
@@ -20,6 +20,12 @@ HealthOnFailure=restart
 [Service]
 Restart=always
 RestartSec=5
+# Give the shutdown chain time to finish before systemd forces a stop.
+# PORTAL_OPERATION_SHUTDOWN_GRACE_SECONDS (default 30) sets the Python grace
+# period and the Gunicorn --graceful-timeout value. container/scripts/start.sh
+# then waits that period plus a 10 second margin before it sends SIGKILL.
+# This value stays above the bash-side wait, so systemd never cuts the drain short.
+TimeoutStopSec=60
 
 [Install]
 WantedBy=default.target

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -37,7 +37,11 @@ def flask_app():
         org_id="test-org-id",
     )
     app.config["TESTING"] = True
-    return app
+    yield app  # Hand the app to every test in the session.
+    # Stop the heartbeat thread and drain the pool now, while streams are still open.
+    # Without this, the atexit hook still runs, but only after pytest closes its
+    # own capture streams, so its shutdown log lines fail with a closed-file error.
+    WebPortalApp.shutdown_app(app)
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/web_portal/test_portal_graceful_shutdown.py
+++ b/tests/unit/web_portal/test_portal_graceful_shutdown.py
@@ -1,0 +1,129 @@
+"""Tests for the graceful shutdown path in the web portal.
+
+Issue #1861 reported that nothing stopped the event bus heartbeat thread
+or the operation pool. A restart aborted an in-flight run and leaked the
+heartbeat thread. These tests hold the fix in place.
+"""
+
+import time
+
+import pytest
+
+from web_portal.app import WebPortalApp
+from web_portal.menu_registry import build_static_menu_actions
+from web_portal.services.event_bus import PortalEventBus
+from web_portal.services.operation import OperationExecutor
+
+
+def _menu_actions() -> dict:
+    """Return one harmless menu entry for the executor under test."""
+    return {"11": (lambda: None, "Export the organization inventory")}  # A no-op action needs no cleanup.
+
+
+def _slow_menu_actions(hold_seconds: float) -> dict:
+    """Return one menu entry whose action sleeps, so a run stays in flight."""
+    # The sleep keeps the run active, so a test can call shutdown() while it runs.
+    return {"11": (lambda: time.sleep(hold_seconds), "Sleep for a bounded time")}
+
+
+@pytest.fixture
+def event_bus():
+    """Return a started PortalEventBus, stopped again after the test."""
+    bus = PortalEventBus()  # Build one bus per test, so tests cannot share thread state.
+    bus.start()  # Start the heartbeat thread, matching how app.py starts the real bus.
+    yield bus
+    bus.stop()  # A second stop() is a safe no-op, so an already-stopped bus raises nothing.
+
+
+@pytest.fixture
+def executor_factory():
+    """Return a factory that builds an OperationExecutor, shut down after the test."""
+    created = []  # Track every executor the test built, so teardown can shut down each one.
+
+    def _build(menu_actions: dict) -> OperationExecutor:
+        executor = OperationExecutor(menu_actions, None, None, None)  # No apisession/org_id/bus needed here.
+        created.append(executor)  # Remember it, so teardown can find it.
+        return executor
+
+    yield _build
+    for executor in created:
+        executor.shutdown()  # A second shutdown() is a safe no-op, so a torn-down executor raises nothing.
+
+
+def _build_test_app():
+    """Return a real WebPortalApp Flask instance for shutdown tests."""
+    # build_static_menu_actions avoids a MistHelper import, matching tests/e2e/conftest.py.
+    menu_actions = build_static_menu_actions()
+    return WebPortalApp.create_app(apisession=None, menu_actions=menu_actions, org_id="test-org-id")
+
+
+def test_event_bus_stop_ends_the_heartbeat_thread(event_bus):
+    """stop() ends the heartbeat thread, so it does not leak past the app."""
+    thread = event_bus._heartbeat_thread  # Hold the handle, because stop() clears the attribute.
+    assert thread.is_alive()  # The thread must be alive right after start().
+    event_bus.stop()  # Run the code under test.
+    assert not thread.is_alive()  # The thread must be gone right after stop() returns.
+
+
+def test_event_bus_stop_is_idempotent(event_bus):
+    """A second stop() call does not raise."""
+    event_bus.stop()  # First call performs the real stop.
+    event_bus.stop()  # Second call must return quietly, not raise.
+
+
+def test_operation_executor_shutdown_stops_the_pool(executor_factory):
+    """shutdown() closes the pool, so a new submit() is refused."""
+    executor = executor_factory(_menu_actions())  # Build one executor for this test.
+    executor.shutdown()  # Run the code under test.
+    with pytest.raises(RuntimeError):  # A closed ThreadPoolExecutor refuses new work.
+        executor._pool.submit(lambda: None)
+
+
+def test_operation_executor_shutdown_is_idempotent(executor_factory):
+    """A second shutdown() call does not raise."""
+    executor = executor_factory(_menu_actions())  # Build one executor for this test.
+    executor.shutdown()  # First call performs the real shutdown.
+    executor.shutdown()  # Second call must return quietly, not raise.
+
+
+def test_operation_executor_shutdown_waits_for_an_in_flight_run(executor_factory):
+    """shutdown() waits for a short in-flight run within the grace period."""
+    executor = executor_factory(_slow_menu_actions(0.2))  # The run sleeps 0.2s, well under the grace period.
+    run = executor.start_operation("11", {})  # Start the run, so a future is in flight.
+    executor.shutdown(grace_seconds=2)  # Wait up to 2s, far more than the run needs.
+    future = executor._runs[run["run_id"]]["_future"]  # Read back the tracked future.
+    assert future.done()  # The grace period must be enough for a 0.2s run to finish.
+
+
+def test_webportalapp_shutdown_app_stops_the_event_bus():
+    """shutdown_app() stops the event bus heartbeat thread for a real app."""
+    app = _build_test_app()  # Build a real app, matching how wsgi.py builds one.
+    bus = app.config["EVENT_BUS"]  # Read the bus create_app already started.
+    thread = bus._heartbeat_thread  # Hold the handle, because stop() clears the attribute.
+    assert thread.is_alive()  # The thread must be alive right after create_app().
+    WebPortalApp.shutdown_app(app)  # Run the code under test.
+    assert not thread.is_alive()  # The thread must be gone right after shutdown_app() returns.
+
+
+def test_webportalapp_shutdown_app_stops_the_operation_executor():
+    """shutdown_app() drains an operation executor a request already built."""
+    app = _build_test_app()  # Build a real app, matching how wsgi.py builds one.
+    # Simulate the lazy build routes/operations.py performs on the first request.
+    executor = OperationExecutor(_menu_actions(), None, None, app.config["EVENT_BUS"])
+    app.config["OPERATION_EXECUTOR"] = executor  # Store it under the real config key.
+    WebPortalApp.shutdown_app(app)  # Run the code under test.
+    with pytest.raises(RuntimeError):  # A closed ThreadPoolExecutor refuses new work.
+        executor._pool.submit(lambda: None)
+
+
+def test_webportalapp_shutdown_app_tolerates_a_missing_executor():
+    """shutdown_app() does not raise when no operation ever ran."""
+    app = _build_test_app()  # Build a real app that never served an operation request.
+    WebPortalApp.shutdown_app(app)  # No OPERATION_EXECUTOR key exists, so this call must not raise.
+
+
+def test_webportalapp_shutdown_app_is_idempotent():
+    """A second shutdown_app() call for the same app does not raise."""
+    app = _build_test_app()  # Build a real app for this test.
+    WebPortalApp.shutdown_app(app)  # First call performs the real shutdown.
+    WebPortalApp.shutdown_app(app)  # Second call must return quietly, not raise.

--- a/web_portal/app.py
+++ b/web_portal/app.py
@@ -24,6 +24,9 @@ class WebPortalApp:
         app.run(port=8055)
     """
 
+    # app.config key that records whether shutdown_app() already ran for this app.
+    SHUTDOWN_DONE_CONFIG_KEY = "SHUTDOWN_DONE"
+
     @staticmethod
     def create_app(
         apisession: Optional[Any],
@@ -43,6 +46,7 @@ class WebPortalApp:
         WebPortalApp._apply_security(app, config)
         WebPortalApp._register_blueprints(app)
         WebPortalApp._register_context_processor(app)
+        WebPortalApp._register_shutdown_hook(app)  # Wire teardown now, so every app built here shuts down cleanly.
         InputInterceptor.install()
         return app
 
@@ -194,3 +198,55 @@ class WebPortalApp:
                 "portal_theme": portal.get("theme", "dark"),
                 "available_themes": theme_mgr.get_themes() if theme_mgr else [],
             }
+
+    @staticmethod
+    def _register_shutdown_hook(app: Flask) -> None:
+        """Register the atexit hook that stops the portal cleanly.
+
+        Gunicorn never runs ``if __name__ == "__main__"``, so this hook is
+        the reliable place to run teardown code inside the worker process.
+        Gunicorn's graceful shutdown path calls ``sys.exit()``, and that
+        call runs every registered ``atexit`` callback before the worker
+        process ends.
+        """
+        logging.info("Registering the web portal shutdown hook")  # Log before the registration.
+        atexit.register(WebPortalApp.shutdown_app, app)  # Run shutdown_app once, when the process exits.
+        logging.debug("Web portal shutdown hook registered")
+
+    @staticmethod
+    def shutdown_app(app: Flask) -> None:
+        """Stop the event bus and the operation pool for one app.
+
+        A second call is a no-op. A duplicate ``atexit`` call at process
+        exit, or a duplicate call from a test, must not raise or repeat
+        the shutdown work.
+        """
+        if app.config.get(WebPortalApp.SHUTDOWN_DONE_CONFIG_KEY):
+            # A prior call already ran, so skip the repeat work.
+            logging.debug("Web portal shutdown already ran, skipping repeat call")
+            return
+        logging.info("Shutting down the web portal")  # One INFO line at the start, an operator can see it begin.
+        app.config[WebPortalApp.SHUTDOWN_DONE_CONFIG_KEY] = True  # Mark done first, so a second call returns above.
+        WebPortalApp._stop_event_bus(app)
+        WebPortalApp._stop_operation_executor(app)
+        logging.info("Web portal shutdown complete")  # One INFO line at the end, an operator can see a clean stop.
+
+    @staticmethod
+    def _stop_event_bus(app: Flask) -> None:
+        """Stop the heartbeat thread if the app started an event bus."""
+        event_bus = app.config.get("EVENT_BUS")  # An app that never started a bus has nothing to stop.
+        if event_bus is None:
+            logging.debug("No event bus to stop")
+            return
+        event_bus.stop()  # Join the heartbeat thread, so it does not outlive the app.
+        logging.debug("Event bus stopped")
+
+    @staticmethod
+    def _stop_operation_executor(app: Flask) -> None:
+        """Stop the operation pool if the app built one on first use."""
+        executor = app.config.get("OPERATION_EXECUTOR")  # No operation ever ran, so there is nothing to drain.
+        if executor is None:
+            logging.debug("No operation executor to stop")
+            return
+        executor.shutdown()  # Wait for in-flight runs, then release the worker threads.
+        logging.debug("Operation executor stopped")

--- a/web_portal/services/operation.py
+++ b/web_portal/services/operation.py
@@ -11,7 +11,8 @@ import threading
 import time
 import uuid
 from collections import deque
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import wait as wait_for_futures
 from typing import Any, Optional
 
 from src.utils.operation_registry import OperationRegistry
@@ -65,6 +66,10 @@ DEFAULT_RUN_OUTPUT_FILES_MAX = 500
 
 # The two states that mark work the portal must never evict.
 ACTIVE_RUN_STATUSES = ("pending", "running")
+
+# Seconds shutdown() waits for in-flight runs before it drops the pool.
+# Issue #1861: without a bound, a stuck run could hang a restart forever.
+DEFAULT_OPERATION_SHUTDOWN_GRACE_SECONDS = 30
 
 
 def _read_positive_int_env(name: str, default: int) -> int:
@@ -368,6 +373,7 @@ class OperationExecutor:
         self._runs = {}
         self._lock = threading.Lock()
         self._sequence = 0  # A rising number orders the runs when the clock repeats a value.
+        self._shutdown_done = False  # Guards shutdown(), so a repeat call is a safe no-op.
         self._configure_limits()  # Read the caps once, so every run shares one setting.
         cpu_count = os.cpu_count() or 2
         max_workers = max(1, cpu_count - 1)
@@ -382,13 +388,19 @@ class OperationExecutor:
         self._history_max = _read_positive_int_env("PORTAL_RUN_HISTORY_MAX", DEFAULT_RUN_HISTORY_MAX)
         self._retention_seconds = _read_positive_int_env("PORTAL_RUN_RETENTION_SECONDS", DEFAULT_RUN_RETENTION_SECONDS)
         self._output_files_max = _read_positive_int_env("PORTAL_RUN_OUTPUT_FILES_MAX", DEFAULT_RUN_OUTPUT_FILES_MAX)
+        # Read the shutdown grace period, so shutdown() honors an operator override.
+        self._shutdown_grace_seconds = _read_positive_int_env(
+            "PORTAL_OPERATION_SHUTDOWN_GRACE_SECONDS", DEFAULT_OPERATION_SHUTDOWN_GRACE_SECONDS
+        )
         # Record the result, so an operator can confirm the caps the portal applied.
         logging.debug(
-            "Run caps: %d log entries, %d finished runs, %d seconds of retention, %d output files",
+            "Run caps: %d log entries, %d finished runs, %d seconds of retention, %d output files, "
+            "%d second shutdown grace period",
             self._log_max_entries,
             self._history_max,
             self._retention_seconds,
             self._output_files_max,
+            self._shutdown_grace_seconds,
         )
 
     def start_operation(self, menu_number: str, parameters: dict) -> dict:
@@ -400,7 +412,8 @@ class OperationExecutor:
         if conflict:
             return conflict
         run = self._create_run(menu_number)
-        self._pool.submit(self._execute_operation, run, parameters)
+        # Keep the future, so shutdown() can wait for this run before it closes the pool.
+        run["_future"] = self._pool.submit(self._execute_operation, run, parameters)
         return self._run_to_dict(run)
 
     def get_run_status(self, run_id: str) -> Optional[dict]:
@@ -444,6 +457,36 @@ class OperationExecutor:
         except OSError as exc:
             logging.warning("Could not create stop_loop.txt: %s", exc)
         return {"status": "stop_requested", "run_id": run_id}
+
+    def shutdown(self, grace_seconds: float | None = None) -> None:
+        """Wait for in-flight runs, then shut down the worker pool.
+
+        A second call is a no-op. A duplicate shutdown signal, or a
+        duplicate call from a test, must not raise or repeat the work.
+        """
+        with self._lock:
+            if self._shutdown_done:  # A prior call already drained the pool, so skip the repeat work.
+                logging.debug("Operation pool already shut down, skipping repeat call")
+                return
+            self._shutdown_done = True  # Mark shutdown first, so a second call returns above.
+            # Collect only the futures still in flight, so a finished run is not awaited again.
+            pending: list[Future] = [
+                run["_future"]
+                for run in self._runs.values()
+                if run.get("_future") is not None and not run["_future"].done()
+            ]
+        # Fall back to the configured default, so a caller need not pass a value.
+        wait_seconds = self._shutdown_grace_seconds if grace_seconds is None else grace_seconds
+        logging.info(
+            "Stopping the operation pool: %d run(s) in flight, %s second grace period", len(pending), wait_seconds
+        )
+        # Bound the wait, so one stuck run cannot hang the whole shutdown path.
+        done, not_done = wait_for_futures(pending, timeout=wait_seconds)
+        if not_done:
+            # Warn, because an operator must know a run did not finish before the pool closed.
+            logging.warning("Operation pool shutdown: %d run(s) still in flight after the grace period", len(not_done))
+        self._pool.shutdown(wait=False)  # Release the worker threads now, the wait above already bounded the delay.
+        logging.info("Operation pool stopped: %d of %d run(s) finished cleanly", len(done), len(pending))
 
     def build_category_list(self, menu_actions: dict) -> list:
         """Build categorized operation list for the UI."""


### PR DESCRIPTION
Fixes #1861

# Spec Conformance Checklist

**Linked Spec Issue**: #1861

## Problem

The web portal started two background resources and never stopped them. `web_portal/app.py`
created a `PortalEventBus`, called `event_bus.start()`, and stored it on `app.config`.
Nothing called `event_bus.stop()`. `web_portal/services/operation.py` created a
`ThreadPoolExecutor` and never called `shutdown()` on it. No `atexit` hook, no
`teardown_appcontext`, and no `SIGTERM` handler existed in `web_portal/` or `wsgi.py`. A
`podman stop`, a systemd restart, or a plain `SIGTERM` aborted an in-flight operation and
left the heartbeat thread running past the worker exit. `container/scripts/start.sh` made
this worse. Its `cleanup()` function sent one `kill` signal to Gunicorn and returned right
away, so it never confirmed a clean drain.

## Fix

- **`web_portal/services/event_bus.py`**: `PortalEventBus.stop()` is now idempotent. It sets
  a `threading.Event` that wakes the heartbeat loop at once, then joins the thread within a
  5-second bound. The old loop called `time.sleep(30)`, so a stop signal could take up to 30
  seconds to land. The new loop waits on the event instead, so `stop()` ends the thread right
  away.
- **`web_portal/services/operation.py`**: `OperationExecutor.shutdown()` is new. It collects
  every future for a run still in flight, waits for them within a bounded grace period
  (`PORTAL_OPERATION_SHUTDOWN_GRACE_SECONDS`, default 30 seconds), then closes the thread
  pool. It logs a WARNING with the count of runs still in flight after the grace period, and
  an INFO line with the count that finished cleanly. A second call returns at once and does
  not raise.
- **`web_portal/app.py`**: `WebPortalApp.create_app` now registers an `atexit` hook through
  `WebPortalApp._register_shutdown_hook`. Gunicorn never runs `if __name__ == "__main__"`, so
  this hook is the reliable place to run teardown code inside a worker process. No
  `gunicorn.conf.py` exists in this repo, so an `atexit` hook plus an explicit shutdown
  function was the right fit over a `worker_exit` server hook. The hook calls the new
  `WebPortalApp.shutdown_app`, which stops the event bus and drains the operation executor.
  `shutdown_app` is idempotent, so a duplicate call at process exit does not raise.
- **`container/scripts/start.sh`**: `cleanup()` now waits for Gunicorn and sshd to exit,
  bounded by the same grace period plus a 10-second margin, then sends `SIGKILL` if a process
  still runs. The Gunicorn invocation also gained a `--graceful-timeout` flag read from the
  same grace period, so Python and Gunicorn agree on the drain time.
- **`deploy/misthelper.container`**: added `TimeoutStopSec=60`, so systemd waits long enough
  for the full bounded shutdown chain before it forces a kill.
- **`deploy/.env.example`**: documented the new `PORTAL_OPERATION_SHUTDOWN_GRACE_SECONDS`
  setting.
- **`tests/e2e/conftest.py`**: the session-scoped `flask_app` fixture now tears down through
  `WebPortalApp.shutdown_app`. This is the one existing place in the test suite that built a
  real app, and it no longer leaks its own heartbeat thread past the test session.

## Validation

Interpreter: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\.venv\Scripts\python.exe`
(has flask, ruff, black, pytest).

| Command | Result |
| --- | --- |
| `python -m py_compile web_portal\app.py web_portal\services\event_bus.py web_portal\services\operation.py tests\e2e\conftest.py tests\unit\web_portal\test_portal_graceful_shutdown.py` | Pass. No output. |
| `python -m ruff check <same 5 files>` | 13 violations reported, all pre-existing `Optional[X]` / one unused-import finding in lines this change did not touch (4 in `app.py`, 1 in `event_bus.py`, 8 in `operation.py`). The count matches the pre-change baseline exactly, so this change adds zero new Ruff violations. The two touched test files report zero violations. |
| `python -m black --check <same 5 files>` | `5 files would be left unchanged`. |
| `python -m pytest tests\unit\web_portal\test_portal_graceful_shutdown.py -q` | `9 passed`. |
| `python -m pytest tests\unit\web_portal\ tests\e2e\ -q` | `59 passed`. No regression in the existing web portal or E2E suites. |
| `python -m pytest tests\unit\ tests\e2e\ -q` (full repo suite) | `9295 passed` in 396 seconds. No regression anywhere in the repo. |

`web_portal/` and `tests/` are outside `MYPY_PATHS` (`src/ MistHelper.py wsgi.py` in
`.github/workflows/ci.yml`), and this change does not touch `wsgi.py`, so mypy does not apply.

**Fails-before-fix check**: I stashed the three source-file changes (event_bus.py,
operation.py, app.py), kept the new test file, and reran it against the pre-fix code. Result:
`8 failed, 1 passed`. Eight tests failed with `AttributeError` (`shutdown()` /
`shutdown_app()` did not exist yet) or a live heartbeat thread after `stop()`. One test
(`test_event_bus_stop_is_idempotent`) passed even against the pre-fix code, because the old
`stop()` only flipped a flag and cleared a dict. It never touched the thread, so calling it
twice was already harmless. That same pre-fix `stop()` left the thread alive, which is exactly
what the sibling test `test_event_bus_stop_ends_the_heartbeat_thread` caught. I restored the
stash before committing.

## Tests

New file `tests/unit/web_portal/test_portal_graceful_shutdown.py`, 9 tests:

- `test_event_bus_stop_ends_the_heartbeat_thread` -- the thread is alive after `start()` and
  dead right after `stop()`.
- `test_event_bus_stop_is_idempotent` -- a second `stop()` call does not raise.
- `test_operation_executor_shutdown_stops_the_pool` -- a `submit()` after `shutdown()` raises
  `RuntimeError`.
- `test_operation_executor_shutdown_is_idempotent` -- a second `shutdown()` call does not
  raise.
- `test_operation_executor_shutdown_waits_for_an_in_flight_run` -- a 0.2-second run finishes
  inside a 2-second grace period.
- `test_webportalapp_shutdown_app_stops_the_event_bus` -- `shutdown_app()` stops the event bus
  for a real app built through `create_app`.
- `test_webportalapp_shutdown_app_stops_the_operation_executor` -- `shutdown_app()` drains an
  executor a request already built.
- `test_webportalapp_shutdown_app_tolerates_a_missing_executor` -- `shutdown_app()` does not
  raise when no operation ever ran.
- `test_webportalapp_shutdown_app_is_idempotent` -- a second `shutdown_app()` call for the
  same app does not raise.

Modified `tests/e2e/conftest.py`: the `flask_app` fixture now yields and tears down through
`shutdown_app`, closing the one production-shaped gap the issue reported for tests.

## Acceptance Criteria (from issue #1861)

- [x] A `SIGTERM` to the container stops the heartbeat thread. Covered by
      `test_webportalapp_shutdown_app_stops_the_event_bus`.
- [x] A `SIGTERM` waits a documented period for a running operation, then reports the abort.
      `PORTAL_OPERATION_SHUTDOWN_GRACE_SECONDS` (default 30s) bounds the wait, and a WARNING
      log reports any run still in flight after the grace period.
- [x] The shutdown path logs the count of operations that did not finish. See the WARNING and
      INFO lines in `OperationExecutor.shutdown()`.
- [x] `WebPortalApp.create_app` exposes a teardown path that a test can call.
      `WebPortalApp.shutdown_app(app)` is a public static method, called directly by the new
      tests.
- [x] A unit test asserts the heartbeat thread is not alive after teardown. Covered by
      `test_event_bus_stop_ends_the_heartbeat_thread` and
      `test_webportalapp_shutdown_app_stops_the_event_bus`.

## Quality
- [x] Tests added or updated for all changed functionality
- [ ] Coverage meets or exceeds 80% threshold -- not measured in this change (no `--cov` run
      against this file alone). The full suite passes at 9295 tests with no regression.
- [x] No new Ruff lint violations (`ruff check .`) -- see the Validation table. The count of
      pre-existing violations in touched files is unchanged.
- [x] Code formatted with Ruff/Black (`black --check`) -- see the Validation table.
- [ ] mypy passes (`mypy MistHelper.py`) -- not applicable. This change does not touch
      `MistHelper.py`, `wsgi.py`, or `src/`, the only paths `MYPY_PATHS` covers.

## Security
- [x] No hardcoded secrets, tokens, or passwords
- [ ] Bandit passes with no new findings -- not run in this session. The change adds no
      subprocess calls, no `eval`, and no new external input handling.
- [ ] pip-audit clean -- not applicable. No dependency changed.
- [x] Sensitive data handled via `.env` / environment variables only -- the new
      `PORTAL_OPERATION_SHUTDOWN_GRACE_SECONDS` setting follows the existing `PORTAL_*` env
      var pattern.

## Deployment
- [x] Dry-run verified locally -- `bash -n container/scripts/start.sh` confirms the script
      still parses. The pytest suite exercises the Python shutdown path directly.
- [x] `.env` changes documented in `deploy/.env.example`
- [ ] Container builds successfully -- not run in this session. Container image builds run
      through GitHub Actions in this repo, per `container-build.yml`, and were not triggered
      from this worktree.

## UI / E2E Testing (if web UI changed)
- Not applicable. This change touches shutdown and process lifecycle, not the UI.

## Documentation
- [x] Changelog entry added under `## [Unreleased]` in `CHANGELOG.md`
- [ ] README.md updated -- not applicable. No user-facing menu or CLI flag changed.
