### PR TITLE
fix(container): bound the SSH session restart loop and add backoff

### DIFF
--- a/container/scripts/misthelper-session.sh
+++ b/container/scripts/misthelper-session.sh
@@ -14,21 +14,66 @@ export DISABLE_AUTO_INSTALL=true
 export AUTO_UPGRADE_UV=false
 export AUTO_UPGRADE_DEPENDENCIES=false
 
+# Restart controls.
+# A failed start repeats when the cause stays, such as a missing dependency or
+# a bad configuration file. An unlimited restart loop burns container CPU and
+# fills the log file, so the loop stops after a small number of attempts.
+# An operator can override each value with an environment variable.
+
+# Largest number of failed starts in a row before the session closes.
+# Five attempts take about 30 seconds with the backoff below. That time covers
+# a short transient fault, such as a locked database file. It also stops a
+# permanent fault quickly.
+MAX_START_ATTEMPTS="${MISTHELPER_MAX_START_ATTEMPTS:-5}"
+
+# Smallest run time in seconds that counts as a real session.
+# A start that fails at once ends in about one second, so the script counts it
+# as a crash. A run that lasts 30 seconds or more shows that MistHelper started
+# and served the operator, so that run clears the crash count.
+MIN_HEALTHY_SECONDS="${MISTHELPER_MIN_HEALTHY_SECONDS:-30}"
+
+# First delay in seconds before a restart.
+# The delay doubles after each failed start. Two seconds keeps the first retry
+# fast, which recovers a transient fault without a long wait.
+RESTART_DELAY_SECONDS="${MISTHELPER_RESTART_DELAY_SECONDS:-2}"
+
+# Largest delay in seconds between two restarts.
+# The cap holds the wait at a value that an operator can watch. The cap also
+# stops the delay from growing without a limit.
+MAX_RESTART_DELAY_SECONDS="${MISTHELPER_MAX_RESTART_DELAY_SECONDS:-60}"
+
+# Application paths and the Python command.
+# The container defaults apply when no override is present. A test harness sets
+# these values to run the session loop outside the container.
+APP_DIR="${MISTHELPER_APP_DIR:-/app}"
+LOG_FILE="${MISTHELPER_LOG_FILE:-${APP_DIR}/data/ssh.log}"
+RUNTIME_LOG_FILE="${MISTHELPER_RUNTIME_LOG_FILE:-${APP_DIR}/data/script.log}"
+PYTHON_COMMAND="${MISTHELPER_PYTHON:-python}"
+
 # Get unique session ID based on SSH connection
 SESSION_ID="${SSH_CONNECTION// /_}"
 SESSION_ID="${SESSION_ID//[:.]/_}"
-SESSION_DIR="/tmp/misthelper_sessions"
+SESSION_DIR="${MISTHELPER_SESSION_DIR:-/tmp/misthelper_sessions}"
 SESSION_FILE="${SESSION_DIR}/session_${SESSION_ID}"
 SESSION_PID_FILE="${SESSION_DIR}/pid_${SESSION_ID}"
 
 # Create session directory
 mkdir -p "$SESSION_DIR"
 
+# Write one line to the operator screen and to the session log.
+# The operator loses the screen when the SSH session closes, so the log keeps
+# the cause of a failure.
+log_session_line() {
+    echo "$1"  # Show the line on the terminal, because the operator watches the terminal.
+    { echo "$1" >> "$LOG_FILE"; } 2>/dev/null || true  # Keep a copy in the log, and never fail the session on a log write error.
+}
+
 # Function to cleanup session on exit
 cleanup_session() {
-    echo "[SESSION] Cleaning up session $SESSION_ID" >> /app/data/ssh.log
-    rm -f "$SESSION_FILE"
-    exit 0
+    SESSION_EXIT_STATUS=$?  # Keep the status of the last command, because the session must report a failure to the SSH client.
+    { echo "[SESSION] Cleaning up session $SESSION_ID" >> "$LOG_FILE"; } 2>/dev/null || true  # Record the end of the session, and ignore a log write error.
+    rm -f "$SESSION_FILE"  # Delete the session marker, because the session is over.
+    exit "$SESSION_EXIT_STATUS"  # Report the original status, because a fixed status of 0 hides a crash loop.
 }
 
 # Set up signal handlers
@@ -42,24 +87,53 @@ echo "================================================"
 echo ""
 
 # Change to application directory
-cd /app
+cd "$APP_DIR"
 
 # Main session loop
+FAILED_STARTS=0  # Count the failed starts in a row, because the loop stops at the attempt limit.
+RESTART_DELAY="$RESTART_DELAY_SECONDS"  # Hold the delay for the next restart, because the delay grows after each failure.
+
 while true; do
     echo "[SESSION] Starting MistHelper..."
