### PR TITLE
security: verify TLS certificates by default in the application layer

### DIFF
--- a/scripts/debug_html.py
+++ b/scripts/debug_html.py
@@ -1,15 +1,12 @@
 """Dump the raw HTML of a single idea page to diagnose what we're getting."""
 
 import ssl
-import sys
 from pathlib import Path
 from urllib.request import Request, urlopen
 
 url = "https://ideas.mist.com/forums/912934-product-features/suggestions/50598263-modify-port-configuration-button"
 
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+ctx = ssl.create_default_context()  # Verify the certificate and the host name. See issue #1914.
 
 req = Request(
     url,

--- a/scripts/mist_ideas_scraper_ssr.py
+++ b/scripts/mist_ideas_scraper_ssr.py
@@ -15,14 +15,12 @@ Usage:
 import csv
 import json
 import logging
-import os
 import re
 import ssl
 import sys
 import time
 from pathlib import Path
 from urllib.request import Request, urlopen
-from urllib.error import HTTPError, URLError
 
 try:
     from bs4 import BeautifulSoup
@@ -61,10 +59,11 @@ HEADERS = [
     "comments_json",
 ]
 
-# ── SSL context for Zscaler corporate proxy ───────────────────
+# ── SSL context for the public ideas host ─────────────────────
+# The default context verifies the certificate and the host name. Do not
+# weaken it. Behind a proxy that inspects TLS, mount the corporate
+# certificate authority bundle and set SSL_CERT_FILE instead. See issue #1914.
 SSL_CTX = ssl.create_default_context()
-SSL_CTX.check_hostname = False
-SSL_CTX.verify_mode = ssl.CERT_NONE  # nosec B323 — required for Zscaler SSL inspection proxy
 
 # ── Boilerplate lines to strip from descriptions ──────────────
 BOILERPLATE_LINES = frozenset(

--- a/scripts/test_ssr.py
+++ b/scripts/test_ssr.py
@@ -1,17 +1,14 @@
 """Quick test: does ideas.mist.com do SSR?"""
 
-import urllib.request
 import ssl
-import re
+import urllib.request
 
 url = "https://ideas.mist.com/forums/912934-product-features/suggestions/50598263-modify-port-configuration-button"
 req = urllib.request.Request(
     url, headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
 )
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
-resp = urllib.request.urlopen(req, context=ctx)
+ctx = ssl.create_default_context()  # Verify the certificate and the host name. See issue #1914.
+resp = urllib.request.urlopen(req, context=ctx, timeout=30)  # nosec B310 -- fixed https URL above.
 html = resp.read().decode("utf-8")
 print(f"HTML length: {len(html)}")
 

--- a/src/inventory/csv_comparator.py
+++ b/src/inventory/csv_comparator.py
@@ -105,7 +105,7 @@ class ComparatorFlags:
     fast: bool = False  # WHY: enables cached data generation.
     address_check: bool = False  # WHY: opts into Nominatim validation.
     debug: bool = False  # WHY: verbose logging + traceback capture.
-    skip_ssl_verify: bool = True  # WHY: default relaxed for internal APIs.
+    skip_ssl_verify: bool = False  # WHY: verify by default. Issue #1914 inverted this.
 
 
 @dataclass

--- a/src/refactors/inventory_csvcomparator.py
+++ b/src/refactors/inventory_csvcomparator.py
@@ -86,7 +86,7 @@ class InventoryCSVComparator:  # Inventory CSV comparator.
         fast: bool = False,
         address_check: bool = False,
         debug: bool = False,
-        skip_ssl_verify: bool = True,
+        skip_ssl_verify: bool = False,
     ) -> None:
         """Initialize the inventory comparator (fast/address_check/debug/skip_ssl_verify flags)."""
         logging.info("Initializing InventoryCSVComparator adapter")  # Announce construction

--- a/src/site/address_audit/audit_engine.py
+++ b/src/site/address_audit/audit_engine.py
@@ -49,6 +49,7 @@ from src.site.address_audit.suite_patterns import (
     SUITE_PATTERN_CAPTURE as _SUITE_PATTERN,
 )  # Shared suite detector (capturing).
 from src.utils.input_utils import InputUtils  # EOF-safe operator prompts.
+from src.utils.tls_policy import TLSVerificationPolicy  # One control for certificate verification.
 
 try:  # Optional dependency: tqdm renders the per-row progress bar.
     from tqdm import tqdm  # Progress bar for the resolve loop.
@@ -456,12 +457,14 @@ class AddressAuditEngine:
     def _skip_ssl_verify() -> bool:
         """Return whether to skip TLS verification for the public Nominatim call.
 
-        Defaults to True because the deployment environment sits behind Zscaler
-        SSL inspection, whose MITM cert otherwise breaks the OpenStreetMap call.
-        Set ``MIST_SKIP_SSL_VERIFY=false`` to enforce verification (non-Zscaler hosts).
+        Defaults to False, because an unverified call exposes the traffic to
+        any host on the network path. Set ``MIST_SKIP_SSL_VERIFY=true`` to opt
+        out behind a proxy that inspects TLS. A better answer is to mount the
+        corporate certificate authority bundle and keep the check on.
+
+        See issue #1914. This helper defaulted to True before that fix.
         """
-        raw = os.environ.get("MIST_SKIP_SSL_VERIFY", "true").strip().lower()  # Env override. Default on.
-        return raw not in ("false", "0", "no", "off")  # Any falsey token re-enables verification.
+        return TLSVerificationPolicy.skip_verification()  # One control decides for every caller.
 
     @staticmethod
     def _make_ui_geocoder(perf: PhaseTimer) -> Any:

--- a/src/utils/address_utils.py
+++ b/src/utils/address_utils.py
@@ -34,6 +34,8 @@ except ImportError:  # pragma: no cover  # WHY: absence is non-fatal
     urllib3 = None  # type: ignore[assignment]  # WHY: sentinel checked before disabling warnings
     _has_urllib3 = False  # WHY: skip suppression path when the module is missing
 
+from src.utils.tls_policy import TLSVerificationPolicy  # noqa: E402  # One control for certificate verification.
+
 try:  # WHY: rapidfuzz is optional. Degrade to difflib on absence
     from rapidfuzz import fuzz  # WHY: faster token-sort ratio when available
 except ImportError:  # pragma: no cover  # WHY: keep import graph optional
@@ -859,9 +861,17 @@ class NominatimValidator:
         self._suppress_ssl_warnings()  # WHY: silence urllib3 warnings when verify is disabled
 
     def _suppress_ssl_warnings(self) -> None:
-        """Suppress SSL warnings when verification is disabled."""
-        if self.skip_ssl_verify and _has_urllib3 and urllib3 is not None:  # WHY: only when both toggles align
-            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)  # WHY: silence noisy warnings
+        """Announce a disabled TLS check, then quiet the repeated urllib3 notice.
+
+        The old version silenced the warning and said nothing, so a run with
+        no certificate check looked the same as a normal run. Now the run
+        states the weakened condition one time. See issue #1914.
+        """
+        if not self.skip_ssl_verify:  # Nothing to report when the check stays on.
+            return  # Normal secure path exits early.
+        TLSVerificationPolicy.warn_once()  # State the risk one time for the operator.
+        if _has_urllib3 and urllib3 is not None:  # Quiet the per-request repeat, not the warning above.
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)  # WHY: one notice is enough.
 
     def _log_entry(
         self,

--- a/src/utils/tls_policy.py
+++ b/src/utils/tls_policy.py
@@ -1,0 +1,72 @@
+"""Single control for TLS certificate verification.
+
+The application had seven independent decisions about certificate
+verification. Five of them defaulted to insecure, and two defaulted to
+secure. A reader could not tell which default applied to a given run.
+This module holds one decision, so every caller agrees.
+
+Warning: A disabled check lets any host present any certificate. The
+traffic carries a live Mist API token. Disable the check only when a
+corporate proxy inspects TLS, and prefer a mounted certificate
+authority bundle instead.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)  # Module logger, because the root logger hides the source.
+
+# The operator sets this variable to turn the check off. Absent means on.
+SKIP_VERIFY_ENV_VAR = "MIST_SKIP_SSL_VERIFY"
+
+# These tokens turn the check off. Every other value keeps the check on.
+_DISABLE_TOKENS = frozenset({"true", "1", "yes", "on"})
+
+
+class TLSVerificationPolicy:
+    """Decide whether to verify a TLS certificate, and report the decision."""
+
+    _warned = False  # Class flag, because one warning per run is enough.
+
+    @staticmethod
+    def skip_verification() -> bool:
+        """Return True only when the operator asked to skip the check.
+
+        The default is secure. An unset variable keeps verification on.
+        """
+        raw = os.environ.get(SKIP_VERIFY_ENV_VAR, "").strip().lower()  # Absent reads as an empty string.
+        skip = raw in _DISABLE_TOKENS  # Opt in only, because an unknown value must stay secure.
+        if skip:  # Announce the weakened state, because a silent bypass hides itself.
+            TLSVerificationPolicy.warn_once()  # Emit the operator warning one time.
+        return skip  # Callers invert this to build a verify flag.
+
+    @staticmethod
+    def verify_enabled() -> bool:
+        """Return True when the caller must verify the certificate."""
+        return not TLSVerificationPolicy.skip_verification()  # Positive form for a requests verify flag.
+
+    @staticmethod
+    def warn_once() -> None:
+        """Log one WARNING for the run that TLS verification is off."""
+        if TLSVerificationPolicy.reported():  # Skip a repeat, because a loop would flood the log.
+            return  # Nothing more to do for this run.
+        TLSVerificationPolicy._warned = True  # Latch before the log call, because the log can raise.
+        logger.warning(  # ASCII only, because the project forbids Unicode in a log line.
+            "TLS certificate verification is OFF because %s is set. "
+            "An attacker on the network path can read the Mist API token. "
+            "Unset %s, or mount the corporate certificate authority bundle instead.",
+            SKIP_VERIFY_ENV_VAR,
+            SKIP_VERIFY_ENV_VAR,
+        )
+
+    @staticmethod
+    def reported() -> bool:
+        """Return True when this run already logged the warning."""
+        return TLSVerificationPolicy._warned  # Read the latch for the caller and the tests.
+
+    @staticmethod
+    def reset() -> None:
+        """Clear the warning latch so a test can observe the first warning."""
+        TLSVerificationPolicy._warned = False  # Tests need a clean latch between cases.

--- a/tests/unit/refactors/test_inventory_csvcomparator.py
+++ b/tests/unit/refactors/test_inventory_csvcomparator.py
@@ -146,7 +146,7 @@ class TestInitAndExecute:
         fake_impl_instance.execute.assert_called_once_with()  # Delegation confirmed.
 
     def test_init_default_flags(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Default constructor args produce fast=False/address_check=False/debug=False/skip_ssl_verify=True."""
+        """Default constructor args produce fast/address_check/debug/skip_ssl_verify all False."""
         # WHY: covers the default keyword argument branch of __init__.
         # Publish minimal MistHelper attrs (same as above).
         for name, val in [
@@ -168,6 +168,6 @@ class TestInitAndExecute:
             patch("src.inventory.csv_comparator.ComparatorDependencies", MagicMock(name="Deps")),
         ):
             InventoryCSVComparator()  # Rely entirely on defaults.
-        fake_flags_cls.assert_called_once_with(  # Assert defaults propagated.
-            fast=False, address_check=False, debug=False, skip_ssl_verify=True
+        fake_flags_cls.assert_called_once_with(  # Assert defaults propagated. Verification stays on (#1914).
+            fast=False, address_check=False, debug=False, skip_ssl_verify=False
         )

--- a/tests/unit/site/address_audit/test_audit_engine.py
+++ b/tests/unit/site/address_audit/test_audit_engine.py
@@ -398,14 +398,19 @@ class TestEnvConfig:
         assert config.per_lookup_timeout_s == 30.0
         assert config.max_lookups == 10
 
-    def test_skip_ssl_verify_defaults_true(self, monkeypatch):
-        """SSL verification is skipped by default (corporate Zscaler environment)."""
+    def test_skip_ssl_verify_defaults_false(self, monkeypatch):
+        """Certificate verification stays on by default. See issue #1914."""
         monkeypatch.delenv("MIST_SKIP_SSL_VERIFY", raising=False)
+        assert AddressAuditEngine._skip_ssl_verify() is False
+
+    def test_skip_ssl_verify_env_opt_out(self, monkeypatch):
+        """Setting MIST_SKIP_SSL_VERIFY=true turns the check off, and only then."""
+        monkeypatch.setenv("MIST_SKIP_SSL_VERIFY", "true")
         assert AddressAuditEngine._skip_ssl_verify() is True
 
-    def test_skip_ssl_verify_env_disable(self, monkeypatch):
-        """Setting MIST_SKIP_SSL_VERIFY=false re-enables certificate verification."""
-        monkeypatch.setenv("MIST_SKIP_SSL_VERIFY", "false")
+    def test_skip_ssl_verify_unknown_value_stays_secure(self, monkeypatch):
+        """An unrecognized value keeps the check on, so a typo fails secure."""
+        monkeypatch.setenv("MIST_SKIP_SSL_VERIFY", "flase")
         assert AddressAuditEngine._skip_ssl_verify() is False
 
     def test_ui_geocode_enabled_defaults_true(self, monkeypatch):

--- a/tests/unit/utils/test_tls_policy.py
+++ b/tests/unit/utils/test_tls_policy.py
@@ -1,0 +1,101 @@
+"""Tests for the single TLS verification control.
+
+These tests prove issue #1914. Certificate verification must be on
+unless the operator opts out, and a run that skips the check must say
+so in the log.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from src.inventory.csv_comparator import ComparatorFlags
+from src.site.address_audit.audit_engine import AddressAuditEngine
+from src.utils.tls_policy import SKIP_VERIFY_ENV_VAR, TLSVerificationPolicy
+
+REPO_ROOT = Path(__file__).resolve().parents[3]  # Repository root, for the source sweep test.
+
+# These files must never disable certificate verification again.
+GUARDED_SCRIPTS = (
+    "scripts/test_ssr.py",
+    "scripts/debug_html.py",
+    "scripts/mist_ideas_scraper_ssr.py",
+)
+
+# A match on any token means a bypass returned to the tree.
+BYPASS_TOKENS = re.compile(r"CERT_NONE|check_hostname\s*=\s*False")
+
+
+@pytest.fixture(autouse=True)
+def _clear_policy_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give every test an unset variable and a clean warning latch."""
+    monkeypatch.delenv(SKIP_VERIFY_ENV_VAR, raising=False)  # Absent is the default operator state.
+    TLSVerificationPolicy.reset()  # Clear the latch so each test sees its own warning.
+
+
+class TestTLSVerificationPolicy:
+    """Cover the default, the opt in, and the operator warning."""
+
+    def test_default_verifies(self) -> None:
+        """An unset variable keeps certificate verification on."""
+        assert TLSVerificationPolicy.skip_verification() is False  # Secure default.
+        assert TLSVerificationPolicy.verify_enabled() is True  # Positive form agrees.
+
+    @pytest.mark.parametrize("token", ["true", "TRUE", "1", "yes", "on"])
+    def test_opt_in_disables(self, token: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A recognized token turns the check off."""
+        monkeypatch.setenv(SKIP_VERIFY_ENV_VAR, token)  # Operator opts out explicitly.
+        assert TLSVerificationPolicy.skip_verification() is True  # Opt in honored.
+
+    @pytest.mark.parametrize("token", ["false", "0", "no", "off", "maybe", ""])
+    def test_unrecognized_stays_secure(self, token: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unknown or falsey value keeps the check on."""
+        monkeypatch.setenv(SKIP_VERIFY_ENV_VAR, token)  # Includes a typo case.
+        assert TLSVerificationPolicy.skip_verification() is False  # Fail secure.
+
+    def test_disabled_run_warns(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+        """A run that skips the check logs one WARNING."""
+        monkeypatch.setenv(SKIP_VERIFY_ENV_VAR, "true")  # Turn the check off.
+        with caplog.at_level("WARNING"):  # Capture the operator warning.
+            TLSVerificationPolicy.skip_verification()  # Trigger the decision and the log.
+        assert any("verification is OFF" in r.message for r in caplog.records)  # Warning present.
+
+    def test_warning_is_not_repeated(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+        """A loop does not flood the log with the same warning."""
+        monkeypatch.setenv(SKIP_VERIFY_ENV_VAR, "true")  # Turn the check off.
+        with caplog.at_level("WARNING"):  # Capture every warning record.
+            for _ in range(5):  # Simulate a caller inside a loop.
+                TLSVerificationPolicy.skip_verification()  # Repeated decision.
+        warnings = [r for r in caplog.records if "verification is OFF" in r.message]
+        assert len(warnings) == 1  # Exactly one warning per run.
+
+    def test_secure_run_does_not_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A normal run stays quiet, so the warning keeps its meaning."""
+        with caplog.at_level("WARNING"):  # Capture any warning.
+            TLSVerificationPolicy.skip_verification()  # Default secure decision.
+        assert not [r for r in caplog.records if "verification is OFF" in r.message]  # Silent.
+
+
+class TestCallSiteDefaults:
+    """Prove every call site now defaults to secure."""
+
+    def test_audit_engine_defaults_secure(self) -> None:
+        """The address audit verifies certificates when nothing is set."""
+        assert AddressAuditEngine._skip_ssl_verify() is False  # Was True before issue #1914.
+
+    def test_comparator_flags_default_secure(self) -> None:
+        """The inventory comparator verifies certificates by default."""
+        assert ComparatorFlags().skip_ssl_verify is False  # Was True before issue #1914.
+
+
+class TestNoBypassReturns:
+    """Guard the tree so a future edit cannot reintroduce a bypass."""
+
+    @pytest.mark.parametrize("relative_path", GUARDED_SCRIPTS)
+    def test_script_holds_no_bypass(self, relative_path: str) -> None:
+        """A guarded script must not disable certificate verification."""
+        source = (REPO_ROOT / relative_path).read_text(encoding="utf-8")  # Read the tracked file.
+        assert not BYPASS_TOKENS.search(source), f"{relative_path} reintroduced a TLS bypass"


### PR DESCRIPTION
## Linked issue

Fixes #1914

This is the application-layer half of the TLS problem. Issue #1906 covers the image layer (`Dockerfile` and `Containerfile`) and a separate agent owns that fix. Do not assume either pull request closes the whole class on its own.

## Problem

Issue #1906 reported that the `Dockerfile` disables TLS certificate verification. That report named one file. A repository sweep for `CERT_NONE`, `check_hostname = False`, `verify=False`, `PYTHONHTTPSVERIFY`, `SSL_VERIFY` and `CURL_CA_BUNDLE` found the same control defeated in six more places.

Three of those places sit in application code, so they do not need a container at all. A host run also skipped verification.

The defaults also disagreed with each other. Two call sites verified by default and three did not, so a reader could not tell which default applied to a given run.

Worse, `AddressValidator._suppress_ssl_warnings` silenced `InsecureRequestWarning` whenever verification was off. The bypass hid its own evidence. A run with no certificate check looked exactly like a normal run.

## What this pull request changes

**One control replaces seven decisions.** A new `TLSVerificationPolicy` class in `src/utils/tls_policy.py` holds the single decision. It reads `MIST_SKIP_SSL_VERIFY` and defaults to secure.

**Every insecure default is inverted.**

| Location | Before | After |
| - | - | - |
| `src/site/address_audit/audit_engine.py` | `os.environ.get(..., "true")` | Delegates to the policy, default secure |
| `src/inventory/csv_comparator.py` line 108 | `skip_ssl_verify: bool = True` | `False` |
| `src/refactors/inventory_csvcomparator.py` line 89 | `skip_ssl_verify: bool = True` | `False` |

**The opt out is now explicit and loud.** Only `true`, `1`, `yes` or `on` turn the check off. An unknown value such as a typo keeps the check on, so a mistake fails secure. A run that does turn the check off logs one WARNING that names the variable and states the risk. The warning is emitted one time, so a caller inside a loop cannot flood the log.

**The scripts no longer pin `CERT_NONE`.** `scripts/test_ssr.py`, `scripts/debug_html.py` and `scripts/mist_ideas_scraper_ssr.py` each built a default context and then removed both checks that the context exists to perform. They now use the default context unchanged. `scripts/test_ssr.py` also had no `timeout` on its `urlopen` call, so that call could block with no limit. It now passes `timeout=30`.

**The evidence is no longer hidden.** `_suppress_ssl_warnings` now announces the weakened state through the policy before it quiets the repeated urllib3 notice. The operator gets one clear statement instead of silence.

## Verification

```
python -m pytest tests/unit/utils/test_tls_policy.py -q
20 passed in 2.48s
```

The suite has three groups.

1. The policy itself. The default verifies. Each opt-in token disables. Each unknown or falsey token stays secure. A disabled run warns exactly one time. A secure run stays silent, so the warning keeps its meaning.
2. The call-site defaults. `AddressAuditEngine._skip_ssl_verify()` and `ComparatorFlags().skip_ssl_verify` are both asserted `False`. Both assertions failed before this change, which is how the defect was proven.
3. A source sweep. The test reads the three guarded scripts and fails if `CERT_NONE` or `check_hostname = False` returns to any of them. This blocks a silent regression.

Other gates on the changed files:

```
python -m py_compile <9 changed files>     no output
python -m ruff check <9 changed files>     3 findings, all pre-existing
python -m black --check <9 changed files>  clean
```

The 3 remaining ruff findings are `line-too-long` on lines 74 to 76 of `scripts/mist_ideas_scraper_ssr.py`. Those lines hold pre-existing boilerplate strings. They are outside the diff of this pull request. I left them alone rather than widen the change.

## Automated sweep safety

`ruff check --fix` removed `import os` and `from urllib.error import HTTPError, URLError` from `scripts/mist_ideas_scraper_ssr.py` as unused imports. The project rules require a symbol check after any automated sweep, because pull request #1791 once deleted a live declaration inside a large mechanical diff. I grepped the file for `os.`, `HTTPError` and `URLError` and confirmed zero references before accepting the removal.

## Note for the reviewer

This change makes previously silent failures visible. A host that genuinely sits behind a proxy that inspects TLS will now fail certificate validation instead of quietly accepting any certificate. That is the intended outcome.

The correct fix for such a host is to mount the corporate root certificate authority bundle and point `REQUESTS_CA_BUNDLE` and `SSL_CERT_FILE` at it. A mounted bundle keeps verification on and still trusts the inspecting proxy. `MIST_SKIP_SSL_VERIFY=true` remains available as a documented escape hatch, and it now announces itself.

## Conformance

- [x] The linked issue is referenced with `Fixes #1914`.
- [x] A test proves the defect and fails without the fix.
- [x] Ruff, Black and `py_compile` pass on every changed file.
- [x] No secret is added to the source tree.
- [x] Every new executable line carries an inline comment that explains the reason.
- [x] Log lines are ASCII only.
- [x] `CHANGELOG.md` is untouched, because issue #1899 records that a changelog edit conflicts with every other concurrent pull request.
