### PR TITLE
fix(ops-platform): release the backup engine and bound the SMTP connect

### DIFF
--- a/mist-ops-platform/.env.example
+++ b/mist-ops-platform/.env.example
@@ -27,5 +27,9 @@ MIST_WEBHOOK_SECRET=generate-a-hex-secret
 # Sync interval (seconds)
 SYNC_INTERVAL_SECONDS=300
 
+# SMTP connect timeout for email alerts (seconds).
+# The adapter uses 10 seconds when this variable is empty or invalid.
+SMTP_TIMEOUT_SECONDS=10
+
 # Log level
 LOG_LEVEL=INFO

--- a/mist-ops-platform/src/shared/services/notification.py
+++ b/mist-ops-platform/src/shared/services/notification.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import smtplib
 from email.message import EmailMessage
 from typing import Any
@@ -14,6 +15,41 @@ from typing import Any
 import httpx
 
 logger = logging.getLogger(__name__)
+
+# The stdlib default for smtplib.SMTP is unbounded, so a silent mail host
+# holds a Celery worker thread forever. Ten seconds matches the timeout that
+# the webhook adapter below already uses.
+DEFAULT_SMTP_TIMEOUT_SECONDS = 10.0
+
+# An operator tunes a slow relay through this environment variable, so a
+# change needs no new image and no code edit.
+SMTP_TIMEOUT_ENV_VAR = "SMTP_TIMEOUT_SECONDS"
+
+
+def _read_smtp_timeout() -> float:
+    """Return the SMTP timeout in seconds from the environment."""
+    raw = os.getenv(SMTP_TIMEOUT_ENV_VAR, "").strip()  # WHY: an unset variable reads as "".
+    if not raw:
+        return DEFAULT_SMTP_TIMEOUT_SECONDS  # WHY: no override keeps the documented default.
+    try:
+        seconds = float(raw)  # WHY: the environment holds text, and the socket needs a number.
+    except ValueError:
+        logger.warning(
+            "Invalid %s value '%s'. Using %.1f seconds.",
+            SMTP_TIMEOUT_ENV_VAR,
+            raw,
+            DEFAULT_SMTP_TIMEOUT_SECONDS,
+        )
+        return DEFAULT_SMTP_TIMEOUT_SECONDS
+    if seconds <= 0:
+        # WHY: zero or less makes the socket non-blocking, which breaks every send.
+        logger.warning(
+            "The %s value must be above zero. Using %.1f seconds.",
+            SMTP_TIMEOUT_ENV_VAR,
+            DEFAULT_SMTP_TIMEOUT_SECONDS,
+        )
+        return DEFAULT_SMTP_TIMEOUT_SECONDS
+    return seconds
 
 
 class EmailAdapter:
@@ -25,11 +61,15 @@ class EmailAdapter:
         port: int = 587,
         username: str = "",
         password: str = "",  # nosec B107 - The empty string is a "not provided" sentinel.
+        *,
+        timeout: float | None = None,
     ) -> None:
         self._host = host
         self._port = port
         self._username = username
         self._password = password
+        # WHY: a caller can set the limit, and the environment supplies the rest.
+        self._timeout = timeout if timeout is not None else _read_smtp_timeout()
 
     def send(
         self,
@@ -38,21 +78,54 @@ class EmailAdapter:
         body: str,
     ) -> bool:
         """Deliver an email notification; return True on success."""