-    
-    # Run MistHelper and capture exit code
-    python MistHelper.py
-    EXIT_CODE=$?
-    
+
+    RUN_START_SECONDS=$SECONDS  # Record the start time, because the run duration separates a crash from a session.
+
+    # Run MistHelper and capture exit code.
+    # The `|| EXIT_CODE=$?` form keeps the exit code. A plain command would end
+    # the script at once, because `set -e` is active.
+    EXIT_CODE=0  # Assume success, because the next line only sets a value on a failure.
+    "$PYTHON_COMMAND" MistHelper.py || EXIT_CODE=$?  # Start MistHelper and keep the exit code for the checks below.
+
+    RUN_SECONDS=$(( SECONDS - RUN_START_SECONDS ))  # Measure the run duration, because a long run is not a crash.
+
     # Check if user chose to exit (option 0)
     if [[ $EXIT_CODE -eq 0 ]]; then
-        echo "[SESSION] User selected exit. Closing session."
-        break
-    else
-        echo "[SESSION] MistHelper exited with code $EXIT_CODE. Restarting..."
-        sleep 2
+        echo "[SESSION] User selected exit. Closing session."  # Tell the operator that the exit was intentional.
+        break  # Leave the loop, because a clean exit needs no restart.
+    fi
+
+    # A run that lasted long enough was a real session, not a crash loop.
+    if [[ $RUN_SECONDS -ge $MIN_HEALTHY_SECONDS ]]; then
+        FAILED_STARTS=0  # Clear the count, because a healthy session must not spend the crash budget.
+        RESTART_DELAY="$RESTART_DELAY_SECONDS"  # Restore the first delay, because the next failure starts a new sequence.
+    fi
+
+    FAILED_STARTS=$(( FAILED_STARTS + 1 ))  # Count this failure, because the limit applies to failures in a row.
+
+    # Stop the loop at the attempt limit.
+    if [[ $FAILED_STARTS -ge $MAX_START_ATTEMPTS ]]; then
+        log_session_line "[SESSION] MistHelper failed $FAILED_STARTS times in a row. The last exit code was $EXIT_CODE."  # State the count and the code, because the operator needs both to find the cause.
+        log_session_line "[SESSION] The session is closed. To find the cause, read $RUNTIME_LOG_FILE and $LOG_FILE."  # Name the two log files, because a junior operator needs the exact path.
+        exit 1  # Close the session with a failure status, because a crash loop must not hold the SSH connection open.
+    fi
+
+    echo "[SESSION] MistHelper exited with code $EXIT_CODE. Attempt $FAILED_STARTS of $MAX_START_ATTEMPTS. Next start in $RESTART_DELAY seconds."  # Show the progress, because a silent wait looks like a hang.
+    sleep "$RESTART_DELAY"  # Wait before the restart, because an immediate restart repeats the same fault and wastes CPU.
+
+    RESTART_DELAY=$(( RESTART_DELAY * 2 ))  # Double the delay, because a repeated fault needs more time to clear.
+    if [[ $RESTART_DELAY -gt $MAX_RESTART_DELAY_SECONDS ]]; then
+        RESTART_DELAY="$MAX_RESTART_DELAY_SECONDS"  # Hold the delay at the cap, because an operator must not wait longer than the cap.
     fi
 done
 
-echo "[SESSION] Session $SESSION_ID terminated." >> /app/data/ssh.log
+{ echo "[SESSION] Session $SESSION_ID terminated." >> "$LOG_FILE"; } 2>/dev/null || true  # Record the clean end of the session, and ignore a log write error.

--- a/documentation/SSH_GUIDE.md
+++ b/documentation/SSH_GUIDE.md
@@ -34,7 +34,7 @@ ssh -p 2200 misthelper@localhost
 Once connected via SSH, MistHelper starts automatically:
 - **Automatic Launch**: MistHelper menu appears immediately upon SSH connection
 - **Session Persistence**: Each SSH connection gets its own isolated session
-- **Bounded Auto-Restart**: After an operation, MistHelper restarts. After a crash, the session restarts MistHelper up to five times, and then closes with a message that names the exit code and the log paths
+- **Bounded Auto-Restart**: MistHelper restarts after each operation. After five crashes in a row, the session closes and names the cause.
 - **Clean Exit**: Use option "0" to properly exit and close SSH session
 - **No Shell Access**: You cannot access the container's command line for security
 
