### PR TITLE
security(web-portal): enforce the webhook signature check

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -71,6 +71,26 @@ MIST_ORG_ID=your_org_id_here
 # Maximum output file names one operation run keeps (default: 500)
 # PORTAL_RUN_OUTPUT_FILES_MAX=500
 
+# ============================================================
+# Web Portal Webhook Receiver (issue #1907)
+# ============================================================
+# The portal can receive Mist Cloud events at POST /api/webhook.
+# The portal verifies an HMAC-SHA256 signature on every request, so the
+# shared secret below is required.
+#
+# Set WEBHOOK_SECRET to the same value that you enter in the Mist Cloud
+# webhook configuration. Generate a value with this command:
+#   python -c "import secrets; print(secrets.token_hex(32))"
+#
+# Caution: If WEBHOOK_SECRET is empty, the portal rejects every webhook
+# with code 503 and writes an error to the log. The portal never accepts
+# an unverified payload, because a forged payload can inject a false
+# device event.
+# WEBHOOK_SECRET=
+
+# Set WEBHOOK_ENABLED to false to remove the /api/webhook route (default: true)
+# WEBHOOK_ENABLED=true
+
 # SSID Template Consolidation specific variables
 # Cache freshness window for SSID Template Consolidation collector (minutes, default: 60)
 # SSID_CONSOLIDATION_CACHE_MINUTES=60