+        msg = self._build_message(destination, subject, body)
+        logger.info(
+            "Sending an email alert to %s through %s:%s",
+            destination,
+            self._host,
+            self._port,
+        )
+        try:
+            # WHY: the timeout bounds the connect, so a silent host cannot hold the worker.
+            with smtplib.SMTP(self._host, self._port, timeout=self._timeout) as server:
+                self._start_session(server)  # WHY: TLS and login run only with a username.
+                server.send_message(msg)
+        except TimeoutError:
+            # WHY: the operator needs the host, the port, and the limit to tune the relay.
+            logger.error(
+                "Email to %s timed out on %s:%s after %s seconds",
+                destination,
+                self._host,
+                self._port,
+                self._timeout,
+            )
+            return False
+        except Exception:
+            logger.exception("Email send failed to %s", destination)
+            return False
+        logger.debug("Email alert delivered to %s", destination)
+        return True
+
+    def _build_message(
+        self,
+        destination: str,
+        subject: str,
+        body: str,
+    ) -> EmailMessage:
+        """Assemble the message the SMTP session sends."""
         msg = EmailMessage()
         msg["Subject"] = subject
         msg["To"] = destination
         msg["From"] = self._username or "noreply@mistops.local"
         msg.set_content(body)
-        try:
-            with smtplib.SMTP(self._host, self._port) as server:
-                if self._username:
-                    server.starttls()
-                    server.login(self._username, self._password)
-                server.send_message(msg)
-            return True
-        except Exception:
-            logger.exception("Email send failed to %s", destination)
-            return False
+        return msg
+
+    def _start_session(self, server: Any) -> None:
+        """Upgrade to TLS and authenticate when a username exists."""
+        if not self._username:
+            return  # WHY: an open relay in a lab needs no login.
+        server.starttls()  # WHY: the password must not cross the network in clear text.
+        server.login(self._username, self._password)
 
 
 class WebhookAdapter:

--- a/mist-ops-platform/src/worker/tasks/sync_tasks.py
+++ b/mist-ops-platform/src/worker/tasks/sync_tasks.py
@@ -8,6 +8,8 @@ pipeline: inventory -> config -> status -> events.
 from __future__ import annotations
 
 import logging
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
@@ -17,41 +19,65 @@ from src.shared.mist.endpoints import MistEndpointService
 from src.shared.mist.session import get_session_factory
 from src.shared.models.inventory import Organization
 from src.worker.celeryconfig import app
+from src.worker.checks.drift import DriftScanner
 from src.worker.sync.config import ConfigSyncService
 from src.worker.sync.events import EventSyncService
 from src.worker.sync.inventory import InventorySyncService
 from src.worker.sync.status import StatusSyncService
-from src.worker.checks.drift import DriftScanner
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from sqlalchemy import Engine
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _sync_engine() -> Iterator[Engine]:
+    """Yield a task-scoped engine and dispose it on every exit path.
+
+    An engine owns a connection pool. A pool that no code disposes keeps
+    its PostgreSQL sockets open until the database reaches
+    ``max_connections``, and then every service on that database fails.
+    The ``finally`` clause runs after a return and after an exception, so
+    no path can skip the release.
+    """
+    settings = get_settings()
+    sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
+    logger.info("Opening a task engine for the sync database")
+    engine = create_engine(sync_url)  # WHY: Celery tasks run sync code, not async code.
+    try:
+        yield engine  # WHY: the caller runs its whole body inside this scope.
+    finally:
+        engine.dispose()  # WHY: this line runs on the success path and on the error path.
+        logger.debug("Disposed the task engine and closed its connection pool")
 
 
 @app.task(name="src.worker.tasks.sync_tasks.sync_all_inventory")
 def sync_all_inventory() -> dict:
     """Sync inventory for every registered organization."""
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
-    engine = create_engine(sync_url)
+    logger.info("Starting the inventory sync for every organization")
+    with _sync_engine() as engine:  # WHY: the scope disposes the engine for us.
+        with Session(engine) as db:
+            org_ids = _load_org_mist_ids(db)
 
-    with Session(engine) as db:
-        org_ids = _load_org_mist_ids(db)
+        results: dict[str, dict] = {}
+        for mist_org_id in org_ids:
+            results[mist_org_id] = _sync_single_org(engine, mist_org_id)
 