@@ -74,7 +74,46 @@ podman stop misthelper-ssh
 podman rm misthelper-ssh
 ```
 
-## SSH Configuration Details
+## Session Restart Behavior
+
+The script `container/scripts/misthelper-session.sh` restarts MistHelper after a
+failed run. The restart stops at a limit, so a permanent fault cannot hold the
+SSH session open and fill the log file.
+
+| Control | Default | Purpose |
+|---------|---------|---------|
+| `MISTHELPER_MAX_START_ATTEMPTS` | 5 | Largest number of failed starts in a row before the session closes |
+| `MISTHELPER_MIN_HEALTHY_SECONDS` | 30 | Smallest run time that counts as a real session and clears the crash count |
+| `MISTHELPER_RESTART_DELAY_SECONDS` | 2 | First delay before a restart. The delay doubles after each failed start |
+| `MISTHELPER_MAX_RESTART_DELAY_SECONDS` | 60 | Largest delay between two restarts |
+
+With the default values, the delays run 2, 4, 8, and 16 seconds. Five failed
+starts therefore take about 30 seconds. The session then closes with a failure
+status and prints the last exit code, the attempt count, and the two log paths
+to read.
+
+### How to Change a Control Value
+
+**Caution:** A `podman run -e` value will not reach the session script, and the
+script will keep the default value. The SSH daemon does not pass the container
+environment to a session. The same limit applies to `docker run -e` and to an
+`Environment=` line in a Quadlet unit file.
+
+Use one of these two methods instead.
+
+1. Edit the assignment at the top of `container/scripts/misthelper-session.sh`
+   and rebuild the image. Use this method for a permanent change.
+2. Add the name and the value to `/etc/environment` inside the container. The
+   SSH daemon reads that file at each login through PAM. Use this method for a
+   test on a running container.
+
+```bash
+# Method 2: raise the attempt limit to 8 on a running container
+podman exec -u root misthelper sh -c 'echo "MISTHELPER_MAX_START_ATTEMPTS=8" >> /etc/environment'
+```
+
+The new value applies to the next SSH login. An open session keeps the old
+value.
 
 ## SSH Configuration Details
 
@@ -119,6 +158,22 @@ All MistHelper data files and logs persist on the host system.
 - Check Podman/Docker installation
 - Verify Containerfile syntax
 - Review build logs for errors
+
+### The SSH Session Closes Right After the Connection
+MistHelper failed to start five times in a row. The session prints a message
+before it closes. The message names the last exit code, the attempt count, and
+the two log paths. Read that message first.
+
+```text
+[SESSION] MistHelper failed 5 times in a row. The last exit code was 1.
+[SESSION] The session is closed. To find the cause, read /app/data/script.log and /app/data/ssh.log.
+```
+
+The same two lines go to `/app/data/ssh.log`, so the message stays after the
+terminal closes. Read `/app/data/script.log` for the MistHelper error. A missing
+dependency, a bad `.env` file, and a data directory without write permission are
+the common causes. To fix a permission error, run `chmod -R 777 data/` on the
+host.
 
 ## Advanced Usage
 

--- a/documentation/SSH_GUIDE.md
+++ b/documentation/SSH_GUIDE.md
@@ -34,7 +34,7 @@ ssh -p 2200 misthelper@localhost
 Once connected via SSH, MistHelper starts automatically:
 - **Automatic Launch**: MistHelper menu appears immediately upon SSH connection
 - **Session Persistence**: Each SSH connection gets its own isolated session
-- **Auto-Restart**: After completing an operation, MistHelper automatically restarts
+- **Bounded Auto-Restart**: After an operation, MistHelper restarts. After a crash, the session restarts MistHelper up to five times, and then closes with a message that names the exit code and the log paths
 - **Clean Exit**: Use option "0" to properly exit and close SSH session
 - **No Shell Access**: You cannot access the container's command line for security
 
@@ -83,7 +83,7 @@ podman rm misthelper-ssh
 - **Authentication:** Password-based
 - **Forced Command:** Automatic MistHelper session launcher
 - **User:** misthelper (restricted to MistHelper only)
-- **Session Management:** Each connection gets isolated session with auto-restart
+- **Session Management:** Each connection gets an isolated session with a bounded auto-restart
 
 ### Security Notes
 - SSH server only accepts connections for user `misthelper`

--- a/documentation/wiki/SSH-Remote-Access.md
+++ b/documentation/wiki/SSH-Remote-Access.md
@@ -35,7 +35,7 @@ ssh -p 2200 misthelper@localhost
 - **Automatic Session Management**: Each SSH connection creates an isolated MistHelper session
 - **Multi-User Support**: Multiple users can connect simultaneously with session isolation
 - **Session Persistence**: Sessions persist until you explicitly exit
-- **Bounded Auto-Restart**: If MistHelper crashes, the session restarts it up to five times, then closes
+- **Bounded Auto-Restart**: After five crashes in a row, the session closes and names the cause.
 - **ForceCommand Architecture**: Direct launch into MistHelper (no shell access for security)
 
 ## Session Management
@@ -50,9 +50,9 @@ Each SSH connection automatically:
 
 ### Restart Controls
 
-The session script `container/scripts/misthelper-session.sh` restarts MistHelper
-after a failed run. The restart stops at a limit, so a permanent fault cannot
-hold the session open and fill the log file.
+The script `container/scripts/misthelper-session.sh` restarts MistHelper after a
+failed run. The restart stops at a limit, so a permanent fault cannot hold the
+session open and fill the log file.
 
 | Control | Default | Purpose |
 |---------|---------|---------|
@@ -65,11 +65,15 @@ With the default values, five failed starts take about 30 seconds. The session
 then closes with a failure status and prints the last exit code, the attempt
 count, and the two log paths to read.
 
-To change a value, edit the assignment at the top of the session script, or add
-the name and the value to `/etc/environment` inside the container. The SSH
-daemon uses PAM, and PAM reads that file at login. The SSH daemon does not pass
-the container environment to a session, so a `podman run -e` value alone does
-not reach the script.
+**Caution:** A `podman run -e` value will not reach the session script, and the
+script will keep the default value. The SSH daemon does not pass the container
+environment to a session. The same limit applies to `docker run -e` and to an
+`Environment=` line in a Quadlet unit file.
+
+To change a value, use one of two methods. Edit the assignment at the top of the
+script and rebuild the image. Or add the name and the value to
+`/etc/environment` inside the container. The SSH daemon reads that file at each
+login through PAM. For the full procedure, see `documentation/SSH_GUIDE.md`.
 
 ## Usage Examples
 

--- a/documentation/wiki/SSH-Remote-Access.md
+++ b/documentation/wiki/SSH-Remote-Access.md
@@ -35,7 +35,7 @@ ssh -p 2200 misthelper@localhost
 - **Automatic Session Management**: Each SSH connection creates an isolated MistHelper session
 - **Multi-User Support**: Multiple users can connect simultaneously with session isolation
 - **Session Persistence**: Sessions persist until you explicitly exit
-- **Auto-Restart**: If MistHelper crashes, the session automatically restarts
+- **Bounded Auto-Restart**: If MistHelper crashes, the session restarts it up to five times, then closes
 - **ForceCommand Architecture**: Direct launch into MistHelper (no shell access for security)
 
 ## Session Management
@@ -46,7 +46,30 @@ Each SSH connection automatically:
 2. Sets up an isolated working directory (`/app/sessions/session_<id>/`)
 3. Launches MistHelper with container detection
 4. Handles clean exit and session cleanup
-5. Provides session restart on unexpected termination
+5. Restarts MistHelper after an unexpected exit, up to the attempt limit
+
+### Restart Controls
+
+The session script `container/scripts/misthelper-session.sh` restarts MistHelper
+after a failed run. The restart stops at a limit, so a permanent fault cannot
+hold the session open and fill the log file.
+
+| Control | Default | Purpose |
+|---------|---------|---------|
+| `MISTHELPER_MAX_START_ATTEMPTS` | 5 | Largest number of failed starts in a row before the session closes |
+| `MISTHELPER_MIN_HEALTHY_SECONDS` | 30 | Smallest run time that counts as a real session and clears the crash count |
+| `MISTHELPER_RESTART_DELAY_SECONDS` | 2 | First delay before a restart. The delay doubles after each failed start |
+| `MISTHELPER_MAX_RESTART_DELAY_SECONDS` | 60 | Largest delay between two restarts |
+
+With the default values, five failed starts take about 30 seconds. The session
+then closes with a failure status and prints the last exit code, the attempt
+count, and the two log paths to read.
+
+To change a value, edit the assignment at the top of the session script, or add
+the name and the value to `/etc/environment` inside the container. The SSH
+daemon uses PAM, and PAM reads that file at login. The SSH daemon does not pass
+the container environment to a session, so a `podman run -e` value alone does
+not reach the script.
 
 ## Usage Examples
 

--- a/tests/unit/container/__init__.py
+++ b/tests/unit/container/__init__.py
@@ -1,0 +1,1 @@
+"""Container test package for the shell scripts under container/scripts."""

--- a/tests/unit/container/test_misthelper_session_script.py
+++ b/tests/unit/container/test_misthelper_session_script.py
@@ -1,0 +1,210 @@
+"""Tests for the restart loop in the SSH session script.
+
+The script ``container/scripts/misthelper-session.sh`` starts MistHelper for
+each SSH session. The script restarts MistHelper when a run fails. A permanent
+fault, such as a missing dependency, makes every run fail. An unbounded loop
+then burns container CPU and fills the log file. See issue #1911.
+
+Each test runs the real script with a stub in place of MistHelper. Each test
+uses a hard timeout, so a lost limit fails the test instead of a hang. The
+script writes to a file and not to a pipe, because a killed shell leaves a
+sleep child that holds a pipe open.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Find the repository root, because pytest moves the working directory.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+# Point at the script under test.
+SESSION_SCRIPT = REPO_ROOT / "container" / "scripts" / "misthelper-session.sh"
+# Locate bash, because the test runs a shell script.
+BASH_PATH = shutil.which("bash")
+# Stop a runaway loop, because a lost limit must fail the test and not hang it.
+HARNESS_TIMEOUT_SECONDS = 60
+
+# Skip the module when bash is absent, because the script needs bash.
+pytestmark = pytest.mark.skipif(BASH_PATH is None, reason="bash is required to run the session script")
+
+# Fail at once with a fixed code, because a startup defect fails at once.
+ALWAYS_FAILS_STUB = "#!/bin/bash\nexit 3\n"
+# Exit with success, because menu option 0 ends a session.
+CLEAN_EXIT_STUB = "#!/bin/bash\nexit 0\n"
+# Fail twice after a long run, then exit clean. A long run is a real session,
+# so the script must clear the crash count after each long run.
+LONG_RUN_THEN_CLEAN_STUB = """#!/bin/bash
+COUNT_FILE="./data/run_count"
+COUNT=0
+if [[ -f "$COUNT_FILE" ]]; then
+    COUNT=$(cat "$COUNT_FILE")
+fi
+COUNT=$(( COUNT + 1 ))
+echo "$COUNT" > "$COUNT_FILE"
+if [[ $COUNT -ge 3 ]]; then
+    exit 0
+fi
+sleep 2
+exit 1
+"""
+
+
+def _build_fake_app(tmp_path: Path, stub_body: str) -> Path:
+    """Build a directory that takes the place of /app inside the container.
+
+    The session script runs the command ``$MISTHELPER_PYTHON MistHelper.py``.
+    A test sets ``MISTHELPER_PYTHON`` to ``bash``, so the stub is a shell
+    script that carries the name of the Python entry point.
+    """
+    app_dir = tmp_path / "app"  # Keep the fake application outside the repository.
+    (app_dir / "data").mkdir(parents=True)  # Create the data directory, because the script appends to data/ssh.log.
+    stub_path = app_dir / "MistHelper.py"  # Use the name that the session script starts.
+    stub_path.write_text(stub_body, encoding="ascii", newline="\n")  # Write LF endings, because bash rejects a CR.
+    stub_path.chmod(0o755)  # Grant the execute bit, because a POSIX runner needs it.
+    return app_dir  # Give the path back for the assertions.
+
+
+def _run_session_script(app_dir: Path, overrides: dict[str, str]) -> tuple[int, str]:
+    """Run the session script and return the exit status and the output."""
+    env = os.environ.copy()  # Start from the real environment, because bash needs PATH.
+    env["MISTHELPER_APP_DIR"] = app_dir.as_posix()  # Point the script at the fake application directory.
+    env["MISTHELPER_SESSION_DIR"] = (app_dir / "sessions").as_posix()  # Keep the session marker in the temporary tree.
+    env["MISTHELPER_PYTHON"] = "bash"  # Run the stub with bash, because the stub is a shell script.
+    env.update(overrides)  # Apply the restart controls for this test.
+    output_path = app_dir / "session_output.txt"  # Collect the output in a file, because a pipe blocks after a kill.
+    with output_path.open("w", encoding="utf-8") as handle:
+        status = subprocess.run(
+            [str(BASH_PATH), SESSION_SCRIPT.as_posix()],  # Run the real script, because the test proves its behavior.
+            stdout=handle,  # Send the screen output to the file.
+            stderr=subprocess.STDOUT,  # Keep the error output with the screen output, because a fault prints there.
+            timeout=HARNESS_TIMEOUT_SECONDS,  # Apply the hard timeout, because a lost limit must not hang the suite.
+            env=env,  # Pass the overrides that select the test values.
+            cwd=str(app_dir),  # Start in the fake application directory, because the stub reads a file there.
+            check=False,  # Keep the failure status, because a give-up returns a non-zero status.
+        ).returncode
+    return status, output_path.read_text(encoding="utf-8", errors="replace")  # Read the output for the assertions.
+
+
+def _run_or_fail(app_dir: Path, overrides: dict[str, str]) -> tuple[int, str]:
+    """Run the script and turn a timeout into a clear test failure."""
+    try:
+        return _run_session_script(app_dir, overrides)  # Run the script under the hard timeout.
+    except subprocess.TimeoutExpired:  # A timeout shows that the loop never stopped.
+        pytest.fail(
+            f"The session script did not stop within {HARNESS_TIMEOUT_SECONDS} seconds. "
+            "The restart loop has no attempt limit."
+        )
+
+
+def _count_starts(output: str) -> int:
+    """Count the start messages, because each message marks one attempt."""
+    return output.count("[SESSION] Starting MistHelper...")  # Match the fixed message from the script.
+
+
+class TestSessionRestartLoop:
+    """Prove that the restart loop is bounded, patient, and clear."""
+
+    def test_script_syntax_is_valid(self) -> None:
+        """The script must parse, because a syntax error closes every session."""
+        result = subprocess.run(
+            [str(BASH_PATH), "-n", SESSION_SCRIPT.as_posix()],  # Ask bash to parse the script without a run.
+            capture_output=True,  # Keep the output, because a failure names the line.
+            text=True,  # Decode the output for the message.
+            timeout=30,  # Bound the parse, because a hung parse hides a defect.
+            check=False,  # Read the status in the assertion instead.
+        )
+        assert result.returncode == 0, result.stderr  # A non-zero status means a syntax error.
+
+    def test_repeated_crash_stops_after_the_attempt_limit(self, tmp_path: Path) -> None:
+        """A permanent fault must stop the loop and close the session."""
+        app_dir = _build_fake_app(tmp_path, ALWAYS_FAILS_STUB)  # Build an application that always fails.
+        status, output = _run_or_fail(
+            app_dir,
+            {
+                "MISTHELPER_MAX_START_ATTEMPTS": "3",  # Use a small limit, because the test must stay fast.
+                "MISTHELPER_RESTART_DELAY_SECONDS": "1",  # Use a short delay for the same reason.
+                "MISTHELPER_MAX_RESTART_DELAY_SECONDS": "1",  # Hold the delay flat, because this test reads the count.
+                "MISTHELPER_MIN_HEALTHY_SECONDS": "30",  # Keep the normal threshold, because every run is short.
+            },
+        )
+
+        assert _count_starts(output) == 3, output  # The script must try exactly three times.
+        assert status != 0, output  # The session must report a failure to the SSH client.
+        assert "failed 3 times in a row" in output, output  # The message must name the attempt count.
+        assert "The last exit code was 3." in output, output  # The message must name the exit code.
+        assert "script.log" in output, output  # The message must point at the runtime log.
+        assert "ssh.log" in output, output  # The message must point at the session log.
+
+    def test_give_up_message_reaches_the_session_log(self, tmp_path: Path) -> None:
+        """The cause must stay in the log, because the screen goes away."""
+        app_dir = _build_fake_app(tmp_path, ALWAYS_FAILS_STUB)  # Build an application that always fails.
+        _run_or_fail(
+            app_dir,
+            {
+                "MISTHELPER_MAX_START_ATTEMPTS": "2",  # Use the smallest useful limit for speed.
+                "MISTHELPER_RESTART_DELAY_SECONDS": "1",  # Keep the single delay short.
+                "MISTHELPER_MAX_RESTART_DELAY_SECONDS": "1",  # Hold the delay flat.
+                "MISTHELPER_MIN_HEALTHY_SECONDS": "30",  # Keep the normal threshold.
+            },
+        )
+
+        log_text = (app_dir / "data" / "ssh.log").read_text(encoding="utf-8")  # Read the log that the operator keeps.
+        assert "failed 2 times in a row" in log_text, log_text  # The log must hold the attempt count.
+        assert "The last exit code was 3." in log_text, log_text  # The log must hold the exit code.
+
+    def test_restart_delay_grows_and_stops_at_the_cap(self, tmp_path: Path) -> None:
+        """The delay must double, and the cap must hold it."""
+        app_dir = _build_fake_app(tmp_path, ALWAYS_FAILS_STUB)  # Build an application that always fails.
+        _status, output = _run_or_fail(
+            app_dir,
+            {
+                "MISTHELPER_MAX_START_ATTEMPTS": "4",  # Allow three delays before the give-up.
+                "MISTHELPER_RESTART_DELAY_SECONDS": "1",  # Start the sequence at one second.
+                "MISTHELPER_MAX_RESTART_DELAY_SECONDS": "2",  # Cap the sequence at two seconds.
+                "MISTHELPER_MIN_HEALTHY_SECONDS": "30",  # Keep the normal threshold.
+            },
+        )
+
+        delays = [int(value) for value in re.findall(r"Next start in (\d+) seconds", output)]  # Read each delay.
+        assert delays == [1, 2, 2], output  # The delay must double one time and then hold at the cap.
+
+    def test_a_healthy_run_clears_the_crash_count(self, tmp_path: Path) -> None:
+        """A long session must not spend the crash budget."""
+        app_dir = _build_fake_app(tmp_path, LONG_RUN_THEN_CLEAN_STUB)  # Build an application with two long failures.
+        status, output = _run_or_fail(
+            app_dir,
+            {
+                "MISTHELPER_MAX_START_ATTEMPTS": "2",  # Give up on the second failure in a row.
+                "MISTHELPER_RESTART_DELAY_SECONDS": "1",  # Keep each delay short.
+                "MISTHELPER_MAX_RESTART_DELAY_SECONDS": "1",  # Hold the delay flat.
+                "MISTHELPER_MIN_HEALTHY_SECONDS": "1",  # Treat a run of one second or more as a real session.
+            },
+        )
+
+        assert _count_starts(output) == 3, output  # Two long failures must not stop the third start.
+        assert "User selected exit. Closing session." in output, output  # The third run ends the session.
+        assert status == 0, output  # A clean exit must report success.
+        assert "times in a row" not in output, output  # The script must not report a give-up.
+
+    def test_clean_exit_closes_the_session_without_a_restart(self, tmp_path: Path) -> None:
+        """Menu option 0 must keep its behavior, because operators rely on it."""
+        app_dir = _build_fake_app(tmp_path, CLEAN_EXIT_STUB)  # Build an application that exits with success.
+        status, output = _run_or_fail(
+            app_dir,
+            {
+                "MISTHELPER_MAX_START_ATTEMPTS": "3",  # Use a small limit, because no restart is expected.
+                "MISTHELPER_RESTART_DELAY_SECONDS": "1",  # Keep the value small for speed.
+                "MISTHELPER_MAX_RESTART_DELAY_SECONDS": "1",  # Keep the value small for speed.
+                "MISTHELPER_MIN_HEALTHY_SECONDS": "30",  # Keep the normal threshold.
+            },
+        )
+
+        assert _count_starts(output) == 1, output  # A clean exit must start MistHelper one time.
+        assert "User selected exit. Closing session." in output, output  # The clean message must stay.
+        assert status == 0, output  # A clean exit must report success.


### PR DESCRIPTION
Fixes #1911

**Linked Spec Issue**: #1911

## Problem

`container/scripts/misthelper-session.sh` restarts MistHelper after every non-zero exit, with a flat 2 second delay and no attempt limit. A clean exit is the only path that leaves the loop. A startup defect, a missing dependency, or a bad configuration file makes every start fail, so the loop repeats for as long as the SSH connection stays open. The loop burns container CPU, fills `ssh.log`, and shows the operator a scrolling message with no statement of the cause.

### A second defect in the same block

The work found a second defect. `set -e` is active, and `python MistHelper.py` is a plain command in the loop body. A failed run therefore ended the script at the first failure, and the `EXIT` trap ran `exit 0`. The result: a crash closed the session after one attempt and reported success to the SSH client, so `sshd` and any monitor saw a clean session. The unbounded loop is real in the code, and it starts as soon as the exit code is captured. The fix repairs both defects together, because a bounded loop needs the exit code.

Evidence for both statements is in the Verification section.

## Fix

`container/scripts/misthelper-session.sh`:

- Capture the exit code with `"$PYTHON_COMMAND" MistHelper.py || EXIT_CODE=$?`, so `set -e` no longer ends the script at the first failure.
- Count the failed starts in a row. Stop at the limit, and `exit 1` so the SSH session closes.
- Measure the run duration with the bash `SECONDS` variable. A run that lasts at least `MIN_HEALTHY_SECONDS` clears the crash count and the delay.
- Replace the flat 2 second sleep with a delay that doubles after each failure and stops at a cap.
- Print one final message with the exit code, the attempt count, and the two log paths. Write that message to the screen and to `ssh.log`, because the screen goes away when the session closes.
- Report the real status from the exit trap. The old `exit 0` hid a crash.
- Keep the clean exit path unchanged. Menu option 0 still prints `[SESSION] User selected exit. Closing session.` and returns 0.

Every path label, the `[SESSION]` prefix, and the ASCII-only rule stay the same.

## Chosen values

Each value is a named variable at the top of the script, with a comment, and each accepts an environment override.

| Variable | Default | Reason |
|---|---|---|
| `MISTHELPER_MAX_START_ATTEMPTS` | 5 | Five attempts take about 30 seconds with the backoff below. That time covers a short transient fault, such as a locked database file. It also stops a permanent fault quickly. The issue suggests the same number. |
| `MISTHELPER_MIN_HEALTHY_SECONDS` | 30 | A start that fails at once ends in about one second. A run of 30 seconds or more shows that MistHelper started and served the operator, so that run must not spend the crash budget. A larger threshold is the safe direction, because a small threshold lets a slow crash reset the count forever. |
| `MISTHELPER_RESTART_DELAY_SECONDS` | 2 | This value keeps the current first delay, so a transient fault still recovers fast. |
| `MISTHELPER_MAX_RESTART_DELAY_SECONDS` | 60 | The cap holds the longest wait at a value an operator can watch, and it stops the delay from growing without a limit. |

With the defaults, the sleeps run 2, 4, 8, and 16 seconds, and the fifth failure closes the session. Total wait: about 30 seconds.

Three more variables (`MISTHELPER_APP_DIR`, `MISTHELPER_SESSION_DIR`, `MISTHELPER_PYTHON`) replace the hardcoded `/app`, `/tmp/misthelper_sessions`, and `python`. Every default matches the previous literal value, so container behavior does not change. The test harness sets these three values to run the real script outside the container.

Note on the override path: the SSH daemon does not pass the container environment to a session, which is why the script already re-exports `PYTHONUNBUFFERED` and its neighbors. The image sets `UsePAM yes`, so an administrator can set a value in `/etc/environment` inside the container. `documentation/SSH_GUIDE.md` carries a Caution that names this limit, the two methods that do work, and a worked example. Wiring the values through `container/scripts/start.sh` was left out on purpose, because PR #1912 owns that file.

## Documentation

`documentation/SSH_GUIDE.md` gains a **Session Restart Behavior** section with the four controls, the default of each, and the reason for each. It also gains a troubleshooting entry, **The SSH Session Closes Right After the Connection**, which shows the give-up message and names the two log paths to read. `documentation/wiki/SSH-Remote-Access.md` carries the same content in short form and points at the guide.

The STE linter grades both files above the threshold, and both scores rose against `main`:

| File | Base score | This branch |
|---|---|---|
| `documentation/SSH_GUIDE.md` | 89 | **94** |
| `documentation/wiki/SSH-Remote-Access.md` | 82 | **93** |

No STE violation remains in any line this PR wrote. The follow-up commit also deletes a duplicate `## SSH Configuration Details` heading that sat next to the new section.

