### PR TITLE
fix(firmware): bound the upgrade monitor retries and add backoff

### DIFF
--- a/src/firmware/firmware_manager.py
+++ b/src/firmware/firmware_manager.py
@@ -36,6 +36,18 @@ apisession: Any = None  # WHY: module-scope api session read by legacy helpers
 org_id: str = ""  # WHY: module-scope org id read by legacy helpers
 PROGRESS_EMITTER: Any = None  # WHY: shared progress emitter for menu 196 sub-flows
 
+# Bounded-retry policy for the continuous monitoring loop (issue #1910).
+# Before this policy a failed status check retried forever, so an expired token
+# or a Mist cloud outage left the operator with an unattended upgrade.
+MONITOR_REFRESH_SECONDS = 7  # WHY: the documented healthy cadence shown in the banner. Do not change it.
+MONITOR_MAX_CONSECUTIVE_FAILURES = 5  # WHY: 5 failed checks span about 105 seconds with the backoff below.
+MONITOR_BACKOFF_BASE_SECONDS = 7  # WHY: the first retry waits the normal cadence, so one short error costs nothing.
+MONITOR_BACKOFF_MULTIPLIER = 2  # WHY: double each wait. The sequence reads 7, 14, 28, 56 seconds.
+MONITOR_BACKOFF_MAX_SECONDS = 60  # WHY: cap the wait at 1 minute, so an outage gets at most 1 request per minute.
+MONITOR_EXIT_COMPLETE = 0  # WHY: every upgrade finished. This is the only success result.
+MONITOR_EXIT_FAILED = 1  # WHY: the status check failed too many times. A scripted caller must see a non-zero code.
+MONITOR_EXIT_CANCELLED = 2  # WHY: the operator pressed Ctrl-C. The upgrades keep running without a watcher.
+
 
 try:
     import mistapi as _mistapi_module  # WHY: optional Mist SDK - module may be absent in test env
@@ -129,6 +141,54 @@ def _bind_module_globals(config: FirmwareManagerConfig) -> None:
         msp_privileges = getattr(main_module, "msp_privileges", [])  # WHY: preserve msp cache visibility
         PROGRESS_EMITTER = getattr(main_module, "PROGRESS_EMITTER", None)  # WHY: hook up progress emitter
     logging.debug("firmware_manager module globals rebound for org %s", config.org_id)  # WHY: confirm side effects
+
+
+class MonitoringRetryPolicy:
+    """Count the consecutive failed status checks and set the next wait.
+
+    Why:
+        The continuous monitoring loop used to retry a failed check forever
+        (issue #1910). This policy holds the failure streak, reports when
+        the streak reaches the limit, and grows the wait between the failed
+        attempts. One good check clears the streak, so a single short API
+        error does not end a long upgrade watch.
+    """
+
+    def __init__(self) -> None:
+        """Start the policy with a clean failure streak."""
+        self.consecutive_failures = 0  # WHY: a fresh watch begins with no failures
+
+    def record_success(self) -> None:
+        """Clear the failure streak after a good status check."""
+        self.consecutive_failures = 0  # WHY: one good check proves the session works again
+
+    def record_failure(self) -> int:
+        """Count one failed status check.
+
+        Returns:
+            The new length of the consecutive failure streak.
+        """
+        self.consecutive_failures += 1  # WHY: only an unbroken streak can stop the loop
+        return self.consecutive_failures  # WHY: the caller reports the streak to the operator
+
+    @property
+    def exhausted(self) -> bool:
+        """Report True when the failure streak reaches the attempt limit."""
+        return self.consecutive_failures >= MONITOR_MAX_CONSECUTIVE_FAILURES  # WHY: the loop must stop here
+
+    def next_delay_seconds(self) -> int:
+        """Return the seconds to wait before the next status check.
+
+        Returns:
+            The healthy cadence when the last check passed. A capped
+            exponential backoff while the failures continue.
+        """
+        if self.consecutive_failures == 0:  # WHY: the healthy path keeps the documented cadence
+            return MONITOR_REFRESH_SECONDS
+        exponent = self.consecutive_failures - 1  # WHY: the first failure waits the base with no growth
+        growth = int(MONITOR_BACKOFF_MULTIPLIER**exponent)  # WHY: int() keeps the power typed as an integer
+        delay = MONITOR_BACKOFF_BASE_SECONDS * growth  # WHY: scale the base wait by the streak length
+        return min(delay, MONITOR_BACKOFF_MAX_SECONDS)  # WHY: the cap protects an unhealthy Mist API
 
 
 class FirmwareManager:
@@ -306,7 +366,8 @@ class FirmwareManager:
         """Route to the correct status handler based on scope."""
         if scope_choice == "5":  # WHY: continuous monitoring is separate flow
             logging.info("Entering continuous monitoring mode")  # WHY: audit
-            self._continuous_monitoring_mode(site_filter)  # WHY: dispatch
+            exit_code = self._continuous_monitoring_mode(site_filter)  # WHY: dispatch
+            logging.debug("Continuous monitoring mode returned exit_code=%s", exit_code)  # WHY: audit the outcome
             return None  # WHY: void handler completed
         if scope_choice == "6":  # WHY: org-level upgrade jobs listing
             logging.info("Fetching org-level upgrade jobs")  # WHY: audit
@@ -315,17 +376,27 @@ class FirmwareManager:
         self._execute_status_check(scope_choice, site_filter)  # WHY: default
         return None  # WHY: uniform sentinel
 
-    def _continuous_monitoring_mode(self, site_filter: str | None = None) -> None:
-        """Continuous monitoring mode that auto-refreshes upgrade status until complete or cancelled."""
+    def _continuous_monitoring_mode(self, site_filter: str | None = None) -> int:
+        """Watch the active upgrades until they finish, the checks fail, or the operator exits.
+
+        Args:
+            site_filter: The site to watch. None watches the whole org.
+
+        Returns:
+            ``MONITOR_EXIT_COMPLETE`` when every upgrade finished.
+            ``MONITOR_EXIT_FAILED`` when the status check failed too many times.
+            ``MONITOR_EXIT_CANCELLED`` when the operator pressed Ctrl-C.
+        """
         logging.info("Entering continuous monitoring mode site_filter=%s", site_filter)  # WHY: audit entry
         self._present_monitoring_header()  # WHY: emit banner explaining refresh cadence + Ctrl-C exit
         try:  # WHY: outer try catches user Ctrl-C for clean exit
-            self._run_monitoring_loop(site_filter)  # WHY: delegate refresh loop to helper
+            exit_code = self._run_monitoring_loop(site_filter)  # WHY: delegate refresh loop to helper
         except KeyboardInterrupt:  # WHY: operator pressed Ctrl-C mid-refresh
             print("\n\n  Monitoring mode cancelled by user.")  # WHY: visible exit banner
             logging.info("Continuous monitoring mode cancelled by user")  # WHY: audit user cancel
-            return  # WHY: exit without raising further
-        logging.debug("Continuous monitoring mode exited normally")  # WHY: trace clean exit
+            return MONITOR_EXIT_CANCELLED  # WHY: a cancel is not a completed upgrade watch
+        logging.debug("Continuous monitoring mode exited exit_code=%s", exit_code)  # WHY: trace the outcome
+        return exit_code  # WHY: hand the result to a scripted caller
 
     def _present_monitoring_header(self) -> None:  # WHY: extract banner block for testability
         """Print the fixed banner describing monitoring behavior."""
@@ -333,22 +404,86 @@ class FirmwareManager:
         print("=" * 70)  # WHY: divider matches other section headers
         print("   Monitoring active firmware upgrades...")  # WHY: purpose line
         print("   Press Ctrl+C to exit at any time")  # WHY: exit instruction