-    results: dict[str, dict] = {}
-    for mist_org_id in org_ids:
-        results[mist_org_id] = _sync_single_org(engine, mist_org_id)
-
-    engine.dispose()
+    logger.debug("Inventory sync finished for %d organizations", len(results))
     return results
 
 
 @app.task(name="src.worker.tasks.sync_tasks.sync_org_inventory")
 def sync_org_inventory(mist_org_id: str) -> dict:
     """Sync inventory for a single organization (on-demand)."""
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
-    engine = create_engine(sync_url)
-    result = _sync_single_org(engine, mist_org_id)
-    engine.dispose()
+    logger.info("Starting the inventory sync for organization %s", mist_org_id)
+    with _sync_engine() as engine:  # WHY: an exception in the sync must not leak a pool.
+        result = _sync_single_org(engine, mist_org_id)
+
+    logger.debug("Inventory sync finished for organization %s", mist_org_id)
     return result
 
 
@@ -159,22 +185,18 @@ def _run_drift_scan(engine, org_id: str) -> dict:  # noqa: ANN001
 @app.task(name="src.worker.tasks.sync_tasks.run_daily_backup")
 def run_daily_backup() -> dict:
     """Export config revisions and audit records to MinIO daily."""
-    import json
     from datetime import UTC, datetime
-
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
-    engine = create_engine(sync_url)
 
     timestamp = datetime.now(tz=UTC).strftime("%Y%m%d_%H%M%S")
     tables = ("config_revisions", "audit_records", "baselines")
     counts: dict[str, int] = {}
 
-    for table_name in tables:
-        count = _export_table_backup(engine, table_name, timestamp)
-        counts[table_name] = count
+    logger.info("Starting the daily backup at %s", timestamp)
+    with _sync_engine() as engine:  # WHY: Beat runs this task daily, so a leak grows every day.
+        for table_name in tables:
+            counts[table_name] = _export_table_backup(engine, table_name, timestamp)
 
-    logger.info("Daily backup complete: %s", counts)
+    logger.debug("Daily backup complete: %s", counts)
     return {"timestamp": timestamp, "rows": counts}
 
 

