### PR TITLE
security(container): verify TLS certificates by default in the image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,14 @@
 # MistHelper Container Image
 # Compatible with both Docker and Podman (OCI-compliant)
-# Features: SSH access on port 2200, SQLite persistence, corporate SSL bypass
+# Features: SSH access on port 2200, SQLite persistence, TLS verification on
 # Usage: podman build -t misthelper . OR docker build -t misthelper .
+#
+# Corporate proxy support (issue #1906):
+# The image verifies every TLS certificate. It never disables the check.
+# If you build behind a TLS-inspecting proxy, add the proxy root certificate:
+#   podman build --build-arg INSTALL_CORPORATE_CA=true -t misthelper .
+# At run time, mount the proxy root certificate instead:
+#   -v /path/to/corp-root-ca.crt:/usr/local/share/ca-certificates/corp-root-ca.crt:ro
 FROM python:3.13-slim
 
 # Metadata following OCI standards
@@ -64,15 +71,30 @@ RUN mkdir -p /home/misthelper/.ssh && \
     chmod 700 /home/misthelper/.ssh && \
     chmod 600 /home/misthelper/.ssh/known_hosts
 
+# Optional corporate root certificate for a TLS-inspecting proxy.
+# The build keeps certificate verification on. It never turns the check off.
+# Set INSTALL_CORPORATE_CA=true to add the supplied root certificate to the
+# system trust store. The default value of false ships a clean trust store.
+ARG INSTALL_CORPORATE_CA=false
+ARG CORPORATE_CA_FILE=zscaler-root-ca.crt
+COPY ${CORPORATE_CA_FILE} /tmp/corporate-root-ca.crt
+RUN if [ "${INSTALL_CORPORATE_CA}" = "true" ]; then \
+        echo "[TLS] Adding the corporate root certificate to the trust store" && \
+        cp /tmp/corporate-root-ca.crt /usr/local/share/ca-certificates/corporate-root-ca.crt && \
+        update-ca-certificates ; \
+    else \
+        echo "[TLS] Skipping the corporate root certificate. The default trust store applies." ; \
+    fi && \
+    rm -f /tmp/corporate-root-ca.crt
+
 # Copy requirements first for better Docker layer caching
 COPY requirements.txt ./
 COPY pyproject.toml ./
 
-# Install Python dependencies with SSL bypass for corporate environments
-RUN pip install --no-cache-dir -r requirements.txt \
-        --trusted-host pypi.org \
-        --trusted-host pypi.python.org \
-        --trusted-host files.pythonhosted.org
+# Install Python dependencies. Every download validates the TLS certificate.
+# Warning: Do not add --trusted-host. That flag disables certificate
+# verification and lets an attacker replace a package during the build.
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application files
 COPY MistHelper.py __init__.py wsgi.py ./
@@ -88,14 +110,17 @@ RUN chmod +x /start.sh
 
 USER misthelper
 
-# Environment variables for SSL bypass and container-specific configurations
+# Environment variables for container-specific configurations
 ENV PYTHONUNBUFFERED=1
 ENV OUTPUT_FORMAT=sqlite
 ENV DATABASE_PATH=/app/data/mist_data.db
-ENV PYTHONHTTPSVERIFY=0
-ENV SSL_VERIFY=false
-ENV REQUESTS_CA_BUNDLE=""
-ENV CURL_CA_BUNDLE=""
+# TLS trust settings. The image verifies every certificate by default.
+# update-ca-certificates writes the merged bundle to this same path, so a
+# mounted corporate root certificate works without any further change.
+ENV PYTHONHTTPSVERIFY=1
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 # Container-specific overrides: Disable UV and auto-installation for reliability
 ENV DISABLE_UV_CHECK=true
 ENV DISABLE_AUTO_INSTALL=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
 # MistHelper Container Image
 # Compatible with both Docker and Podman (OCI-compliant)
-# Features: SSH access on port 2200, SQLite persistence, corporate SSL bypass
+# Features: SSH access on port 2200, SQLite persistence, TLS verification on
 # Usage: podman build -t misthelper . OR docker build -t misthelper .
+#
+# Corporate proxy support (issue #1906):
+# The image verifies every TLS certificate. It never disables the check.
+# If you build behind a TLS-inspecting proxy, add the proxy root certificate:
+#   podman build --build-arg INSTALL_CORPORATE_CA=true -t misthelper .
+# At run time, mount the proxy root certificate instead:
+#   -v /path/to/corp-root-ca.crt:/usr/local/share/ca-certificates/corp-root-ca.crt:ro
 FROM python:3.13-slim
 
 # Metadata following OCI standards
@@ -64,15 +71,30 @@ RUN mkdir -p /home/misthelper/.ssh && \
     chmod 700 /home/misthelper/.ssh && \
     chmod 600 /home/misthelper/.ssh/known_hosts
 