--- a/tests/unit/web_portal/test_webhook_signature.py
+++ b/tests/unit/web_portal/test_webhook_signature.py
@@ -1,0 +1,307 @@
+"""Unit tests for the web portal webhook signature check.
+
+Regression cover for issue #1907. The route read ``WEBHOOK_SECRET`` from
+the Flask config, but no code ever wrote that key. The secret was always
+the empty string, and the empty string is false, so the guard
+``if secret and not _verify_signature(...)`` short circuited. The check
+never ran. Any client that could reach the portal could post an unsigned
+body and reach the dispatch path.
+
+These tests hold the fail-closed contract:
+
+* A request with no signature receives code 403 when the secret is set.
+* A request with a wrong signature receives code 403.
+* A request receives code 503 when the secret is absent or empty.
+* A rejected request never reaches the dispatch path.
+* The app factory reads the secret from the environment.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from web_portal.app import WebPortalApp
+from web_portal.routes import webhooks as webhooks_module
+from web_portal.routes.webhooks import webhook_bp
+
+# WHY: a fixed secret keeps every signature in these tests reproducible.
+_SECRET = "0123456789abcdef0123456789abcdef"
+
+# WHY: the audit topic reaches the router, so it proves the dispatch path.
+_AUDIT_BODY = json.dumps({"topic": "audits", "events": [{"id": "event-1"}]}).encode()
+
+_JSON_HEADERS = {"Content-Type": "application/json"}
+
+
+class _RecordingRouter:
+    """Record every audit event that the route dispatches."""
+
+    def __init__(self) -> None:
+        """Start with an empty record of dispatched events."""
+        self.audit_events: list[dict] = []
+
+    def handle_webhook_audit(self, event: dict) -> None:
+        """Store one dispatched audit event for a later assertion."""
+        self.audit_events.append(event)
+
+
+def _sign(body: bytes, secret: str) -> str:
+    """Return the HMAC-SHA256 hex digest that the route expects."""
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _build_test_app(secret: Any = None, router: Any = None) -> Flask:
+    """Build a minimal Flask app that serves the webhook blueprint."""
+    app = Flask(__name__)  # WHY: a bare app avoids the portal factory and its side effects.
+    if secret is not None:  # WHY: None models a config key that no code ever wrote.
+        app.config["WEBHOOK_SECRET"] = secret
+    app.config["DB_ROUTER"] = router  # WHY: the route reads this key to find the dispatch target.
+    app.register_blueprint(webhook_bp)  # WHY: register the route under test only.
+    return app
+
+
+@pytest.fixture
+def recording_router() -> _RecordingRouter:
+    """Return a router that records the events the route dispatches."""
+    return _RecordingRouter()
+
+
+class TestUnsignedRequests:
+    """Verify the route rejects a request that carries no signature."""
+
+    def test_a_post_with_no_signature_header_is_rejected(self, recording_router: _RecordingRouter) -> None:
+        """A missing X-Mist-Signature header must produce code 403."""
+        client = _build_test_app(_SECRET, recording_router).test_client()
+
+        response = client.post("/api/webhook", data=_AUDIT_BODY, headers=_JSON_HEADERS)
+
+        assert response.status_code == 403, "An unsigned webhook must never receive a success reply"
+        assert response.get_json()["error"] == "invalid signature"
+
+    def test_a_post_with_no_signature_never_reaches_the_dispatch_path(self, recording_router: _RecordingRouter) -> None:
+        """An unsigned payload must not reach the database router."""
+        client = _build_test_app(_SECRET, recording_router).test_client()
+
+        client.post("/api/webhook", data=_AUDIT_BODY, headers=_JSON_HEADERS)
+
+        assert recording_router.audit_events == [], "A forged payload must not reach the audit handler"
+
+    def test_an_empty_signature_header_is_rejected(self, recording_router: _RecordingRouter) -> None:
+        """An empty signature value must produce code 403."""
+        headers = dict(_JSON_HEADERS, **{"X-Mist-Signature": ""})
+        client = _build_test_app(_SECRET, recording_router).test_client()
+
+        response = client.post("/api/webhook", data=_AUDIT_BODY, headers=headers)
+
+        assert response.status_code == 403
+        assert recording_router.audit_events == []
+
+
+class TestSignatureVerification:
+    """Verify the route accepts a valid signature and rejects a wrong one."""
+
+    def test_a_valid_signature_is_accepted(self, recording_router: _RecordingRouter) -> None:
+        """A correct digest must produce code 200 and reach the router."""
+        headers = dict(_JSON_HEADERS, **{"X-Mist-Signature": _sign(_AUDIT_BODY, _SECRET)})
+        client = _build_test_app(_SECRET, recording_router).test_client()
+
+        response = client.post("/api/webhook", data=_AUDIT_BODY, headers=headers)
+
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "ok"
+        assert recording_router.audit_events == [{"id": "event-1"}]
+
+    def test_a_wrong_signature_is_rejected_with_403(self, recording_router: _RecordingRouter) -> None:
+        """A digest from another secret must produce code 403."""
+        headers = dict(_JSON_HEADERS, **{"X-Mist-Signature": _sign(_AUDIT_BODY, "the-wrong-secret")})
+        client = _build_test_app(_SECRET, recording_router).test_client()
+
+        response = client.post("/api/webhook", data=_AUDIT_BODY, headers=headers)
+
+        assert response.status_code == 403
+        assert recording_router.audit_events == []
+
+    def test_a_signature_for_a_different_body_is_rejected(self, recording_router: _RecordingRouter) -> None:
+        """A replayed digest must not authenticate a changed body."""
+        tampered = json.dumps({"topic": "audits", "events": [{"id": "forged"}]}).encode()
+        headers = dict(_JSON_HEADERS, **{"X-Mist-Signature": _sign(_AUDIT_BODY, _SECRET)})
+        client = _build_test_app(_SECRET, recording_router).test_client()
+
+        response = client.post("/api/webhook", data=tampered, headers=headers)
+
+        assert response.status_code == 403
+        assert recording_router.audit_events == []
+
+    def test_the_route_compares_the_digest_in_constant_time(
+        self, recording_router: _RecordingRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The route must compare with hmac.compare_digest.
+
+        A comparison with ``==`` stops at the first wrong byte, so an
+        attacker can recover the digest one byte at a time.
+        """
+        calls: list[tuple[Any, Any]] = []
+        real_compare = hmac.compare_digest  # WHY: keep the real behavior, and only count the calls.
+
+        def _recording_compare(left: Any, right: Any) -> bool:
+            """Record one comparison and return the real result."""
+            calls.append((left, right))
+            return bool(real_compare(left, right))
+
+        monkeypatch.setattr(webhooks_module.hmac, "compare_digest", _recording_compare)
+        headers = dict(_JSON_HEADERS, **{"X-Mist-Signature": _sign(_AUDIT_BODY, _SECRET)})
+        client = _build_test_app(_SECRET, recording_router).test_client()
+
+        response = client.post("/api/webhook", data=_AUDIT_BODY, headers=headers)
+
+        assert response.status_code == 200
+        assert calls, "The route must call hmac.compare_digest to compare the signature"
+
+
+class TestMissingSecret:
+    """Verify the route fails closed when no secret is configured."""
+
+    @pytest.mark.parametrize(
+        "secret",
+        [None, "", "   "],
+        ids=["absent-key", "empty-string", "whitespace-only"],
+    )
+    def test_an_unconfigured_secret_returns_503(self, secret: Any, recording_router: _RecordingRouter) -> None:
+        """An unusable secret must produce code 503, not a success reply."""
+        headers = dict(_JSON_HEADERS, **{"X-Mist-Signature": _sign(_AUDIT_BODY, _SECRET)})
+        client = _build_test_app(secret, recording_router).test_client()
+
+        response = client.post("/api/webhook", data=_AUDIT_BODY, headers=headers)
+
+        assert response.status_code == 503, "An unconfigured receiver must refuse the request"
+        assert recording_router.audit_events == [], "An unverified payload must not reach the audit handler"
+
+    def test_an_unconfigured_secret_rejects_an_unsigned_post(self, recording_router: _RecordingRouter) -> None:
+        """The defect case must fail closed rather than accept the body."""
+        client = _build_test_app(None, recording_router).test_client()
+
+        response = client.post("/api/webhook", data=_AUDIT_BODY, headers=_JSON_HEADERS)
+
+        assert response.status_code != 200, "An unsigned post must never receive a success reply"
+        assert response.status_code == 503
+        assert recording_router.audit_events == []
+
+
+class TestVerifySignatureHelper:
+    """Verify the helper that computes and compares the digest."""
+
+    def test_an_empty_secret_never_verifies(self) -> None:
+        """An empty secret must fail, because it authenticates nobody."""
+        assert _verify(_AUDIT_BODY, _sign(_AUDIT_BODY, ""), "") is False
+
+    def test_an_empty_signature_never_verifies(self) -> None:
+        """An empty signature must fail, because it matches no digest."""
+        assert _verify(_AUDIT_BODY, "", _SECRET) is False
+
+    def test_a_correct_signature_verifies(self) -> None:
+        """A digest built from the same secret and body must pass."""
+        assert _verify(_AUDIT_BODY, _sign(_AUDIT_BODY, _SECRET), _SECRET) is True
+
+
+def _verify(body: bytes, signature: str, secret: str) -> bool:
+    """Call the module helper under test by its private name."""
+    return webhooks_module._verify_signature(body, signature, secret)
+
+
+class TestAppFactoryWebhookConfig:
+    """Verify the app factory loads the webhook settings from the environment."""
+
+    def test_the_factory_reads_the_secret_from_the_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The factory must copy WEBHOOK_SECRET into the app config."""
+        monkeypatch.setenv("WEBHOOK_SECRET", _SECRET)
+        app = Flask(__name__)
+
+        WebPortalApp._load_webhook_config(app)
+
+        assert app.config["WEBHOOK_SECRET"] == _SECRET
+
+    def test_the_factory_stores_an_empty_secret_when_the_variable_is_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An absent variable must leave an empty secret, not a missing key."""
+        monkeypatch.delenv("WEBHOOK_SECRET", raising=False)
+        app = Flask(__name__)
+
+        WebPortalApp._load_webhook_config(app)
+
+        assert app.config["WEBHOOK_SECRET"] == ""
+        assert app.config["WEBHOOK_ENABLED"] is True
+
+    def test_the_factory_disables_the_receiver_on_request(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """WEBHOOK_ENABLED=false must turn the receiver off."""
+        monkeypatch.setenv("WEBHOOK_ENABLED", "false")
+        app = Flask(__name__)
+
+        WebPortalApp._load_webhook_config(app)
+
+        assert app.config["WEBHOOK_ENABLED"] is False
+
+    def test_a_disabled_receiver_serves_no_webhook_route(self) -> None:
+        """A disabled receiver must not register the route at all."""
+        app = Flask(__name__)
+        app.config["WEBHOOK_ENABLED"] = False
+
+        WebPortalApp._register_webhook_blueprint(app)
+
+        assert "/api/webhook" not in {rule.rule for rule in app.url_map.iter_rules()}
+
+    def test_an_enabled_receiver_serves_the_webhook_route(self) -> None:
+        """An enabled receiver must register the route."""
+        app = Flask(__name__)
+        app.config["WEBHOOK_ENABLED"] = True
+
+        WebPortalApp._register_webhook_blueprint(app)
+
+        assert "/api/webhook" in {rule.rule for rule in app.url_map.iter_rules()}
+
+
+class TestCsrfExemption:
+    """Verify the webhook route stays reachable behind CSRF protection.
+
+    The portal protects every form post with flask-wtf. Mist Cloud holds
+    no CSRF token, so an unexempt route would answer 400 for every real
+    webhook and the HMAC check would never run.
+    """
+
+    @staticmethod
+    def _build_protected_app() -> Flask:
+        """Build an app that carries CSRF protection and the webhook route."""
+        from flask_wtf.csrf import CSRFProtect
+
+        app = Flask(__name__)
+        app.secret_key = "test-secret-key"  # WHY: flask-wtf signs the CSRF token with this key.
+        app.config["WEBHOOK_ENABLED"] = True
+        app.config["WEBHOOK_SECRET"] = _SECRET
+        csrf = CSRFProtect()
+        csrf.init_app(app)
+        app.config["csrf"] = csrf  # WHY: SecurityMiddleware stores the instance under this key.
+        WebPortalApp._register_webhook_blueprint(app)
+        return app
+
+    def test_a_signed_post_passes_the_csrf_guard(self) -> None:
+        """A signed webhook must reach the route, not a CSRF rejection."""
+        headers = dict(_JSON_HEADERS, **{"X-Mist-Signature": _sign(_AUDIT_BODY, _SECRET)})
+        client = self._build_protected_app().test_client()
+
+        response = client.post("/api/webhook", data=_AUDIT_BODY, headers=headers)
+
+        assert response.status_code == 200, "CSRF protection must not block a signed machine request"
+
+    def test_an_unsigned_post_still_receives_403(self) -> None:
+        """The CSRF exemption must not weaken the signature check."""
+        client = self._build_protected_app().test_client()
+
+        response = client.post("/api/webhook", data=_AUDIT_BODY, headers=_JSON_HEADERS)
+
+        assert response.status_code == 403

--- a/web_portal/app.py
+++ b/web_portal/app.py
@@ -36,6 +36,7 @@ class WebPortalApp:
             static_folder=WebPortalApp._get_static_dir(),
         )
         config = WebPortalApp._load_portal_config(app)