## Verification

All commands ran on Windows with Git bash 5.2.37 and Python 3.13.3.

**1. The old loop is unbounded.** A throwaway harness took the script from `HEAD`, replaced `/app` with a local directory, and ran it against a stub that always exits 3, with a 20 second timeout.

```text
python verify_1911_v2.py HEAD --no-errexit
RESULT: the loop did NOT stop within 20 seconds.
Start attempts observed: 8
  [SESSION] MistHelper exited with code 3. Restarting...
  [SESSION] Starting MistHelper...
  [SESSION] MistHelper exited with code 3. Restarting...
```

**2. The old script hid the crash.** The same harness, with `set -e` left in place:

```text
python verify_1911_v2.py HEAD
RESULT: the loop stopped. Exit status 0.
Start attempts observed: 1
```

**3. The new tests fail against the old script.** `tests/unit/container/test_misthelper_session_script.py` ran before the change:

```text
python -m pytest tests/unit/container/test_misthelper_session_script.py -q
5 failed, 1 passed in 13.37s
```

**4. The new tests pass against the new script.**

```text
python -m pytest tests/unit/container/test_misthelper_session_script.py -q
6 passed in 24.72s
```

The six tests are: the script parses, a repeated crash stops at the limit, the give-up message reaches `ssh.log`, the delay grows and holds at the cap (`[1, 2, 2]` with a cap of 2), a healthy run clears the crash count, and a clean exit still starts MistHelper one time and returns 0. Each test uses a 60 second hard timeout and sends the output to a file, because a killed shell leaves a `sleep` child that holds a pipe open. A lost limit fails the test instead of hanging the suite.