+# Optional corporate root certificate for a TLS-inspecting proxy.
+# The build keeps certificate verification on. It never turns the check off.
+# Set INSTALL_CORPORATE_CA=true to add the supplied root certificate to the
+# system trust store. The default value of false ships a clean trust store.
+ARG INSTALL_CORPORATE_CA=false
+ARG CORPORATE_CA_FILE=zscaler-root-ca.crt
+COPY ${CORPORATE_CA_FILE} /tmp/corporate-root-ca.crt
+RUN if [ "${INSTALL_CORPORATE_CA}" = "true" ]; then \
+        echo "[TLS] Adding the corporate root certificate to the trust store" && \
+        cp /tmp/corporate-root-ca.crt /usr/local/share/ca-certificates/corporate-root-ca.crt && \
+        update-ca-certificates ; \
+    else \
+        echo "[TLS] Skipping the corporate root certificate. The default trust store applies." ; \
+    fi && \
+    rm -f /tmp/corporate-root-ca.crt
+
 # Copy requirements first for better Docker layer caching
 COPY requirements.txt ./
 COPY pyproject.toml ./
 
-# Install Python dependencies with SSL bypass for corporate environments
-RUN pip install --no-cache-dir -r requirements.txt \
-        --trusted-host pypi.org \
-        --trusted-host pypi.python.org \
-        --trusted-host files.pythonhosted.org
+# Install Python dependencies. Every download validates the TLS certificate.
+# Warning: Do not add --trusted-host. That flag disables certificate
+# verification and lets an attacker replace a package during the build.
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application files
 COPY MistHelper.py __init__.py ./
@@ -86,14 +108,17 @@ RUN chmod +x /start.sh
 
 USER misthelper
 
-# Environment variables for SSL bypass and container-specific configurations
+# Environment variables for container-specific configurations
 ENV PYTHONUNBUFFERED=1
 ENV OUTPUT_FORMAT=sqlite
 ENV DATABASE_PATH=/app/data/mist_data.db
-ENV PYTHONHTTPSVERIFY=0
-ENV SSL_VERIFY=false
-ENV REQUESTS_CA_BUNDLE=""
-ENV CURL_CA_BUNDLE=""
+# TLS trust settings. The image verifies every certificate by default.
+# update-ca-certificates writes the merged bundle to this same path, so a
+# mounted corporate root certificate works without any further change.
+ENV PYTHONHTTPSVERIFY=1
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 # Container-specific overrides: Disable UV and auto-installation for reliability
 ENV DISABLE_UV_CHECK=true
 ENV DISABLE_AUTO_INSTALL=true