-        print("   Auto-refreshing every 7 seconds")  # WHY: cadence disclosure
+        print(f"   Auto-refreshing every {MONITOR_REFRESH_SECONDS} seconds")  # WHY: cadence disclosure
+        print(
+            f"   The monitor stops after {MONITOR_MAX_CONSECUTIVE_FAILURES} failed status checks in a row"
+        )  # WHY: tell the operator the watch can end on its own
         print("   NOTE: Each refresh scans ALL devices for active upgrades")  # WHY: scope disclosure
         print("=" * 70)  # WHY: closing divider
-        logging.info("Starting continuous monitoring mode with 7-second refresh interval")  # WHY: audit
+        logging.info(
+            "Starting continuous monitoring mode refresh_seconds=%d failure_limit=%d",
+            MONITOR_REFRESH_SECONDS,
+            MONITOR_MAX_CONSECUTIVE_FAILURES,
+        )  # WHY: audit the cadence and the retry bound at the start of every watch
 
-    def _run_monitoring_loop(self, site_filter: str | None) -> None:
-        """Drive the poll-print-sleep loop until all upgrades complete."""
+    def _run_monitoring_loop(self, site_filter: str | None) -> int:
+        """Drive the poll-print-sleep loop until the upgrades finish or the checks fail.
+
+        Args:
+            site_filter: The site to watch. None watches the whole org.
+
+        Returns:
+            ``MONITOR_EXIT_COMPLETE`` when every upgrade finished, or
+            ``MONITOR_EXIT_FAILED`` after the consecutive failure limit.
+        """
         iteration = 0  # WHY: counter used in refresh banner
-        while True:  # WHY: loop exits via break when all upgrades done or via KeyboardInterrupt
+        policy = MonitoringRetryPolicy()  # WHY: bound the retries so a broken session cannot loop forever
+        while True:  # WHY: the loop exits on completion, on the failure limit, or on Ctrl-C
             iteration += 1  # WHY: increment before display so first refresh reads #1
             self._clear_monitoring_screen()  # WHY: fresh visual for each iteration
             self._present_monitoring_iteration_header(iteration)  # WHY: banner per iteration
             result = self._execute_monitoring_check(site_filter)  # WHY: fetch upgrades
             if self._handle_monitoring_result(result, iteration):  # WHY: True means loop should exit
-                return  # WHY: propagate loop-exit signal
-            time.sleep(7)  # WHY: pause before next refresh per documented cadence
+                return MONITOR_EXIT_COMPLETE  # WHY: every upgrade finished. Report success
+            if self._record_monitoring_attempt(result, policy, iteration):  # WHY: True means the limit is reached
+                return MONITOR_EXIT_FAILED  # WHY: report the stop so a scripted caller can react
+            time.sleep(policy.next_delay_seconds())  # WHY: normal cadence, or backoff after a failed check
+
+    def _record_monitoring_attempt(self, result: int | None, policy: MonitoringRetryPolicy, iteration: int) -> bool:
+        """Update the retry policy for one status check.
+
+        Args:
+            result: The check result. None marks a failed check.
+            policy: The retry policy that holds the failure streak.
+            iteration: The refresh number shown to the operator.
+
+        Returns:
+            True when the failure streak reached the limit and the loop must stop.
+        """
+        if result is not None:  # WHY: a good check clears the streak, so one short error cannot end a long watch
+            policy.record_success()  # WHY: reset the counter and the backoff
+            return False  # WHY: keep watching
+        failures = policy.record_failure()  # WHY: count this failure and read the new streak length
+        logging.warning(
+            "Monitoring status check failed iteration=%d consecutive=%d limit=%d",
+            iteration,
+            failures,
+            MONITOR_MAX_CONSECUTIVE_FAILURES,
+        )  # WHY: leave an audit trail of every failed check, not only the last one
+        if not policy.exhausted:  # WHY: below the limit the operator only needs the retry notice
+            wait_seconds = policy.next_delay_seconds()  # WHY: show the real wait, which grows per failure
+            print(f"   Retry {failures} of {MONITOR_MAX_CONSECUTIVE_FAILURES} in {wait_seconds} seconds...")
+            return False  # WHY: keep watching
+        self._present_monitoring_failure(failures)  # WHY: tell the operator what failed and what to do next
+        return True  # WHY: signal the loop to stop
+
+    def _present_monitoring_failure(self, failures: int) -> None:
+        """Print the final failure block after the retry limit.
+
+        Args:
+            failures: The number of consecutive failed status checks.
+        """
+        print(f"\n  MONITORING STOPPED after {failures} failed status checks in a row.")  # WHY: clear final state
+        print("   The Mist API did not answer the upgrade status request.")  # WHY: name the cause
+        print("   The firmware upgrade can continue. This tool no longer watches it.")  # WHY: prevent a false belief
+        print("   Do these steps:")  # WHY: give the operator a short recovery list
+        print("   1. Check that your Mist API token is valid and not expired.")  # WHY: the most common cause
+        print("   2. Check the network path from this host to the Mist cloud.")  # WHY: the second cause
+        print("   3. Check the Mist cloud status page for an outage.")  # WHY: the third cause
+        print("   4. Start the monitor again after you correct the problem.")  # WHY: the recovery action
+        logging.error(
+            "Continuous monitoring stopped after %d consecutive failed status checks", failures
+        )  # WHY: ASCII audit record of the final failure for the run log
 
     def _clear_monitoring_screen(self) -> None:  # WHY: platform abstraction wrapped in a helper
         """Clear the terminal window between refreshes."""