**5. Syntax and lint.**

```text
bash -n container/scripts/misthelper-session.sh    -> exit 0
python -m ruff check tests                         -> All checks passed!
python -m black --check tests                      -> 417 files would be left unchanged.
```

`shellcheck` is not installed on this runner, so that check did not run. `bash -n` covers the syntax.

## Acceptance criteria from the issue

- [x] A repeated crash stops the loop after the attempt limit.
- [x] The final message names the exit code and the log path.
- [x] The delay grows between consecutive restarts and stops growing at a cap.
- [x] A long healthy session resets the counter.

## Scope and conformance

- [x] Tests added for all changed behavior (`tests/unit/container/`)
- [x] No new Ruff violations, and Black reports no change
- [x] No secrets, and no credential in any file
- [x] Documentation updated: `documentation/SSH_GUIDE.md` and `documentation/wiki/SSH-Remote-Access.md`. The guide states the controls, the override limit, and the troubleshooting steps, so the information survives the merge of this PR.
- [x] Files outside `container/scripts/misthelper-session.sh` and its tests and documents were not touched. `container/scripts/start.sh`, the `Dockerfile`, `MistHelper.py`, `src/`, `web_portal/`, and `mist-ops-platform/` are unchanged.
- [ ] Changelog entry: left out on purpose. Issue #1899 records that a changelog edit collides with every other open agent PR.
- [ ] mypy, Bandit, and pip-audit: not run here. The change is a shell script plus a test file. `MYPY_PATHS` is `src/ MistHelper.py wsgi.py`, and the Bandit configuration excludes `tests`, so neither gate reads a changed file.
- [ ] Coverage: the shell script is not Python, so the Python coverage number does not move.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