+        WebPortalApp._load_webhook_config(app)
         WebPortalApp._inject_dependencies(app, apisession, menu_actions, org_id)
         WebPortalApp._setup_theme_manager(app, config)
         WebPortalApp._apply_security(app, config)
@@ -64,6 +65,28 @@ class WebPortalApp:
         app.config["PORTAL"] = config
         app.secret_key = config["secret_key"]
         return config
+
+    @staticmethod
+    def _load_webhook_config(app: Flask) -> None:
+        """Load the webhook receiver settings from the environment.
+
+        Issue #1907: the route read WEBHOOK_SECRET, but no code wrote
+        the key. The secret was always empty, so the signature check
+        never ran. This method is the single writer of that key.
+        """
+        from web_portal.routes.webhooks import WEBHOOK_ENABLED_CONFIG_KEY, WEBHOOK_SECRET_CONFIG_KEY
+
+        raw_enabled = os.environ.get(WEBHOOK_ENABLED_CONFIG_KEY, "true")  # WHY: match the src/db default.
+        enabled = raw_enabled.strip().lower() == "true"  # WHY: only the exact word "true" turns the route on.
+        app.config[WEBHOOK_ENABLED_CONFIG_KEY] = enabled
+        secret = os.environ.get(WEBHOOK_SECRET_CONFIG_KEY, "").strip()  # WHY: whitespace is not a secret.
+        app.config[WEBHOOK_SECRET_CONFIG_KEY] = secret
+        if enabled and not secret:
+            logging.error(
+                "Webhook receiver is enabled, but WEBHOOK_SECRET is empty. "
+                "The portal rejects every webhook with code 503 until you set the secret."
+            )  # WHY: an operator must see the cause before the first 503 reply arrives.
+        logging.debug("Webhook receiver enabled=%s, secret configured=%s", enabled, bool(secret))
 
     @staticmethod
     def _inject_dependencies(
@@ -115,6 +138,26 @@ class WebPortalApp:
         app.register_blueprint(operations_bp)
         app.register_blueprint(maps_bp)
         app.register_blueprint(settings_bp)
+        WebPortalApp._register_webhook_blueprint(app)
+
+    @staticmethod
+    def _register_webhook_blueprint(app: Flask) -> None:
+        """Register the Mist webhook receiver when the operator enables it.
+
+        A disabled receiver serves no route, so an unwanted endpoint
+        never reaches the dispatch path.
+        """
+        from web_portal.routes.webhooks import WEBHOOK_ENABLED_CONFIG_KEY, webhook_bp
+
+        if not app.config.get(WEBHOOK_ENABLED_CONFIG_KEY, False):
+            logging.info("Webhook receiver is disabled, so the portal does not serve /api/webhook")
+            return
+
+        app.register_blueprint(webhook_bp)
+        csrf = app.config.get("csrf")  # WHY: SecurityMiddleware stores the CSRFProtect instance here.
+        if csrf is not None:
+            csrf.exempt(webhook_bp)  # WHY: an HMAC signature authenticates Mist Cloud, not a browser session.
+        logging.debug("Webhook receiver registered at POST /api/webhook")
 
     @staticmethod
     def _register_context_processor(app: Flask) -> None:

--- a/web_portal/app.py
+++ b/web_portal/app.py
@@ -81,12 +81,13 @@ class WebPortalApp:
         app.config[WEBHOOK_ENABLED_CONFIG_KEY] = enabled
         secret = os.environ.get(WEBHOOK_SECRET_CONFIG_KEY, "").strip()  # WHY: whitespace is not a secret.
         app.config[WEBHOOK_SECRET_CONFIG_KEY] = secret
-        if enabled and not secret:
+        has_secret = bool(secret)  # WHY: log only whether a secret exists, never the value itself.
+        if enabled and not has_secret:
             logging.error(
                 "Webhook receiver is enabled, but WEBHOOK_SECRET is empty. "
                 "The portal rejects every webhook with code 503 until you set the secret."
             )  # WHY: an operator must see the cause before the first 503 reply arrives.
-        logging.debug("Webhook receiver enabled=%s, secret configured=%s", enabled, bool(secret))
+        logging.debug("Webhook receiver enabled=%s, secret configured=%s", enabled, has_secret)
 
     @staticmethod
     def _inject_dependencies(

--- a/web_portal/app.py
+++ b/web_portal/app.py
@@ -147,6 +147,11 @@ class WebPortalApp:
     def _register_webhook_blueprint(app: Flask) -> None:
         """Register the Mist webhook receiver when the operator enables it.
 
+        Issue #1907: no code registered this blueprint, so POST
+        /api/webhook returned 404 and the receiver never worked. That
+        broken state hid a latent hole, because the signature check
+        behind the route also never ran.
+
         A disabled receiver serves no route, so an unwanted endpoint
         never reaches the dispatch path.
         """
@@ -159,7 +164,14 @@ class WebPortalApp:
         app.register_blueprint(webhook_bp)
         csrf = app.config.get("csrf")  # WHY: SecurityMiddleware stores the CSRFProtect instance here.
         if csrf is not None:
-            csrf.exempt(webhook_bp)  # WHY: an HMAC signature authenticates Mist Cloud, not a browser session.
+            # Warning: Do not remove this exemption. It is not a weakness.
+            # SecurityMiddleware protects every browser form with a CSRF
+            # token. Mist Cloud is a machine caller and holds no token, so
+            # an unexempt route answers 400 for every real webhook and the
+            # signature check never runs. The HMAC signature authenticates
+            # the sender here, and it is the stronger control, because it
+            # covers the raw body as well as the sender.
+            csrf.exempt(webhook_bp)
         logging.debug("Webhook receiver registered at POST /api/webhook")
 
     @staticmethod

--- a/web_portal/app.py
+++ b/web_portal/app.py
@@ -79,15 +79,17 @@ class WebPortalApp:
         raw_enabled = os.environ.get(WEBHOOK_ENABLED_CONFIG_KEY, "true")  # WHY: match the src/db default.
         enabled = raw_enabled.strip().lower() == "true"  # WHY: only the exact word "true" turns the route on.
         app.config[WEBHOOK_ENABLED_CONFIG_KEY] = enabled
-        secret = os.environ.get(WEBHOOK_SECRET_CONFIG_KEY, "").strip()  # WHY: whitespace is not a secret.
-        app.config[WEBHOOK_SECRET_CONFIG_KEY] = secret
-        has_secret = bool(secret)  # WHY: log only whether a secret exists, never the value itself.
-        if enabled and not has_secret:
+        app.config[WEBHOOK_SECRET_CONFIG_KEY] = os.environ.get(WEBHOOK_SECRET_CONFIG_KEY, "").strip()
+        logging.info("Webhook receiver enabled=%s", enabled)  # WHY: log the setting, never the secret.
+        if app.config[WEBHOOK_SECRET_CONFIG_KEY]:  # WHY: a branch reports the state without logging the value.
+            logging.debug("Webhook receiver found a configured secret")
+        elif enabled:
             logging.error(
                 "Webhook receiver is enabled, but WEBHOOK_SECRET is empty. "
                 "The portal rejects every webhook with code 503 until you set the secret."
             )  # WHY: an operator must see the cause before the first 503 reply arrives.
-        logging.debug("Webhook receiver enabled=%s, secret configured=%s", enabled, has_secret)
+        else:
+            logging.debug("Webhook receiver is off and holds no secret")
 
     @staticmethod
     def _inject_dependencies(

--- a/web_portal/routes/webhooks.py
+++ b/web_portal/routes/webhooks.py
@@ -71,9 +71,8 @@ def _reject_unverified_request() -> tuple | None:
     secret = _get_configured_secret()
     if not secret:
         logging.error(
-            "Webhook rejected: %s is not configured, so the portal cannot identify the sender",
-            WEBHOOK_SECRET_CONFIG_KEY,
-        )  # WHY: an operator needs a clear cause for every 503 reply.
+            "Webhook rejected: WEBHOOK_SECRET is not configured, so the portal cannot identify the sender"
+        )  # WHY: a static message names the cause without passing a secret-named value into the log.
         return jsonify({"error": "webhook receiver is not configured"}), 503
     body = request.get_data()  # WHY: the digest covers the raw bytes, not the parsed JSON.
     logging.info("Verifying the webhook signature for a body of %d bytes", len(body))

--- a/web_portal/routes/webhooks.py
+++ b/web_portal/routes/webhooks.py
@@ -1,7 +1,13 @@
 """Webhook receiver endpoint for Mist Cloud audit and stats events.
 
-Verifies HMAC-SHA256 signatures, dispatches audit payloads to ArangoDB
-config snapshots, and stats payloads to Redis TimeSeries ingestion.
+The route verifies an HMAC-SHA256 signature on every request before it
+dispatches a payload. Audit payloads reach the ArangoDB config snapshot
+handler. Stats payloads reach the Redis TimeSeries ingestion handler.
+
+The route fails closed. If the shared secret is absent, the route
+rejects every request with code 503, and no payload reaches the
+dispatch path. An unset secret never means "accept every caller".
+See issue #1907.
 """
 
 from __future__ import annotations
@@ -15,13 +21,34 @@ from flask import Blueprint, current_app, jsonify, request
 
 webhook_bp = Blueprint("webhooks", __name__)
 
+# WHY: one name for the config key stops a typo from disabling the check.
+# The nosec below marks a bandit false positive. The string is a Flask
+# config key name, not a credential. See B105.
+WEBHOOK_SECRET_CONFIG_KEY = "WEBHOOK_SECRET"  # nosec B105
+
+# WHY: one name for the on/off key keeps the factory and the tests in step.
+WEBHOOK_ENABLED_CONFIG_KEY = "WEBHOOK_ENABLED"
+
+# WHY: Mist Cloud sends the HMAC-SHA256 hex digest in this header.
+SIGNATURE_HEADER = "X-Mist-Signature"
+
+# WHY: these topics carry metrics, so they reach the time-series handler.
+_STATS_TOPICS = {
+    "client-sessions",
+    "device-updowns",
+    "device-events",
+    "client-latency",
+}
+
 
 def _verify_signature(body: bytes, signature: str, secret: str) -> bool:
-    """Verify HMAC-SHA256 signature from X-Mist-Signature header."""
+    """Verify the HMAC-SHA256 signature from the X-Mist-Signature header."""
     if not secret:
-        return False
-    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(expected, signature)
+        return False  # WHY: an empty secret authenticates nobody, so refuse it.
+    if not signature:
+        return False  # WHY: an absent header can never match a computed digest.
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()  # WHY: recompute from the raw body.
+    return hmac.compare_digest(expected, signature)  # WHY: constant time stops a byte-by-byte digest leak.
 
 
 def _get_router() -> Any | None:
@@ -29,40 +56,60 @@ def _get_router() -> Any | None:
     return current_app.config.get("DB_ROUTER")
 
 
+def _get_configured_secret() -> str:
+    """Return the configured shared secret, or an empty string."""
+    raw = current_app.config.get(WEBHOOK_SECRET_CONFIG_KEY, "")  # WHY: an absent key must read as unconfigured.
+    return str(raw or "").strip()  # WHY: a whitespace-only value is not a usable secret.
+
+
+def _reject_unverified_request() -> tuple | None:
+    """Return a rejection response when the request is not authentic.
+
+    The function returns None only when the signature matches the raw
+    request body. Every other outcome is a rejection.
+    """
+    secret = _get_configured_secret()
+    if not secret:
+        logging.error(
+            "Webhook rejected: %s is not configured, so the portal cannot identify the sender",
+            WEBHOOK_SECRET_CONFIG_KEY,
+        )  # WHY: an operator needs a clear cause for every 503 reply.
+        return jsonify({"error": "webhook receiver is not configured"}), 503
+    body = request.get_data()  # WHY: the digest covers the raw bytes, not the parsed JSON.
+    logging.info("Verifying the webhook signature for a body of %d bytes", len(body))
+    if not _verify_signature(body, request.headers.get(SIGNATURE_HEADER, ""), secret):
+        logging.warning("Webhook rejected: the signature does not match the body")
+        return jsonify({"error": "invalid signature"}), 403
+    logging.debug("Webhook signature verified for a body of %d bytes", len(body))
+    return None
+
+
 @webhook_bp.route("/api/webhook", methods=["POST"])
 def receive_webhook() -> tuple:
     """Receive and dispatch Mist webhook payloads."""
-    secret = current_app.config.get("WEBHOOK_SECRET", "")
-    signature = request.headers.get("X-Mist-Signature", "")
-    body = request.get_data()
-
-    if secret and not _verify_signature(body, signature, secret):
-        logging.warning("Webhook signature verification failed")
-        return jsonify({"error": "invalid signature"}), 403
-
-    payload = request.get_json(silent=True)
+    rejection = _reject_unverified_request()  # WHY: verify first, so no forged body reaches a handler.
+    if rejection is not None:
+        return rejection
+    payload = request.get_json(silent=True)  # WHY: parse only after the body proves authentic.
     if not payload:
+        logging.warning("Webhook rejected: the signed body is not valid JSON")
         return jsonify({"error": "invalid JSON"}), 400
+    _dispatch_payload(payload)
+    return jsonify({"status": "ok"}), 200
 
+
+def _dispatch_payload(payload: dict) -> None:
+    """Send one verified payload to the handler that matches its topic."""
     topic = payload.get("topic", "")
     router = _get_router()
-
+    logging.info("Dispatching a verified webhook payload for topic '%s'", topic)
     if topic == "audits":
         _handle_audit(router, payload)
     elif topic in _STATS_TOPICS:
         _handle_stats(router, payload)
     else:
         logging.debug("Unhandled webhook topic: %s", topic)
-
-    return jsonify({"status": "ok"}), 200
-
-
-_STATS_TOPICS = {
-    "client-sessions",
-    "device-updowns",
-    "device-events",
-    "client-latency",
-}
+    logging.debug("Dispatch complete for topic '%s'", topic)
 
 
 def _handle_audit(router: Any | None, payload: dict) -> None:

--- a/web_portal/routes/webhooks.py
+++ b/web_portal/routes/webhooks.py
@@ -7,7 +7,13 @@ handler. Stats payloads reach the Redis TimeSeries ingestion handler.
 The route fails closed. If the shared secret is absent, the route
 rejects every request with code 503, and no payload reaches the
 dispatch path. An unset secret never means "accept every caller".
-See issue #1907.
+
+Issue #1907 records the defect. Two faults sat on top of each other.
+No code wrote the WEBHOOK_SECRET config key, so the secret was always
+empty and the signature check never ran. No code registered this
+blueprint either, so POST /api/webhook returned 404. The 404 held the
+hole shut, so the vulnerability was latent rather than reachable. A
+later commit that only registered the blueprint would have opened it.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Fixes #1907

## Severity: latent, not reachable. Read this first.

The issue text said any client could POST an unsigned body to `/api/webhook` and receive a success reply. **That was not true, and the record has been corrected.**

`webhook_bp` was never registered with the Flask app. On the base revision, `web_portal/app.py` lines 113 to 117 register `dashboard_bp`, `data_bp`, `operations_bp`, `maps_bp`, and `settings_bp`. Nothing registers `webhook_bp`. `POST /api/webhook` therefore returned **404**, and the described exploit path could not be walked.

The accurate description is a **latent vulnerability sitting behind a silently broken feature**. The webhook receiver did not work at all. The dead signature check was hidden behind a dead route.

**No incident response is warranted.** A reviewer is getting a repaired feature plus a closed latent hole, not an emergency patch.

The latent hole was still worth closing, and closing it first was the right order. A later commit that only registered the blueprint, with no other change, would have exposed the unverified route exactly as the issue described.

## The two faults

**Fault 1. The secret was never loaded, so the check never ran.**

```python
secret = current_app.config.get("WEBHOOK_SECRET", "")
if secret and not _verify_signature(body, signature, secret):
    return jsonify({"error": "invalid signature"}), 403
```

No code ever wrote `app.config["WEBHOOK_SECRET"]`. A search across `web_portal/`, `container/`, `deploy/`, and `wsgi.py` returned only the `.get()` read above. So `secret` was always the empty string, the `if secret and ...` guard short circuited, and `_verify_signature` never ran.

This fault also hid itself. A reviewer saw an HMAC comparison and concluded the route was protected.

**Fault 2. The blueprint was never registered, so the route returned 404.**

This is what made the exposure latent rather than reachable. It is described in the section above.

## Fix

1. **Load the secret.** `WebPortalApp._load_webhook_config()` reads `WEBHOOK_SECRET` and `WEBHOOK_ENABLED` from the environment and writes both into `app.config`. This method is the single writer of those keys. It follows the existing `os.environ.get` pattern in the factory and the same variable names that `src/db/__init__.py` already uses.
2. **Fail closed.** The receiver no longer has a silent accept path. See the policy table below.
3. **Constant-time compare.** `_verify_signature` already used `hmac.compare_digest`, so no change was needed there. A test now locks that behavior, because a `==` compare would leak the digest byte by byte. The helper also rejects an empty signature early.
4. **Register the route.** The factory registers `webhook_bp` and exempts it from CSRF. This repairs the broken feature, and the fail-closed policy lands in the same change, so the route is never registered in an unverified state.
5. **Document the variable.** `deploy/.env.example` now describes `WEBHOOK_SECRET` and `WEBHOOK_ENABLED`, and states the 503 consequence of an empty secret.

## Fail-closed policy

| Condition | Result |
| - | - |
| `WEBHOOK_ENABLED=false` | The route is not registered. The path returns 404. |
| Secret absent, empty, or whitespace only | Code 503, and an error in the log. No payload reaches the dispatch path. |
| Signature header absent or empty | Code 403. |
| Signature does not match the raw body | Code 403. |
| Signature matches the raw body | Code 200, and the payload reaches the dispatch path. |

The route verifies the signature before it parses the JSON, so a forged body never reaches `_handle_audit` or `_handle_stats`.

`WEBHOOK_ENABLED` defaults to `true` to match `src/db/__init__.py`. An operator who sets no secret therefore gets a loud startup error and a 503 on every request, not a silent accept.

## The CSRF exemption is deliberate. Please do not remove it.

`_register_webhook_blueprint` calls `csrf.exempt(webhook_bp)`. This reads as a weakness at a glance, and it is not one.

`SecurityMiddleware` protects every browser form with a CSRF token. Mist Cloud is a machine caller and holds no token. An unexempt route would answer 400 for every real webhook, so the signature check would never run and the receiver would stay broken. The HMAC signature authenticates the sender here, and it is the stronger control, because it covers the raw request body as well as the sender identity.

The code carries that reasoning in a block comment with a `Warning:` signal word, so the next reader does not delete the line. Two tests lock the behavior: a signed POST passes the CSRF guard, and an unsigned POST still receives 403 with the guard active.

## Verification

**The defect was proved first.** The new tests were written and run before the fix. The run produced 9 failures, including this one, which is the fail-open behavior itself:

```
FAILED tests/unit/web_portal/test_webhook_signature.py::TestMissingSecret::test_an_unconfigured_secret_rejects_an_unsigned_post
E   AssertionError: An unsigned post must never receive a success reply
E   assert 200 != 200
```

After the fix:

```
$ python -m pytest tests/unit/test_webhook_ingestion.py tests/unit/web_portal -q
64 passed in 30.02s
```

That total covers the 21 new tests, the 3 pre-existing `_verify_signature` tests, the pre-existing `TestWebhookAuditDispatch` dispatch test, and the other 39 web portal tests.

### Quality gates

| Gate | Command | Result |
| - | - | - |
| Ruff | `python -m ruff check .` | `All checks passed!` |
| Black | `python -m black --check .` | 1011 files unchanged |
| Bandit | `python -m bandit -c pyproject.toml -r web_portal` | 0 findings at every severity |
| pydocstyle | `python -m pydocstyle src/ wsgi.py web_portal` | exit 0 |
| Vulture | `python -m vulture ... web_portal --min-confidence 70` | exit 0 |
| Interrogate | `python -m interrogate ... --fail-under 90` | PASSED, 99.6% |
| pytest | `python -m pytest tests/unit/test_webhook_ingestion.py tests/unit/web_portal -q` | 64 passed |

Notes on two gates, stated rather than skipped:

* **Ruff.** `python -m ruff check web_portal tests` reports 26 findings, but every one is pre-existing and none come from this change. I measured the baseline by stashing the change, and the count was the same 26. `web_portal` sits in `extend-exclude` in `pyproject.toml`, so the CI command `ruff check .` does not scan it. The CI command passes.
* **Bandit.** A repo-wide `bandit -r .` reports 42 low findings on a Windows worktree. All 42 sit in `tools/test_quality_analyzer/fixtures/`, which `exclude_dirs` excludes with a forward-slash path that does not match on Windows. None come from this change. A first run flagged the new `WEBHOOK_SECRET_CONFIG_KEY` constant as B105. That string is a Flask config key name, not a credential, so it carries a `# nosec B105` marker with a written reason, in the same style as the existing `# nosec B104` in `web_portal/services/config.py`.
* **mypy and Pylint** do not scan `web_portal`, so this change cannot affect them.
* **Full unit suite.** A full `pytest tests/unit` run on a fresh worktree fails to collect several modules with `ModuleNotFoundError` for `paramiko` and `arango`. That is the known fresh-worktree dependency gap in #1866 and is unrelated to this change. I installed `python-arango` and confirmed the one affected webhook test passes, rather than asserting the failures were unrelated.

## CodeQL follow-up

The first push raised one high severity CodeQL alert, `Clear-text logging of sensitive information`. Two commits fixed it, and CodeQL now passes.

1. `web_portal/routes/webhooks.py` passed the constant `WEBHOOK_SECRET_CONFIG_KEY` into `logging.error` as a format argument. The value is a Flask config key name and not a credential, but the data flow still reached a log call. The message is now static and names the variable in its text.
2. `web_portal/app.py` passed `bool(secret)` into a debug log. CodeQL does not treat `bool()` as a sanitizer, so the flow survived. The factory now reports the secret state with a branch over three static messages, and it writes the stripped value straight into `app.config`, so no local variable carries the flow into a log argument.

Both alerts were fixed rather than suppressed, per the project rule of fix over suppress. No CodeQL suppression comment was added.

## Merge order

This branch touches `web_portal/app.py`, so it may conflict with #1912, which also modifies that file. Please merge in an order that accounts for that. The change to `app.py` is deliberately small: one call in `create_app`, one new `_load_webhook_config` method, and one new `_register_webhook_blueprint` method.

`CHANGELOG.md` is untouched on purpose, per #1899.

## Files changed

| File | Change |
| - | - |
| `web_portal/routes/webhooks.py` | Fail closed, verify before parse, reject an empty signature, name the config keys, record the true severity |
| `web_portal/app.py` | Load the webhook config, register the blueprint, exempt it from CSRF with the full reason |
| `deploy/.env.example` | Document `WEBHOOK_SECRET` and `WEBHOOK_ENABLED` |
| `tests/unit/web_portal/test_webhook_signature.py` | 21 new regression tests |

## Acceptance criteria

- [x] A request with no signature receives a rejection when the secret is set.
- [x] A request receives a rejection when the secret is absent, rather than a success reply.
- [x] A test proves that an unsigned POST cannot reach the dispatch path.
- [x] `deploy/.env.example` documents the new variable.