@@ -371,9 +506,9 @@ class FirmwareManager:
     def _handle_monitoring_result(self, result: int | None, iteration: int) -> bool:
         """Interpret the check result. Return True if loop should exit."""
         if result is None:  # WHY: transient error path
-            print("\n   Error fetching upgrade status. Retrying...")  # WHY: user-visible retry hint
+            print("\n   Error fetching upgrade status.")  # WHY: user-visible failure notice
             logging.warning("Monitoring iteration %s failed", iteration)  # WHY: audit failure
-            return False  # WHY: keep polling despite one failed iteration
+            return False  # WHY: the retry policy decides whether the loop continues
         if result == 0:  # WHY: zero active upgrades => job complete
             print("\n  All upgrades completed!")  # WHY: completion banner
             print("   No active firmware upgrades detected.")  # WHY: clarify outcome
@@ -381,7 +516,7 @@ class FirmwareManager:
             logging.info("Monitoring mode exiting - all upgrades complete")  # WHY: audit success
             return True  # WHY: signal loop exit
         print(f"\n   Found {result} device(s) actively upgrading")  # WHY: progress signal
-        print("   Next refresh in 7 seconds...")  # WHY: set expectation for cadence
+        print(f"   Next refresh in {MONITOR_REFRESH_SECONDS} seconds...")  # WHY: set expectation for cadence
         return False  # WHY: continue polling
 
     def _print_upgrade_job_timing_info(self, details: dict[str, Any]) -> None:

--- a/tests/unit/firmware/test_firmware_manager_monitoring.py
+++ b/tests/unit/firmware/test_firmware_manager_monitoring.py
@@ -44,6 +44,57 @@ def _make_manager(**overrides: Any) -> FirmwareManager:
     return FirmwareManager(FirmwareManagerConfig(**defaults))
 
 