--- a/mist-ops-platform/tests/unit/shared/test_notification_timeout.py
+++ b/mist-ops-platform/tests/unit/shared/test_notification_timeout.py
@@ -1,0 +1,177 @@
+"""Tests that the SMTP adapter bounds its connect time (issue #1909).
+
+``smtplib.SMTP`` waits without a limit when the caller passes no
+``timeout`` argument. A mail host that drops packets then holds a Celery
+worker thread forever. These tests prove that the adapter passes an
+explicit timeout and reports a timeout as a clean failure.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+from src.shared.services import notification
+
+if TYPE_CHECKING:
+    # WHY: this module reads pytest names in annotations only.
+    import pytest
+
+_TEST_HOST = "mail.example.net"
+_TEST_PORT = 2525
+_CUSTOM_TIMEOUT_SECONDS = 2.5
+_ENVIRONMENT_TIMEOUT_SECONDS = 4.0
+_DESTINATION = "noc@example.net"
+
+
+def _make_adapter(**kwargs: Any) -> notification.EmailAdapter:
+    """Build an adapter that points at the test mail host."""
+    # WHY: a fixed host and port let the log assertions match exact text.
+    return notification.EmailAdapter(
+        host=_TEST_HOST,
+        port=_TEST_PORT,
+        **kwargs,
+    )
+
+
+def _install_fake_smtp(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception | None = None,
+) -> dict[str, Any]:
+    """Replace smtplib.SMTP and return the captured constructor arguments."""
+    captured: dict[str, Any] = {}
+
+    class _FakeSMTP:
+        """Record the constructor arguments and simulate one session."""
+
+        def __init__(self, host: str, port: int, **kwargs: Any) -> None:
+            captured["host"] = host  # WHY: the test asserts the target host.
+            captured["port"] = port  # WHY: the test asserts the target port.
+            captured.update(kwargs)  # WHY: the timeout arrives as a keyword.
+            if error is not None:
+                # WHY: a silent mail host raises during the connect call.
+                raise error
+
+        def __enter__(self) -> _FakeSMTP:
+            return self
+
+        def __exit__(self, *_exc_info: Any) -> bool:
+            return False
+
+        def starttls(self) -> None:
+            """Accept the TLS upgrade without a network call."""
+
+        def login(self, *_args: Any) -> None:
+            """Accept the credentials without a network call."""
+
+        def send_message(self, _message: Any) -> None:
+            """Accept the message without a network call."""
+
+    # WHY: the adapter reads smtplib.SMTP at call time, so patch the attribute.
+    monkeypatch.setattr(notification.smtplib, "SMTP", _FakeSMTP)
+    return captured
+
+
+class TestEmailAdapterTimeout:
+    """The SMTP connect must carry an explicit and tunable timeout."""
+
+    def test_connect_passes_a_timeout(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured = _install_fake_smtp(monkeypatch)
+
+        assert _make_adapter().send(_DESTINATION, "subject", "body") is True
+
+        assert "timeout" in captured
+        assert captured["timeout"] == notification.DEFAULT_SMTP_TIMEOUT_SECONDS
+        assert captured["timeout"] > 0
+
+    def test_constructor_timeout_wins(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured = _install_fake_smtp(monkeypatch)
+
+        adapter = _make_adapter(timeout=_CUSTOM_TIMEOUT_SECONDS)
+        adapter.send(_DESTINATION, "subject", "body")
+
+        assert captured["timeout"] == _CUSTOM_TIMEOUT_SECONDS
+
+    def test_environment_variable_tunes_the_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured = _install_fake_smtp(monkeypatch)
+        monkeypatch.setenv(
+            notification.SMTP_TIMEOUT_ENV_VAR,
+            str(_ENVIRONMENT_TIMEOUT_SECONDS),
+        )
+
+        _make_adapter().send(_DESTINATION, "subject", "body")
+
+        assert captured["timeout"] == _ENVIRONMENT_TIMEOUT_SECONDS
+
+    def test_invalid_environment_value_keeps_the_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured = _install_fake_smtp(monkeypatch)
+        # WHY: an operator can type a word or a negative number by mistake.
+        monkeypatch.setenv(notification.SMTP_TIMEOUT_ENV_VAR, "soon")
+
+        _make_adapter().send(_DESTINATION, "subject", "body")
+
+        assert captured["timeout"] == notification.DEFAULT_SMTP_TIMEOUT_SECONDS
+
+
+class TestEmailAdapterTimeoutFailure:
+    """A stalled mail host must produce a clean failure and a clear log."""
+
+    def test_timeout_returns_false(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _install_fake_smtp(monkeypatch, error=TimeoutError("timed out"))
+
+        result = _make_adapter().send(_DESTINATION, "subject", "body")
+
+        assert result is False
+
+    def test_timeout_logs_host_port_and_limit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        _install_fake_smtp(monkeypatch, error=TimeoutError("timed out"))
+        caplog.set_level(logging.ERROR, logger=notification.logger.name)
+
+        _make_adapter(timeout=_CUSTOM_TIMEOUT_SECONDS).send(
+            _DESTINATION,
+            "subject",
+            "body",
+        )
+
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert errors, "the timeout must report at ERROR level"
+        message = errors[0].getMessage()
+        assert _TEST_HOST in message
+        assert str(_TEST_PORT) in message
+        assert str(_CUSTOM_TIMEOUT_SECONDS) in message
+
+
+class TestWebhookAdapterTimeout:
+    """The webhook POST must keep its explicit timeout."""
+
+    def test_post_passes_a_timeout(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        post = MagicMock(name="httpx_post")
+        post.return_value = MagicMock(is_success=True)
+        monkeypatch.setattr(notification.httpx, "post", post)
+
+        assert notification.WebhookAdapter().send("https://hook", {}) is True
+
+        assert post.call_args.kwargs["timeout"] > 0

--- a/mist-ops-platform/tests/unit/worker/test_sync_task_engine_disposal.py
+++ b/mist-ops-platform/tests/unit/worker/test_sync_task_engine_disposal.py
@@ -1,0 +1,249 @@
+"""Tests that the sync tasks release the database engine (issue #1908).
+
+Each Celery task in ``src.worker.tasks.sync_tasks`` builds its own
+SQLAlchemy engine. An engine owns a connection pool, and an undisposed
+pool holds open PostgreSQL sockets until the database reaches
+``max_connections``. These tests prove that every task disposes its
+engine on the success path and on the error path.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+# The task module imports Celery and the settings module at import time.
+# Celery is absent from the test environment, and the package
+# ``src.shared.config`` is absent from the repository, so the fixture below
+# installs one stub for each missing name.
+_STUBBED_MODULES = (
+    "celery",
+    "celery.schedules",
+    "src.shared.config",
+    "src.shared.config.settings",
+    "src.shared.config.constants",
+)
+
+# The fixture reimports these two modules under the stubs, so it must drop
+# any copy that an earlier test left in the module cache.
+_RELOADED_MODULES = (
+    "src.worker.celeryconfig",
+    "src.worker.tasks.sync_tasks",
+)
+
+_ASYNC_DATABASE_URL = "postgresql+asyncpg://user:pass@localhost:5432/mistops"
+
+
+class _StubCelery:
+    """Celery stand-in whose task decorator returns the plain function."""
+
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        # WHY: celeryconfig assigns include and beat_schedule on conf.
+        self.conf = MagicMock(name="celery_conf")
+
+    def config_from_object(self, *_args: Any, **_kwargs: Any) -> None:
+        """Accept the broker settings and keep no state."""
+
+    def task(self, *_args: Any, **_kwargs: Any) -> Callable[[Any], Any]:
+        """Return a decorator that leaves the wrapped function callable."""
+
+        def _decorate(func: Any) -> Any:
+            # WHY: the test calls the task body directly, so no Celery
+            # wrapper may hide it.
+            return func
+
+        return _decorate
+
+
+class _StubSettings:
+    """Settings stand-in that carries the fields the tasks read."""
+
+    database_url = _ASYNC_DATABASE_URL
+    redis_url = "redis://localhost:6379/0"
+    sync_interval_seconds = 300
+    vault_addr = ""
+    vault_token = ""  # nosec B105 - The empty string means "not configured".
+
+
+def _build_stub_modules() -> dict[str, types.ModuleType]:
+    """Return the stub module for every missing import."""
+    celery_module = types.ModuleType("celery")
+    celery_module.Celery = _StubCelery  # type: ignore[attr-defined]
+    schedules_module = types.ModuleType("celery.schedules")
+    # WHY: celeryconfig calls crontab() to build the Beat schedule.
+    schedules_module.crontab = lambda **kwargs: kwargs  # type: ignore[attr-defined]
+
+    config_package = types.ModuleType("src.shared.config")
+    config_package.__path__ = []  # type: ignore[attr-defined]
+    settings_module = types.ModuleType("src.shared.config.settings")
+    settings_module.AppSettings = _StubSettings  # type: ignore[attr-defined]
+    settings_module.get_settings = _StubSettings  # type: ignore[attr-defined]
+    constants_module = types.ModuleType("src.shared.config.constants")
+    # WHY: the sync services read EntityType members at import time.
+    constants_module.EntityType = MagicMock(name="EntityType")  # type: ignore[attr-defined]
+
+    return {
+        "celery": celery_module,
+        "celery.schedules": schedules_module,
+        "src.shared.config": config_package,
+        "src.shared.config.settings": settings_module,
+        "src.shared.config.constants": constants_module,
+    }
+
+
+@pytest.fixture
+def sync_tasks() -> Iterator[types.ModuleType]:
+    """Import the task module under the stubs and restore the cache after."""
+    tracked = _STUBBED_MODULES + _RELOADED_MODULES
+    saved = {name: sys.modules.get(name) for name in tracked}
+    sys.modules.update(_build_stub_modules())
+    for name in _RELOADED_MODULES:
+        # WHY: a cached copy would hold the real settings import and fail.
+        sys.modules.pop(name, None)
+    try:
+        import src.worker.tasks.sync_tasks as module
+
+        yield module
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def _patch_engine(
+    module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> MagicMock:
+    """Replace the engine factory and the session with test doubles."""
+    engine = MagicMock(name="engine")
+    # WHY: create_engine would open a real PostgreSQL connection pool.
+    monkeypatch.setattr(module, "create_engine", lambda _url: engine)
+    # WHY: Session would issue SQL against a database the test cannot reach.
+    monkeypatch.setattr(module, "Session", MagicMock(name="Session"))
+    return engine
+
+
+def _raise_runtime_error(*_args: Any, **_kwargs: Any) -> None:
+    """Fail the way a broken query or a lost network link fails."""
+    raise RuntimeError("stage failed")
+
+
+class TestDailyBackupDisposesEngine:
+    """run_daily_backup must release its pool on both exit paths."""
+
+    def test_disposes_engine_after_success(
+        self,
+        sync_tasks: types.ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        engine = _patch_engine(sync_tasks, monkeypatch)
+        # WHY: the export reads real tables, so the test replaces it.
+        monkeypatch.setattr(sync_tasks, "_export_table_backup", lambda *_a: 0)
+
+        result = sync_tasks.run_daily_backup()
+
+        assert "timestamp" in result
+        engine.dispose.assert_called_once_with()
+
+    def test_disposes_engine_after_failure(
+        self,
+        sync_tasks: types.ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        engine = _patch_engine(sync_tasks, monkeypatch)
+        monkeypatch.setattr(
+            sync_tasks,
+            "_export_table_backup",
+            _raise_runtime_error,
+        )
+
+        with pytest.raises(RuntimeError):
+            sync_tasks.run_daily_backup()
+
+        engine.dispose.assert_called_once_with()
+
+
+class TestSyncAllInventoryDisposesEngine:
+    """sync_all_inventory must release its pool on both exit paths."""
+
+    def test_disposes_engine_after_success(
+        self,
+        sync_tasks: types.ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        engine = _patch_engine(sync_tasks, monkeypatch)
+        monkeypatch.setattr(sync_tasks, "_load_org_mist_ids", lambda _db: ["org-1"])
+        monkeypatch.setattr(
+            sync_tasks,
+            "_sync_single_org",
+            lambda _engine, _org: {"inventory": {}},
+        )
+
+        result = sync_tasks.sync_all_inventory()
+
+        assert result == {"org-1": {"inventory": {}}}
+        engine.dispose.assert_called_once_with()
+
+    def test_disposes_engine_after_failure(
+        self,
+        sync_tasks: types.ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        engine = _patch_engine(sync_tasks, monkeypatch)
+        monkeypatch.setattr(
+            sync_tasks,
+            "_load_org_mist_ids",
+            _raise_runtime_error,
+        )
+
+        with pytest.raises(RuntimeError):
+            sync_tasks.sync_all_inventory()
+
+        engine.dispose.assert_called_once_with()
+
+
+class TestSyncOrgInventoryDisposesEngine:
+    """sync_org_inventory must release its pool on both exit paths."""
+
+    def test_disposes_engine_after_success(
+        self,
+        sync_tasks: types.ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        engine = _patch_engine(sync_tasks, monkeypatch)
+        monkeypatch.setattr(
+            sync_tasks,
+            "_sync_single_org",
+            lambda _engine, _org: {"inventory": {}},
+        )
+
+        result = sync_tasks.sync_org_inventory("org-1")
+
+        assert result == {"inventory": {}}
+        engine.dispose.assert_called_once_with()
+
+    def test_disposes_engine_after_failure(
+        self,
+        sync_tasks: types.ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        engine = _patch_engine(sync_tasks, monkeypatch)
+        monkeypatch.setattr(
+            sync_tasks,
+            "_sync_single_org",
+            _raise_runtime_error,
+        )
+
+        with pytest.raises(RuntimeError):
+            sync_tasks.sync_org_inventory("org-1")
+
+        engine.dispose.assert_called_once_with()


### PR DESCRIPTION
Fixes #1908
Fixes #1909

## Defect A. The daily backup task leaked a connection pool

`run_daily_backup` in `mist-ops-platform/src/worker/tasks/sync_tasks.py` built a
SQLAlchemy engine and never disposed it. An engine owns a connection pool, and an
abandoned pool holds open PostgreSQL sockets. Celery Beat runs this task every day,
so the socket count grew every day. When the count reached `max_connections`, the
database refused every new connection, and the API, the sync tasks, and the drift
detection failed together.

The two sibling tasks carried the same defect on the error path. `sync_all_inventory`
and `sync_org_inventory` called `engine.dispose()` after the work, and not in a
`finally` clause. An exception skipped the call and leaked the pool.

**Fix.** A new `_sync_engine` context manager builds the engine and disposes it in a
`finally` clause. All three tasks now use that scope, so no exit path can skip the
release. One helper replaces three copies of the same setup, so a future task cannot
repeat the mistake.

The change also removes an unused `import json` inside `run_daily_backup`, because the
rewrite touched that block.

## Defect B. The SMTP adapter connected without a timeout

`EmailAdapter.send` in `mist-ops-platform/src/shared/services/notification.py` called
`smtplib.SMTP(self._host, self._port)`. The stdlib default timeout is unbounded. A mail
host that drops packets stays silent instead of refusing, so the call held a Celery
worker thread forever and the alert never arrived. Enough blocked alerts starve the
worker pool, which stops the sync tasks and the deploy tasks too.

**Fix.**

- The adapter passes an explicit `timeout` to `smtplib.SMTP`.
- The default is 10.0 seconds, which matches the webhook adapter beside it.
- A caller can pass `timeout=` to the constructor.
- An operator can set `SMTP_TIMEOUT_SECONDS` instead. An invalid value or a value below
  zero falls back to the default and writes a warning.
- A timeout logs at ERROR level with the destination, the host, the port, and the limit,
  and `send` returns False. The old code logged the destination only, so the operator
  could not tell which relay stalled.
- `send` moved the message build and the login into two small helpers, so the function
  stays inside the 5-item rule.
- `.env.example` records the new variable.

## Other network calls in the same module

I checked `notification.py` and its siblings under `src/shared/services/`. The webhook
adapter already sets `timeout=10.0`, and `auth.py` receives an injected Redis client, so
it builds no connection.

Two Redis clients outside that scope still omit a socket timeout. They sit in
`src/shared/mist/session.py` line 118 and `src/api/routes/health.py` line 206.
`redis-py` waits without a limit when the caller sets no `socket_timeout`. I wrote and
verified that fix, then reverted it, because open pull request #1913 rewrites
`_build_redis_client` in the same file and a second edit guarantees a conflict. Issue
#1918 records the finding and the tested fix.

## Verification

No CI gate runs the `mist-ops-platform` suite today. Issue #1895 records that gap, so
every command below ran locally from `mist-ops-platform/` on Python 3.13.3.

**The tests fail on the old code.** I wrote them before the fix.

```
python -m pytest tests/unit/worker/test_sync_task_engine_disposal.py tests/unit/shared/test_notification_timeout.py -q
9 failed, 4 passed in 4.15s
```

The four passing cases are the paths that already worked. They guard the success path
and the webhook timeout against a regression.

**The tests pass on the new code.**

```
python -m pytest tests/unit/worker/test_sync_task_engine_disposal.py tests/unit/shared/test_notification_timeout.py -q
13 passed in 2.64s
```

**The full subproject suite reports no new failure.**

```
python -m pytest tests -q --continue-on-collection-errors
before: 8 failed, 149 passed, 32 skipped, 7 errors
after:  8 failed, 162 passed, 32 skipped, 7 errors
```

The failing set and the error set are identical before and after. I compared the two
lists name by name. The 7 collection errors come from the missing `src/shared/config`
package, which this branch does not touch. Open pull request #1905 restores
`constants.py` for that package.

**The pre-existing failures are genuine, and no missing dependency disguises them.**

Issue #1923 records a trap. A missing dependency can break an import and make a
declared name look absent, which reads as a product defect. I therefore repeated the
whole measurement inside a clean virtual environment that holds every dependency in
`mist-ops-platform/pyproject.toml`. All 21 runtime packages import, and 9 of them were
absent from the first environment.

The numbers do not move.

| Measurement | First environment | Full dependencies |
| - | - | - |
| Baseline, my tests excluded | 8 failed, 149 passed, 32 skipped, 7 errors | 8 failed, 149 passed, 32 skipped, 7 errors |
| This branch | 8 failed, 162 passed, 32 skipped, 7 errors | 8 failed, 162 passed, 32 skipped, 7 errors |
| My tests on the old code | 9 failed, 4 passed | 9 failed, 4 passed |
| My tests on the new code | 13 passed | 13 passed |

The baseline row checks out the parent commit version of both source files, so it
measures the real previous state and not the current state with the tests removed.

Every one of the 8 failures and 7 errors raises
`ModuleNotFoundError: No module named 'src.shared.config'`. One test module adds a
second cause, an `ImportError` for `InventoryStatsResponse` from
`src.api.schemas.sync`. Both gaps are real absences, not import artifacts.
`git ls-files mist-ops-platform/src/shared/config*` returns nothing, the directory is
absent from disk, and `git grep InventoryStatsResponse -- mist-ops-platform/src`
returns nothing. Issue #1900 records the missing package, and pull request #1905
restores it.

No failure names a third-party package. The 32 skips come from entity types with no
list method, read method, or write method, and the count holds in both environments.

**Lint and format.**

```
python -m ruff check mist-ops-platform/src/worker/tasks/sync_tasks.py mist-ops-platform/src/shared/services/notification.py mist-ops-platform/tests/unit/worker/ mist-ops-platform/tests/unit/shared/test_notification_timeout.py
Found 8 errors.
```

All 8 are pre-existing findings in `sync_tasks.py`. Seven are unused `noqa: ANN001`
directives on helper signatures this branch does not touch. One is an unused
`import json` inside `_export_table_backup`. The file reported 10 findings before this
branch, so the count fell by 2. `notification.py` and both test files report zero.

Warning: `python -m ruff check mist-ops-platform` reports 377 findings on the whole
subproject at the current `main`. That failure is pre-existing and unrelated to this
change. The repository root `pyproject.toml` excludes `mist-ops-platform` from the ruff
gate, so the subproject `pyproject.toml` applies a stricter rule set that no gate has
ever enforced.

```
python -m black --check mist-ops-platform
All done! 99 files would be left unchanged.
```

## Merge order and likely conflicts

- **`src/worker/tasks/sync_tasks.py`**: open pull request #1913 edits `_sync_single_org`
  in the same file. This branch edits the import block, the three task bodies, and
  `run_daily_backup`. The two hunks do not overlap, but the line offsets shift. Merge
  #1913 first, and this branch rebases cleanly.
- **`tests/unit/worker/__init__.py`**: pull request #1913 and pull request #1894 also add
  this empty file. The content is identical, so git resolves the add.
- `src/shared/services/notification.py` and `.env.example` have no other open pull
  request.

## Files changed

| File | Change |
| - | - |
| `src/worker/tasks/sync_tasks.py` | Added `_sync_engine`, and all three tasks now dispose on every exit path. |
| `src/shared/services/notification.py` | Added the SMTP timeout, the environment override, the ERROR log, and two helpers. |
| `.env.example` | Recorded `SMTP_TIMEOUT_SECONDS`. |
| `tests/unit/worker/test_sync_task_engine_disposal.py` | 6 new tests. |
| `tests/unit/shared/test_notification_timeout.py` | 7 new tests. |

## Conformance

- [x] Both fixes carry a test that fails on the old code.
- [x] The tests hold no secret and reach no network.
- [x] Every new line of code carries an inline comment that states the reason.
- [x] The logs use ASCII only.
- [x] The text follows Simplified Technical English.
- [x] `CHANGELOG.md` stays unchanged, per issue #1899.