--- a/README.md
+++ b/README.md
@@ -50,6 +50,30 @@ same gate closes that issue when it passes again.
 
 See `deploy/.env.example` for environment variable documentation. For full container and SSH setup, see the [Container Setup](https://github.com/jmorrison-juniper/MistHelper/wiki/Container-Setup) and [SSH Remote Access](https://github.com/jmorrison-juniper/MistHelper/wiki/SSH-Remote-Access) wiki pages.
 
+### Corporate proxy and TLS certificates
+
+The container image verifies every TLS certificate. It never disables the check.
+
+Warning: Do not set `PYTHONHTTPSVERIFY=0`, and do not set a CA bundle variable to
+an empty value. Without the check, an attacker on the network path can read your
+Mist API token.
+
+If you sit behind a TLS-inspecting proxy such as Zscaler, mount the proxy root
+certificate. The container adds it to the system trust store at start time.
+
+```powershell
+podman run -d --name misthelper -p 2200:2200 -p 8055:8055 `
+  -v "${PWD}/data:/app/data:rw" -v "${PWD}/.env:/app/.env:ro" `
+  -v "${PWD}/zscaler-root-ca.crt:/usr/local/share/ca-certificates/corp-root-ca.crt:ro" `
+  ghcr.io/jmorrison-juniper/misthelper:latest
+```
+
+To build behind the same proxy, add the root certificate at build time:
+
+```powershell
+podman build --build-arg INSTALL_CORPORATE_CA=true -t misthelper -f Containerfile .
+```
+
 ---
 
 ## Visual Documentation
@@ -217,7 +241,7 @@ mindmap
 | `data/SSH_COMMANDS.CSV` | Fallback SSH command list (legacy root path still supported) |
 | `delay_metrics.json` / `tuning_data.json` | Adaptive rate / tuning persistence |
 | `data/script.log` | Unified runtime log |
-| `Dockerfile` / `Containerfile` | Two container strategies (UV hybrid vs simplified SSL-bypass) |
+| `Dockerfile` / `Containerfile` | Two container strategies (UV hybrid vs simplified pip build). Both verify TLS certificates. |
 | `compose.yml` | Orchestrated service definition (uses `Containerfile` by default) |
 | `agents.md` | Internal "Agents Guide" (style, safety, refactor guidance) |
 
@@ -577,6 +601,7 @@ SQLite, and ArangoDB backends.
 | SSH | Paramiko host key auto-add restricted to trusted internal contexts |
 | Logging | Secrets & tokens excluded; debug gating prevents noisy stdout |
 | Data Integrity | Natural/composite PK strategies avoid silent duplication |
+| Container TLS | The image verifies every certificate. A corporate proxy needs a mounted root certificate, not a disabled check. |
 
 Before extending destructive workflows, replicate existing confirmation pattern and add SECURITY comments as per `agents.md`.
 

--- a/container/scripts/start.sh
+++ b/container/scripts/start.sh
@@ -17,6 +17,36 @@ touch /app/data/ssh.log
 chown misthelper:misthelper /app/data/ssh.log
 chmod 664 /app/data/ssh.log
 
+# Corporate TLS trust store.
+# The image verifies every TLS certificate. An operator behind a
+# TLS-inspecting proxy mounts the proxy root certificate into
+# /usr/local/share/ca-certificates. This step adds the mounted certificate to
+# the system trust store, so the check stays on. See issue #1906.
+CUSTOM_CA_DIR="/usr/local/share/ca-certificates"
+if ls -A "$CUSTOM_CA_DIR"/*.crt >/dev/null 2>&1; then
+    echo "[TLS] Installing operator-supplied root certificates from $CUSTOM_CA_DIR" >> /app/data/ssh.log
+    update-ca-certificates >> /app/data/ssh.log 2>&1 || true
+    echo "[TLS] Trust store updated. Certificate verification stays on." >> /app/data/ssh.log
+else
+    echo "[TLS] No operator-supplied root certificate found. The default trust store applies." >> /app/data/ssh.log
+fi
+
+# Report a run-time bypass of certificate verification.
+# A bypass is never the default. An operator must pass the variable at run
+# time. The container records a warning, so the operator sees the exposure.
+if [ "${PYTHONHTTPSVERIFY:-1}" = "0" ]; then
+    echo "[TLS] WARNING: PYTHONHTTPSVERIFY=0 turns off certificate verification." >> /app/data/ssh.log
+    echo "[TLS] WARNING: An attacker on the network path can read the Mist API token." >> /app/data/ssh.log
+fi
+for CA_VARIABLE in REQUESTS_CA_BUNDLE CURL_CA_BUNDLE SSL_CERT_FILE; do
+    # An empty value removes the trust store. An unset value keeps the default.
+    CA_VALUE="${!CA_VARIABLE-unset}"
+    if [ -z "$CA_VALUE" ]; then
+        echo "[TLS] WARNING: $CA_VARIABLE is empty, which removes the trust store." >> /app/data/ssh.log
+        echo "[TLS] WARNING: Point $CA_VARIABLE at a mounted root certificate." >> /app/data/ssh.log
+    fi
+done
+
 # If a different username is requested, create it (idempotent).
 if ! id "$USERNAME" >/dev/null 2>&1; then
     echo "[SSH] Creating user $USERNAME" >> /app/data/ssh.log

--- a/documentation/sample.env
+++ b/documentation/sample.env
@@ -187,11 +187,25 @@ RADIUS_FAST_DOT1X=true
 # CONTAINER_TIMEZONE=UTC
 # CONTAINER_USER=misthelper
 
-# SSL and HTTPS Configuration for containers
-PYTHONHTTPSVERIFY=0
-SSL_VERIFY=false
-REQUESTS_CA_BUNDLE=
-CURL_CA_BUNDLE=
+# TLS certificate verification for containers
+#
+# Warning: Do not turn certificate verification off. Without the check, an
+# attacker on the network path can present a self-signed certificate and read
+# the Mist API token. Issue #1906 records the defect.
+#
+# The image verifies every certificate by default and needs no setting here.
+#
+# If you sit behind a TLS-inspecting corporate proxy, mount the proxy root
+# certificate and keep verification on:
+#   podman run -v /path/to/corp-root-ca.crt:/usr/local/share/ca-certificates/corp-root-ca.crt:ro ...
+# The container entrypoint adds the mounted certificate to the system trust
+# store at start time.
+#
+# On a host that runs MistHelper without a container, point these variables at
+# your own certificate bundle. Use a path that exists on your host.
+# REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+# CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+# SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 # Package Management Configuration for containers
 DISABLE_UV_CHECK=true

--- a/documentation/wiki/Container-Setup.md
+++ b/documentation/wiki/Container-Setup.md
@@ -4,7 +4,7 @@
 
 Two build strategies are available:
 
-1. **`Containerfile`** (simple, pip only, SSL bypass env overrides for constrained corporate PKI)
+1. **`Containerfile`** (simple, pip only, TLS verification on, optional corporate root certificate)
 2. **`Dockerfile`** (multi-path UV attempt + HEALTHCHECK)
 
 ## Local Container Usage
@@ -37,6 +37,51 @@ podman run -d --name misthelper -p 2200:2200 -p 8055:8055 \
   -v "${PWD}/data:/app/data:rw" -v "${PWD}/.env:/app/.env:ro" \
   misthelper
 ```
+
+## Corporate Proxy and TLS Certificates
+
+The image verifies every TLS certificate. It never disables the check.
+
+Warning: Do not set `PYTHONHTTPSVERIFY=0`, and do not set `REQUESTS_CA_BUNDLE`,
+`CURL_CA_BUNDLE`, or `SSL_CERT_FILE` to an empty value. Without the check, an
+attacker on the network path can present a self-signed certificate and read your
+Mist API token. Issue #1906 records the earlier defect.
+
+### Run behind a TLS-inspecting proxy
+
+Mount the proxy root certificate into `/usr/local/share/ca-certificates`. The
+container entrypoint adds the certificate to the system trust store at start
+time, and it writes the result to `data/ssh.log`.
+
+```powershell
+podman run -d --name misthelper -p 2200:2200 -p 8055:8055 `
+  -v "${PWD}/data:/app/data:rw" -v "${PWD}/.env:/app/.env:ro" `
+  -v "${PWD}/zscaler-root-ca.crt:/usr/local/share/ca-certificates/corp-root-ca.crt:ro" `
+  ghcr.io/jmorrison-juniper/misthelper:latest
+```
+
+Confirm the result:
+
+```powershell
+podman exec misthelper env | Select-String "CA_BUNDLE|SSL_CERT_FILE|PYTHONHTTPSVERIFY"
+Select-String -Path data/ssh.log -Pattern "\[TLS\]"
+```
+
+### Build behind a TLS-inspecting proxy
+
+The build fetches packages from PyPI over verified TLS. If the proxy replaces
+the PyPI certificate, add the proxy root certificate at build time:
+
+```powershell
+podman build --build-arg INSTALL_CORPORATE_CA=true -t misthelper -f Containerfile .
+```
+
+The build reads the certificate from `zscaler-root-ca.crt` in the repository
+root. To use a different file, pass `--build-arg CORPORATE_CA_FILE=<path>`. The
+path is relative to the build context.
+
+The default build argument value is `false`, so the published image ships a
+clean trust store.
 
 ## Container Registry
 

--- a/tests/guardrails/test_container_tls_verification.py
+++ b/tests/guardrails/test_container_tls_verification.py
@@ -1,0 +1,175 @@
+"""Guardrail tests for TLS certificate verification in the shipped container files.
+
+Issue #1906 recorded a critical defect. The image build files set environment
+defaults that turned off TLS certificate verification for every outbound HTTPS
+call. The sample environment file shipped the same values to every operator.
+An attacker on the network path could present a self-signed certificate and
+read the Mist API token.
+
+These tests parse the three shipped files and fail if any file sets an insecure
+default again. The supported path for a TLS-inspecting corporate proxy is a
+mounted root certificate, never a disabled check.
+"""
+
+from __future__ import annotations
+
+import logging  # Report each parse step for test troubleshooting.
+import shlex  # Split an ENV instruction and honor the quoting rules.
+from pathlib import Path  # Build cross-platform paths to the shipped files.
+
+import pytest  # Provide the parametrize decorator for the file matrix.
+
+logger = logging.getLogger(__name__)  # Module logger keeps the parse steps observable.
+
+# Repository root holds the two image build files at the top level.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Both image build files must stay secure, because each one builds a published image.
+_IMAGE_FILES = ("Dockerfile", "Containerfile")
+
+# Path parts of the sample environment file that operators copy to their own .env file.
+_ENV_SAMPLE_PARTS = ("documentation", "sample.env")
+
+# Display name of the sample environment file for the test identifiers.
+_ENV_SAMPLE_NAME = "documentation/sample.env"
+
+# An empty value in one of these variables removes the trust store for the related client.
+_CA_BUNDLE_VARIABLES = (
+    "REQUESTS_CA_BUNDLE",  # The requests library reads this bundle path.
+    "CURL_CA_BUNDLE",  # The curl client reads this bundle path.
+    "SSL_CERT_FILE",  # The OpenSSL default file lookup reads this path.
+    "SSL_CERT_DIR",  # The OpenSSL default directory lookup reads this path.
+    "NODE_EXTRA_CA_CERTS",  # The Node.js client reads this extra bundle path.
+)
+
+# Values that a shell or a dotenv file treats as "on".
+_TRUE_VALUES = frozenset({"true", "1", "yes", "on"})
+
+# Values that a shell or a dotenv file treats as "off".
+_FALSE_VALUES = frozenset({"false", "0", "no", "off"})
+
+# The Python standard HTTPS client checks certificates when this variable is absent or set to "1".
+_SECURE_HTTPS_VERIFY_VALUES = frozenset({"1"})
+
+
+class ContainerEnvironmentReader:
+    """Read the environment defaults that a shipped container file declares."""
+
+    @staticmethod
+    def read_image_environment(path: Path) -> dict[str, str]:
+        """Return every variable that a Dockerfile or a Containerfile sets with ENV."""
+        logger.info("Reading image environment defaults from %s", path)  # Announce the parse step.
+        settings: dict[str, str] = {}  # Collect one entry for each declared variable.
+        for line in ContainerEnvironmentReader._logical_lines(path):  # Walk the joined lines.
+            stripped = line.strip()  # Remove the surrounding whitespace of the line.
+            if not stripped.upper().startswith("ENV "):  # Keep the ENV instructions only.
+                continue  # Every other instruction sets no default.
+            pairs = ContainerEnvironmentReader._parse_env_instruction(stripped[4:])  # Parse the body.
+            settings.update(pairs)  # A later ENV instruction overrides an earlier one.
+        logger.debug("Parsed %d image environment defaults from %s", len(settings), path)  # Report the count.
+        return settings  # Hand the caller the effective image defaults.
+
+    @staticmethod
+    def read_dotenv_environment(path: Path) -> dict[str, str]:
+        """Return every active assignment of a dotenv sample file."""
+        logger.info("Reading dotenv assignments from %s", path)  # Announce the parse step.
+        settings: dict[str, str] = {}  # Collect one entry for each active assignment.
+        for line in path.read_text(encoding="utf-8").splitlines():  # Walk the physical lines.
+            stripped = line.strip()  # Remove the surrounding whitespace of the line.
+            if not stripped or stripped.startswith("#") or "=" not in stripped:  # Skip a comment or a blank line.
+                continue  # A commented assignment sets no value.
+            key, _, value = stripped.partition("=")  # Split the line at the first equals sign.
+            settings[key.strip()] = value.strip().strip("\"'")  # Store the value without the quotes.
+        logger.debug("Parsed %d dotenv assignments from %s", len(settings), path)  # Report the count.
+        return settings  # Hand the caller the active assignments.
+
+    @staticmethod
+    def _logical_lines(path: Path) -> list[str]:
+        """Return the lines of a build file with the backslash continuations joined."""
+        raw = path.read_text(encoding="utf-8")  # Read the whole build file as text.
+        joined = raw.replace("\\\n", " ")  # Join a line that continues on the next line.
+        return joined.splitlines()  # Split the joined text into logical lines.
+
+    @staticmethod
+    def _parse_env_instruction(body: str) -> dict[str, str]:
+        """Return the variables that the body of one ENV instruction declares."""
+        pairs: dict[str, str] = {}  # Collect the variables of this single instruction.
+        tokens = shlex.split(body, posix=True)  # Split on whitespace and drop the quote characters.
+        if tokens and "=" not in tokens[0]:  # Detect the legacy "ENV KEY VALUE" form.
+            pairs[tokens[0]] = " ".join(tokens[1:])  # The legacy form declares one variable only.
+            return pairs  # Stop, because the legacy form holds no further pairs.
+        for token in tokens:  # Walk the tokens of the "ENV KEY=VALUE" form.
+            key, separator, value = token.partition("=")  # Split the token at the first equals sign.
+            if not separator:  # Ignore a token that carries no assignment.
+                continue  # A bare token declares no value.
+            pairs[key] = value  # Record the declared value of this variable.
+        return pairs  # Hand the caller the variables of this instruction.
+
+
+def _environment_sources() -> list[tuple[str, dict[str, str]]]:
+    """Return the parsed environment defaults of every shipped container file."""
+    sources: list[tuple[str, dict[str, str]]] = []  # Collect one entry for each shipped file.
+    for image_file in _IMAGE_FILES:  # Read both published image build files.
+        image_path = _REPO_ROOT / image_file  # Build the absolute path of the image build file.
+        sources.append((image_file, ContainerEnvironmentReader.read_image_environment(image_path)))  # Parse it.
+    sample_path = _REPO_ROOT.joinpath(*_ENV_SAMPLE_PARTS)  # Build the absolute path of the sample file.
+    sources.append((_ENV_SAMPLE_NAME, ContainerEnvironmentReader.read_dotenv_environment(sample_path)))  # Parse it.
+    return sources  # Hand the test matrix one entry for each file.
+
+
+# Parse the shipped files once at collection time, because the files never change during a run.
+_ENVIRONMENT_SOURCES = _environment_sources()
+
+# Test identifiers name the file under test, so a failure reports the exact file.
+_SOURCE_IDS = [source_name for source_name, _ in _ENVIRONMENT_SOURCES]
+
+
+class TestContainerTlsVerification:
+    """Verify that no shipped container file turns off TLS certificate verification."""
+
+    @pytest.mark.parametrize(("source_name", "settings"), _ENVIRONMENT_SOURCES, ids=_SOURCE_IDS)
+    def test_python_https_verification_stays_on(self, source_name: str, settings: dict[str, str]) -> None:
+        """PYTHONHTTPSVERIFY must be absent or set to 1 in every shipped file."""
+        value = settings.get("PYTHONHTTPSVERIFY")  # Read the declared value, or None when absent.
+        assert value is None or value in _SECURE_HTTPS_VERIFY_VALUES, (  # Any other value drops the check.
+            f"{source_name} sets PYTHONHTTPSVERIFY={value!r}. "
+            "That value turns off certificate verification in the Python HTTPS client. "
+            "Mount a corporate root certificate instead of disabling the check. See issue #1906."
+        )
+
+    @pytest.mark.parametrize(("source_name", "settings"), _ENVIRONMENT_SOURCES, ids=_SOURCE_IDS)
+    def test_ssl_verify_flag_stays_on(self, source_name: str, settings: dict[str, str]) -> None:
+        """SSL_VERIFY must be absent or set to a value that keeps verification on."""
+        value = settings.get("SSL_VERIFY")  # Read the declared value, or None when absent.
+        assert value is None or value.lower() in _TRUE_VALUES, (  # An off value or an empty value fails.
+            f"{source_name} sets SSL_VERIFY={value!r}. "
+            "That value tells the application to skip certificate verification. "
+            "Mount a corporate root certificate instead of disabling the check. See issue #1906."
+        )
+
+    @pytest.mark.parametrize(("source_name", "settings"), _ENVIRONMENT_SOURCES, ids=_SOURCE_IDS)
+    def test_skip_ssl_verify_flag_stays_off(self, source_name: str, settings: dict[str, str]) -> None:
+        """MIST_SKIP_SSL_VERIFY must be absent or set to a value that keeps verification on."""
+        value = settings.get("MIST_SKIP_SSL_VERIFY")  # Read the declared value, or None when absent.
+        assert value is None or value.lower() in _FALSE_VALUES, (  # An on value disables the check.
+            f"{source_name} sets MIST_SKIP_SSL_VERIFY={value!r}. "
+            "That value tells the address audit to skip certificate verification. "
+            "Mount a corporate root certificate instead of disabling the check. See issue #1906."
+        )
+
+    @pytest.mark.parametrize(("source_name", "settings"), _ENVIRONMENT_SOURCES, ids=_SOURCE_IDS)
+    def test_ca_bundle_variables_keep_a_value(self, source_name: str, settings: dict[str, str]) -> None:
+        """No shipped file may set a CA bundle variable to an empty value."""
+        emptied = [name for name in _CA_BUNDLE_VARIABLES if settings.get(name, "unset") == ""]  # Find empty ones.
+        assert not emptied, (  # An empty bundle path removes the trust store of that client.
+            f"{source_name} sets {', '.join(emptied)} to an empty value. "
+            "An empty bundle path removes the trust store and stops certificate verification. "
+            "Point the variable at a mounted root certificate instead. See issue #1906."
+        )
+
+    def test_every_shipped_container_file_exists(self) -> None:
+        """The guardrail must fail if a shipped file moves and the matrix goes stale."""
+        for image_file in _IMAGE_FILES:  # Check both published image build files.
+            assert (_REPO_ROOT / image_file).is_file(), f"{image_file} is missing from the repository root."
+        sample_path = _REPO_ROOT.joinpath(*_ENV_SAMPLE_PARTS)  # Build the path of the sample file.
+        assert sample_path.is_file(), f"{_ENV_SAMPLE_NAME} is missing from the repository."


### PR DESCRIPTION
Fixes #1906

## Problem

The `Dockerfile` shipped four environment defaults that turned off TLS certificate verification for every container built from the image:

```dockerfile
ENV PYTHONHTTPSVERIFY=0
ENV SSL_VERIFY=false
ENV REQUESTS_CA_BUNDLE=""
ENV CURL_CA_BUNDLE=""
```

`PYTHONHTTPSVERIFY=0` removes the certificate check in the Python HTTPS client. The two empty CA bundle values strip the trust store for `requests` and for `curl`. Every user of the published image lost certificate validation, and nothing reported the loss. An attacker on the network path could present a self-signed certificate and read the live Mist API token.

The same block existed in two more shipped files that the issue did not name:

- `Containerfile`, lines 95 to 98. This is the Podman-facing twin, and CI builds the published image from **this** file. A fix to the `Dockerfile` alone would have left the published image insecure.
- `documentation/sample.env`, lines 190 to 194. Operators copy this file to `.env`, so it reintroduced the bypass at run time.

The `pip install` step also passed `--trusted-host` for `pypi.org`, `pypi.python.org`, and `files.pythonhosted.org`, which disabled certificate verification for every package download during the build.

## Second finding: a build-time supply-chain exposure

Reviewer note: this pull request fixes a second, separate defect that issue #1906
does not name. Do not skim past it. The defect is a supply-chain exposure, not a
run-time one, and it hides inside a change that otherwise reads as run-time TLS
work.

Both build files passed three `--trusted-host` flags to `pip install`:

```dockerfile
RUN pip install --no-cache-dir -r requirements.txt \
        --trusted-host pypi.org \
        --trusted-host pypi.python.org \
        --trusted-host files.pythonhosted.org
```

`--trusted-host` tells pip to treat a host as trusted and to skip certificate
verification for every download from it. Every Python dependency in the image
therefore arrived over an unverified channel. An attacker on the build network
path could replace any wheel, and pip would install the replacement with no
warning. The tampered code would then run inside every published image with the
operator's Mist API token.

This pull request removes all three flags. Every package download now validates
the certificate. The corporate build path still works, because
`--build-arg INSTALL_CORPORATE_CA=true` adds the proxy root certificate to the
trust store before the `pip install` step runs. The evidence section below shows
that build succeeding.

Issue #1914 tracks this as bypass path 8. Neither issue #1906 nor the original
sweep found it.

## Fix

TLS verification is now on by default, and the corporate-proxy path uses a real root certificate instead of a disabled check.

**Image defaults (`Dockerfile`, `Containerfile`)**

- Set `PYTHONHTTPSVERIFY=1`.
- Point `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, and `CURL_CA_BUNDLE` at `/etc/ssl/certs/ca-certificates.crt`. `update-ca-certificates` writes the merged bundle to that same path, so a mounted corporate root works with no further change.
- Drop `SSL_VERIFY` from the image. No code in the repository reads that variable.
- Remove the three `--trusted-host` flags from `pip install`.

**Opt-in corporate root certificate (build time)**

- `--build-arg INSTALL_CORPORATE_CA=true` adds the root certificate to the system trust store.
- `--build-arg CORPORATE_CA_FILE=<path>` selects the file. The default is `zscaler-root-ca.crt`, which the repository already ships.
- The default value of `INSTALL_CORPORATE_CA` is `false`, so the published image keeps a clean trust store.

**Opt-in corporate root certificate (run time)**

- `container/scripts/start.sh` runs `update-ca-certificates` when an operator mounts a certificate into `/usr/local/share/ca-certificates`, and it records the result in `data/ssh.log`.

**Warning on a run-time bypass**

- `container/scripts/start.sh` logs a WARNING when `PYTHONHTTPSVERIFY=0` arrives at run time, or when `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, or `SSL_CERT_FILE` holds an empty value. The line names the exposed Mist API token. No bypass is baked into the image.

**Sample environment**

- `documentation/sample.env` no longer ships the four insecure assignments. The section explains the mounted certificate path, and it keeps every CA bundle line commented, so a copy to `.env` cannot reintroduce the bypass.

**Documentation**

- `README.md` gains a "Corporate proxy and TLS certificates" section and a Security table row.
- `documentation/wiki/Container-Setup.md` gains build-time and run-time procedures with verification commands.

## Verification evidence

### 1. The test failed first, then passed

The guardrail test parses all three shipped files. It reads the `ENV KEY=VALUE` form, the legacy `ENV KEY VALUE` form, and the bare dotenv assignment form, and it treats an empty CA bundle value as a finding.

Before the fix:

```text
rtk proxy python -m pytest tests/guardrails/test_container_tls_verification.py -q
========================= 9 failed, 4 passed in 2.17s =========================
FAILED ...::test_python_https_verification_stays_on[Dockerfile]
FAILED ...::test_python_https_verification_stays_on[Containerfile]
FAILED ...::test_python_https_verification_stays_on[documentation/sample.env]
FAILED ...::test_ssl_verify_flag_stays_on[Dockerfile]
FAILED ...::test_ssl_verify_flag_stays_on[Containerfile]
FAILED ...::test_ssl_verify_flag_stays_on[documentation/sample.env]
FAILED ...::test_ca_bundle_variables_keep_a_value[Dockerfile]
FAILED ...::test_ca_bundle_variables_keep_a_value[Containerfile]
FAILED ...::test_ca_bundle_variables_keep_a_value[documentation/sample.env]
```

After the fix:

```text
rtk proxy python -m pytest tests/guardrails/test_container_tls_verification.py -q
============================= 13 passed in 1.06s ==============================
```

### 2. Both build paths build, and the image verifies certificates

The default build, with no corporate root certificate:

```text
podman build -t misthelper-tls-1906-default -f Containerfile .
Successfully tagged localhost/misthelper-tls-1906-default:latest

podman run --rm --entrypoint "" misthelper-tls-1906-default env | Select-String "PYTHONHTTPSVERIFY|CA_BUNDLE|SSL_CERT"
PYTHONHTTPSVERIFY=1
SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt

podman run --rm --entrypoint "" misthelper-tls-1906-default python -c "..."
verify_mode 2
mist_status 200
```

`verify_mode 2` is `ssl.CERT_REQUIRED`, and `check_hostname` is `True`. The call to `https://api.mist.com` returned 200 with verification on.

The corporate build, which satisfies acceptance criterion 2:

```text
podman build --build-arg INSTALL_CORPORATE_CA=true -t misthelper-tls-1906 -f Containerfile .
Successfully tagged localhost/misthelper-tls-1906:latest
verify_mode 2
mist_status 200
```

### 3. The startup log reports the trust store and any bypass

Default run, with the corporate root added at build time:

```text
[TLS] Installing operator-supplied root certificates from /usr/local/share/ca-certificates
[TLS] Trust store updated. Certificate verification stays on.
```

Run with an explicit bypass, `-e PYTHONHTTPSVERIFY=0 -e REQUESTS_CA_BUNDLE=`:

```text
[TLS] WARNING: PYTHONHTTPSVERIFY=0 turns off certificate verification.
[TLS] WARNING: An attacker on the network path can read the Mist API token.
[TLS] WARNING: REQUESTS_CA_BUNDLE is empty, which removes the trust store.
[TLS] WARNING: Point REQUESTS_CA_BUNDLE at a mounted root certificate.
```

### 4. Quality gates

Every gate passed on the first push. Confirmed with
`rtk proxy gh pr checks 1919`, which reported 20 of 20 green, including the
pytest coverage gate.

| Gate | Result |
| - | - |
| Ruff (lint) | pass |
| Black (format check) | pass |
| mypy (strict) | pass |
| pytest (coverage gate) | pass |
| Bandit (security) | pass |
| pip-audit (CVE scan) | pass |
| CodeQL and analyze (python) | pass |
| Pylint (score gate) | pass |
| Radon (complexity) | pass |
| Vulture (dead code) | pass |
| pydocstyle and Interrogate | pass |
| STE compliance | pass |
| E2E smoke tests | pass |
| Diagram reference lint, Menu reference drift, ops-portal | pass |

No existing test asserted the old insecure behavior, so no test needed an
inversion. A repository search for `PYTHONHTTPSVERIFY`, `trusted-host`,
`REQUESTS_CA_BUNDLE`, and `CURL_CA_BUNDLE` under `tests/` returned only the new
guardrail file. The two `MIST_SKIP_SSL_VERIFY` tests in
`tests/unit/site/address_audit/test_audit_engine.py` belong to pull request
#1915.

Local commands that produced the same result before the push:

| Gate | Command | Result |
| - | - | - |
| Lint | `rtk proxy python -m ruff check .` | `All checks passed!` |
| Format | `rtk proxy python -m black --check .` | `1011 files would be left unchanged` |
| New test | `rtk proxy python -m pytest tests/guardrails/test_container_tls_verification.py -q` | `13 passed` |
| Shell syntax | `rtk proxy bash -n container/scripts/start.sh` | exit code 0 |
| Bandit | `rtk proxy python -m bandit -c pyproject.toml -r tests/guardrails/test_container_tls_verification.py` | `No issues identified` |

**Unrelated pre-existing failures**: none. An earlier draft of this body claimed
35 pre-existing failures in `tests/guardrails/`. That claim was wrong, and this
body retracts it. The cause was a missing `numpy` package in the local worktree,
which is issue #1866. `MistHelper.py` degrades when a required import fails, so
the module loaded without `menu_actions` and without `PacketCaptureManager`. The
failure looked structural, but it was a missing dependency. After
`pip install numpy`, the same command reports:

```text
rtk proxy python -m pytest tests/guardrails -q
============================= 61 passed in 1.30s ==============================
```

That count is the 48 existing tests plus the 13 new ones. No test in the
directory fails.

## Acceptance criteria

- [x] The published image performs certificate verification by default.
- [x] A build behind the corporate proxy still succeeds, through the installed root certificate.
- [x] A bypass requires an explicit opt-in, and the startup log reports it.
- [x] A test asserts that `PYTHONHTTPSVERIFY` is absent or set to `1` in the built image.

## Scope: this pull request closes the image layer only

Warning: Do not merge this pull request and conclude that the TLS bypass class is
closed. This change covers the container image. Two more work items cover the
rest, and all three must land.

| Layer | Owner | Files |
| - | - | - |
| Image | This pull request, #1919, for issue #1906 | `Dockerfile`, `Containerfile`, `documentation/sample.env`, `container/scripts/start.sh` |
| Application and scripts | Pull request #1915 | `src/site/address_audit/audit_engine.py`, `scripts/test_ssr.py`, `scripts/debug_html.py`, `scripts/mist_ideas_scraper_ssr.py` |
| Full inventory | Issue #1914 | Records the complete set of eight bypass paths |

Issue #1906 named the `Dockerfile` alone. Issue #1914 records the further paths
that ship the same defect outside that one file. This branch fixes four of the
eight: the `Dockerfile`, the `Containerfile`, `documentation/sample.env`, and the
`--trusted-host` build-time exposure described above. Pull request #1915 fixes
the remaining four, which are the `MIST_SKIP_SSL_VERIFY` default in
`src/site/address_audit/audit_engine.py` and the three `verify=False` calls under
`scripts/`. Another agent owns those files, so this branch does not touch them.

A reviewer who merges this pull request alone still ships a tool that skips
certificate verification on the address audit path.

`CHANGELOG.md` is intentionally not edited. Issue #1899 records that every
concurrent pull request collides on the changelog head.