+_CHECK_CALL_CEILING = 40  # WHY: far above the retry limit. A regression trips this instead of hanging.
+
+
+class _ScriptedCheck:
+    """Return a scripted list of status-check results and refuse to run forever.
+
+    Why:
+        Before issue #1910 the monitoring loop retried a failed check
+        forever. A plain endless fake would hang the whole test suite, so
+        this helper raises after a hard call ceiling. A regression then
+        fails fast with a readable message instead of blocking CI.
+    """
+
+    def __init__(self, results: list[int | None]) -> None:
+        """Store the scripted results and reset the call counter.
+
+        Args:
+            results: One result per call. The last result repeats forever.
+        """
+        self.results = results  # WHY: drive one loop iteration per entry
+        self.calls = 0  # WHY: the tests assert how many checks the loop ran
+
+    def __call__(self, _site_filter: str | None) -> int | None:
+        """Return the next scripted result and count the call."""
+        self.calls += 1  # WHY: record this iteration before any early exit
+        if self.calls > _CHECK_CALL_CEILING:  # WHY: the loop must stop long before this point
+            raise AssertionError(f"the monitoring loop ran {self.calls} checks and did not stop")
+        if self.calls <= len(self.results):  # WHY: still inside the scripted part
+            return self.results[self.calls - 1]  # WHY: scripts are 0-indexed, calls start at 1
+        return self.results[-1]  # WHY: hold the final state so a broken loop keeps failing
+
+
+def _wire_monitoring_loop(mgr: FirmwareManager, monkeypatch: pytest.MonkeyPatch, check: _ScriptedCheck) -> list[int]:
+    """Silence the screen work, inject the scripted check, and capture the sleeps.
+
+    Args:
+        mgr: The manager under test.
+        monkeypatch: The pytest patching fixture.
+        check: The scripted status check to inject.
+
+    Returns:
+        A list that collects every delay the loop passes to ``time.sleep``.
+    """
+    delays: list[int] = []  # WHY: the backoff assertions read the recorded delays
+    monkeypatch.setattr(mgr, "_clear_monitoring_screen", lambda: None)  # WHY: no terminal reset in a test
+    monkeypatch.setattr(mgr, "_present_monitoring_iteration_header", lambda _i: None)  # WHY: quiet banner
+    monkeypatch.setattr(mgr, "_execute_monitoring_check", check)  # WHY: control every check result
+    monkeypatch.setattr(fm_mod.time, "sleep", lambda seconds: delays.append(seconds))  # WHY: run fast
+    return delays  # WHY: hand the recorder to the caller
+
+
 class TestPresentMonitoringHeader:
     """``_present_monitoring_header`` banner block.
 
@@ -120,13 +171,13 @@ class TestHandleMonitoringResult:
         the monitoring loop or exits it early.
     """
 
-    def test_none_result_prints_retry_and_continues(
+    def test_none_result_prints_error_and_continues(
         self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
     ) -> None:
         caplog.set_level(logging.WARNING, logger="root")
         assert _make_manager()._handle_monitoring_result(None, 3) is False
         out = capsys.readouterr().out
-        assert "Error fetching upgrade status. Retrying..." in out
+        assert "Error fetching upgrade status." in out
         assert any("Monitoring iteration 3 failed" in r.message for r in caplog.records)
 
     def test_zero_result_signals_completion(
@@ -198,8 +249,137 @@ class TestContinuousMonitoringMode:
             raise KeyboardInterrupt
 
         monkeypatch.setattr(mgr, "_run_monitoring_loop", raise_kb)
-        mgr._continuous_monitoring_mode(None)
+        assert mgr._continuous_monitoring_mode(None) == fm_mod.MONITOR_EXIT_CANCELLED
         assert "Monitoring mode cancelled by user." in capsys.readouterr().out
+
+    def test_returns_the_loop_exit_code(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_present_monitoring_header", lambda: None)
+        monkeypatch.setattr(mgr, "_run_monitoring_loop", lambda _sf: fm_mod.MONITOR_EXIT_FAILED)
+        assert mgr._continuous_monitoring_mode("site-a") == fm_mod.MONITOR_EXIT_FAILED
+
+
+class TestMonitoringRetryPolicy:
+    """``MonitoringRetryPolicy`` failure counting and backoff growth.
+
+    Why:
+        The policy is the only guard that stops an endless retry loop when
+        the Mist API stays down (issue #1910). A wrong counter ends a
+        healthy watch too early. A missing cap keeps a request going to an
+        unhealthy API every few seconds.
+    """
+
+    def test_healthy_delay_matches_the_documented_cadence(self) -> None:
+        policy = fm_mod.MonitoringRetryPolicy()
+        assert policy.consecutive_failures == 0
+        assert policy.next_delay_seconds() == fm_mod.MONITOR_REFRESH_SECONDS
+
+    def test_delay_grows_and_stops_at_the_cap(self) -> None:
+        policy = fm_mod.MonitoringRetryPolicy()
+        delays: list[int] = []
+        for _ in range(8):  # WHY: more failures than the cap needs, so the ceiling is visible
+            policy.record_failure()
+            delays.append(policy.next_delay_seconds())
+        assert delays[0] == fm_mod.MONITOR_BACKOFF_BASE_SECONDS
+        assert delays[1] == fm_mod.MONITOR_BACKOFF_BASE_SECONDS * fm_mod.MONITOR_BACKOFF_MULTIPLIER
+        assert delays == sorted(delays)  # WHY: the wait never shrinks while the failures continue
+        assert max(delays) == fm_mod.MONITOR_BACKOFF_MAX_SECONDS
+
+    def test_success_clears_the_failure_streak(self) -> None:
+        policy = fm_mod.MonitoringRetryPolicy()
+        policy.record_failure()
+        policy.record_failure()
+        policy.record_success()
+        assert policy.consecutive_failures == 0
+        assert policy.exhausted is False
+        assert policy.next_delay_seconds() == fm_mod.MONITOR_REFRESH_SECONDS
+
+    def test_exhausted_reports_true_at_the_limit(self) -> None:
+        policy = fm_mod.MonitoringRetryPolicy()
+        for _ in range(fm_mod.MONITOR_MAX_CONSECUTIVE_FAILURES - 1):
+            assert policy.record_failure() < fm_mod.MONITOR_MAX_CONSECUTIVE_FAILURES
+            assert policy.exhausted is False
+        assert policy.record_failure() == fm_mod.MONITOR_MAX_CONSECUTIVE_FAILURES
+        assert policy.exhausted is True
+
+
+class TestRunMonitoringLoopRetryBound:
+    """``_run_monitoring_loop`` bounded retry behavior (issue #1910).
+
+    Why:
+        An expired token or a Mist cloud outage made every status check
+        fail. The loop retried forever and the operator saw no final
+        error. These tests pin the attempt limit, the backoff, the reset
+        after one good check, and the non-zero result.
+    """
+
+    @pytest.mark.timeout(15)
+    def test_stops_after_the_consecutive_failure_limit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level(logging.ERROR, logger="root")
+        mgr = _make_manager()
+        check = _ScriptedCheck([None])  # WHY: every check fails, like a revoked token
+        delays = _wire_monitoring_loop(mgr, monkeypatch, check)
+        exit_code = mgr._run_monitoring_loop("site-down")
+        assert exit_code == fm_mod.MONITOR_EXIT_FAILED
+        assert check.calls == fm_mod.MONITOR_MAX_CONSECUTIVE_FAILURES
+        assert len(delays) == fm_mod.MONITOR_MAX_CONSECUTIVE_FAILURES - 1  # WHY: no sleep after the last check
+        assert delays == sorted(delays)  # WHY: the backoff grows between the failed attempts
+        assert max(delays) <= fm_mod.MONITOR_BACKOFF_MAX_SECONDS
+        out = capsys.readouterr().out
+        assert "MONITORING STOPPED" in out
+        assert "Mist API token" in out  # WHY: the operator needs the next action, not only the error
+        assert any("consecutive failed status checks" in r.message for r in caplog.records)
+
+    @pytest.mark.timeout(15)
+    def test_one_failure_then_success_keeps_watching(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mgr = _make_manager()
+        # Four failures, one good check, four more failures, then the upgrade completes.
+        # Without a reset the ninth check would exceed the limit and end the watch.
+        check = _ScriptedCheck([None, None, None, None, 2, None, None, None, None, 0])
+        delays = _wire_monitoring_loop(mgr, monkeypatch, check)
+        exit_code = mgr._run_monitoring_loop(None)
+        assert exit_code == fm_mod.MONITOR_EXIT_COMPLETE
+        assert check.calls == 10
+        assert delays[4] == fm_mod.MONITOR_REFRESH_SECONDS  # WHY: the good check restores the cadence
+        assert delays[5] == fm_mod.MONITOR_BACKOFF_BASE_SECONDS  # WHY: the backoff restarts at the base
+        assert "MONITORING STOPPED" not in capsys.readouterr().out
+
+    @pytest.mark.timeout(15)
+    def test_healthy_loop_keeps_the_seven_second_cadence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        check = _ScriptedCheck([3, 2, 1, 0])  # WHY: a normal upgrade that drains to zero
+        delays = _wire_monitoring_loop(mgr, monkeypatch, check)
+        assert mgr._run_monitoring_loop(None) == fm_mod.MONITOR_EXIT_COMPLETE
+        assert delays == [fm_mod.MONITOR_REFRESH_SECONDS] * 3
+
+
+class TestRecordMonitoringAttempt:
+    """``_record_monitoring_attempt`` counter updates and the stop signal."""
+
+    def test_success_resets_the_counter_and_continues(self) -> None:
+        mgr = _make_manager()
+        policy = fm_mod.MonitoringRetryPolicy()
+        policy.record_failure()
+        assert mgr._record_monitoring_attempt(4, policy, 2) is False
+        assert policy.consecutive_failures == 0
+
+    def test_failure_below_the_limit_continues(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="root")
+        mgr = _make_manager()
+        policy = fm_mod.MonitoringRetryPolicy()
+        assert mgr._record_monitoring_attempt(None, policy, 1) is False
+        assert policy.consecutive_failures == 1
+        assert "Retry 1 of" in capsys.readouterr().out
+        assert any("status check failed" in r.message for r in caplog.records)
 
 
 class TestPrintUpgradeJobTimingInfo:


### PR DESCRIPTION
Fixes #1910

## Problem

The continuous firmware upgrade monitor retried a failed status check forever.
`_handle_monitoring_result` returned `False` for a failed check, and `False`
means "keep looping". The loop then slept a flat 7 seconds and tried again.

An expired token, a revoked token, or a Mist API outage turned the monitor into
a loop with no end. The operator saw the line "Retrying..." repeat forever and
had no way to tell a slow upgrade from a broken session. The loop also sent a
request to the Mist API every 7 seconds while the API was already unhealthy.
The only exit was Ctrl-C.

## Fix

- Add the `MonitoringRetryPolicy` class. It holds the consecutive failure
  count, reports when the count reaches the limit, and returns the delay
  before the next check.
- Add `FirmwareManager._record_monitoring_attempt`. It updates the policy for
  one check and tells the loop to stop when the limit is reached. A successful
  check clears the count, so one short API error cannot end a long watch.
- Add `FirmwareManager._present_monitoring_failure`. It prints the final
  failure block, names the cause, and lists four recovery steps for the
  operator.
- `_run_monitoring_loop` and `_continuous_monitoring_mode` now return an exit
  code, so a scripted caller can detect the outcome.
- Every failed check writes a `logging.warning` record with the streak length,
  and the final stop writes a `logging.error` record. All log text is ASCII.

## Chosen values

Each value is a named module constant with a comment that explains it.

| Constant | Value | Reason |
| - | - | - |
| `MONITOR_REFRESH_SECONDS` | 7 | The documented healthy cadence in the banner. It does not change. |
| `MONITOR_MAX_CONSECUTIVE_FAILURES` | 5 | Five failed checks span about 105 seconds with the backoff. That is long enough to ride out a short API error and short enough to warn the operator quickly. |
| `MONITOR_BACKOFF_BASE_SECONDS` | 7 | The first retry waits the normal cadence, so a single failure costs no extra time. |
| `MONITOR_BACKOFF_MULTIPLIER` | 2 | Each wait doubles. The sequence reads 7, 14, 28, 56 seconds. |
| `MONITOR_BACKOFF_MAX_SECONDS` | 60 | The cap holds the request rate at one per minute during an outage. |
| `MONITOR_EXIT_COMPLETE` | 0 | Every upgrade finished. This is the only success result. |
| `MONITOR_EXIT_FAILED` | 1 | The status check failed too many times. |
| `MONITOR_EXIT_CANCELLED` | 2 | The operator pressed Ctrl-C. |

The healthy path keeps the 7 second cadence. The backoff applies only while
the failures continue.

## Structural compliance

Every new method stays under the 25 line limit and the 5 parameter limit.
`_record_monitoring_attempt` takes 4 parameters including `self`. The new
behavior lives in the `MonitoringRetryPolicy` class and in methods on
`FirmwareManager`. No standalone wrapper function was added.

## Verification

The defect test failed first, as required. Before the fix the scripted check
raised after a hard call ceiling:

```
tests/unit/firmware/test_firmware_manager_monitoring.py:73: AssertionError:
the monitoring loop ran 41 checks and did not stop
1 failed in 0.68s
```

After the fix:

```
python -m pytest tests/unit/firmware/test_firmware_manager_monitoring.py -q
59 passed in 2.02s
```

The whole firmware test package also passes:

```
python -m pytest tests/unit/firmware -q
688 passed in 12.53s
```

Quality gates:

```
python -m ruff check src/firmware tests      -> All checks passed!
python -m black --check src/firmware tests   -> 421 files would be left unchanged
python -m mypy src/firmware --config-file pyproject.toml -> Success: no issues found in 6 source files
python -m radon cc src/firmware/firmware_manager.py -n C -> no block above complexity C
python -m vulture src/firmware/firmware_manager.py --min-confidence 70 -> no findings
python -m pydocstyle src/firmware/firmware_manager.py -> no findings
python -m interrogate -c pyproject.toml src/firmware/firmware_manager.py -> PASSED 100.0%
```

## New tests

- `test_stops_after_the_consecutive_failure_limit` proves the loop stops at the
  limit, returns `MONITOR_EXIT_FAILED`, grows the delay, and prints the
  recovery steps.
- `test_one_failure_then_success_keeps_watching` proves that four failures, one
  good check, and four more failures do not end the watch.
- `test_healthy_loop_keeps_the_seven_second_cadence` proves the healthy path
  still sleeps 7 seconds.
- `TestMonitoringRetryPolicy` pins the backoff growth, the cap, and the reset.
- `TestRecordMonitoringAttempt` pins the counter update and the stop signal.

Every loop test carries `@pytest.mark.timeout(15)`. The scripted check also
raises after 40 calls, so a regression fails fast instead of hanging CI.

## Correction to an earlier note in this pull request

An earlier version of this text reported a failure in
`tests/unit/firmware/test_firmware_manager_ssr.py::TestBulkUpgradeSwitchFirmwareBySite::test_delegates_to_bulk_switch_upgrader`
with `AttributeError: module 'MistHelper' has no attribute 'InputUtils'`, and
called it a pre-existing product defect. That conclusion was wrong. Read this
paragraph instead.

The cause was a missing `paramiko` package in a fresh worktree, which is issue
#1866. `MistHelper.py` imports `EnhancedSSHRunner`, that import reaches
`src/ssh/connection/connector.py`, and the missing `paramiko` raises there.
Python then leaves a partly built `MistHelper` module in `sys.modules`.
`MistHelper.py` binds `InputUtils` far below the failed import line, so the
name never binds. `_MistHelperProxy.__getattr__` reads the partly built module
from the cache and reports the missing name in place of the missing package.

After the install of `paramiko` the test passes with no other change, and the
whole firmware package passes: 688 passed. No new issue is needed.

## Scope

Only `src/firmware/firmware_manager.py` and
`tests/unit/firmware/test_firmware_manager_monitoring.py` changed. `CHANGELOG.md`
is not edited, per issue #1899.
