### PR TITLE
security(container): report a certificate install failure instead of claiming success

### DIFF
--- a/container/scripts/start.sh
+++ b/container/scripts/start.sh
@@ -25,8 +25,39 @@ chmod 664 /app/data/ssh.log
 CUSTOM_CA_DIR="/usr/local/share/ca-certificates"
 if ls -A "$CUSTOM_CA_DIR"/*.crt >/dev/null 2>&1; then
     echo "[TLS] Installing operator-supplied root certificates from $CUSTOM_CA_DIR" >> /app/data/ssh.log
+    # Check each file before the install.
+    # Warning: update-ca-certificates exits 0 and appends the raw bytes even when
+    # the file is not a certificate, so neither the exit status nor the bundle
+    # content can report a bad file. Parse each file instead.
+    CA_INSTALL_FAILURES=0
+    for CA_FILE in "$CUSTOM_CA_DIR"/*.crt; do
+        CA_NAME=$(basename "$CA_FILE")  # Name the file in every message, so the operator knows which one failed.
+        # Test for the PEM header first. update-ca-certificates reads PEM only,
+        # and it reports "1 added" for a DER file that it cannot use. OpenSSL 3
+        # auto-detects the encoding, so a parse test alone accepts a DER file.
+        if grep -q -- "-----BEGIN CERTIFICATE-----" "$CA_FILE" && openssl x509 -in "$CA_FILE" -noout >/dev/null 2>&1; then
+            echo "[TLS] Read $CA_NAME as a PEM certificate." >> /app/data/ssh.log
+        elif openssl x509 -in "$CA_FILE" -noout >/dev/null 2>&1; then
+            # The file holds a real certificate in an encoding the trust store cannot read.
+            CA_INSTALL_FAILURES=$((CA_INSTALL_FAILURES + 1))
+            echo "[TLS] WARNING: $CA_NAME is not PEM. The trust store cannot use it." >> /app/data/ssh.log
+            echo "[TLS] WARNING: Convert it with: openssl x509 -inform DER -in $CA_NAME -out $CA_NAME.pem" >> /app/data/ssh.log
+        else
+            # Count the failure, because the summary line below must not claim success.
+            CA_INSTALL_FAILURES=$((CA_INSTALL_FAILURES + 1))
+            echo "[TLS] WARNING: $CA_NAME is not a certificate that the trust store can read." >> /app/data/ssh.log
+            echo "[TLS] WARNING: Check that $CA_NAME holds one PEM certificate." >> /app/data/ssh.log
+        fi
+    done
+    # Keep the container alive if the command fails. The count above decides the result.
     update-ca-certificates >> /app/data/ssh.log 2>&1 || true
-    echo "[TLS] Trust store updated. Certificate verification stays on." >> /app/data/ssh.log
+    if [ "$CA_INSTALL_FAILURES" -eq 0 ]; then
+        # Print the success line only when every file parsed as a certificate.
+        echo "[TLS] Trust store updated. Certificate verification stays on." >> /app/data/ssh.log
+    else
+        echo "[TLS] WARNING: $CA_INSTALL_FAILURES certificate file(s) failed to install." >> /app/data/ssh.log
+        echo "[TLS] WARNING: A connection through the proxy will fail until you repair them." >> /app/data/ssh.log
+    fi
 else
     echo "[TLS] No operator-supplied root certificate found. The default trust store applies." >> /app/data/ssh.log
 fi


### PR DESCRIPTION
Refs #1906. Follow-up to #1919, which merged before this fix landed.

## Problem

Pull request #1919 added a `[TLS]` block to `container/scripts/start.sh`. That
block printed the success line after every install attempt:

```bash
update-ca-certificates >> /app/data/ssh.log 2>&1 || true
echo "[TLS] Trust store updated. Certificate verification stays on." >> /app/data/ssh.log
```

The merge plan on #1914 tells an operator to mount the corporate root
certificate, start the container, and read that line as proof that the trust
store is correct. The line printed even when the certificate never installed.

A verification step that passes on a broken setup is worse than no verification.
The operator reads the success line, merges the change that depends on it, and
learns about the fault on the first real run against the Mist API.

The commit that fixed this reached the #1919 branch after the squash merge, so
it never reached `main`. This pull request carries it.

## Proof of the defect

Mount a file that holds the text `this is not a certificate`:

```text
[TLS] Installing operator-supplied root certificates from /usr/local/share/ca-certificates
rehash: warning: skipping corp-root-ca.pem, it does not contain exactly one certificate or CRL
[TLS] Trust store updated. Certificate verification stays on.
```

The trust store rejected the file, and the log reported success.

## Why the two obvious checks do not work

**The exit status cannot report the failure.** `update-ca-certificates` exits 0
and appends the raw bytes to `ca-certificates.crt` even when the file is not a
certificate. The `|| true` guard is therefore not the cause, and removing it does
not fix the defect.

**A search of the bundle cannot report the failure either.** My first attempt
tested whether the file body reached `ca-certificates.crt`. That test passed the
malformed file, because `update-ca-certificates` appended the text verbatim.
OpenSSL skips the junk between certificates, so TLS still worked and nothing
looked wrong.

**A DER file is the dangerous case.** `update-ca-certificates` reports `1 added`,
and the certificate never becomes a usable trust anchor:

```text
openssl crl2pkcs7 -nocrl -certfile /etc/ssl/certs/ca-certificates.crt \
  | openssl pkcs7 -print_certs -noout | grep -c Zscaler
0
```

OpenSSL 3 auto-detects the encoding, so `openssl x509 -noout` accepts a DER file
as well. The check has to test for the PEM header, because PEM is the encoding
that `update-ca-certificates` requires.

## Fix

The script parses each mounted file before it reports a result. It prints the
success line only when every file is a PEM certificate. A DER file gets the exact
conversion command. An unreadable file gets a repair instruction.

## Verification

Built the image and ran four cases against it.

| Case | Log result |
| - | - |
| Valid PEM certificate | `Read corp-root-ca.crt as a PEM certificate`, then the success line. A live call to `https://api.mist.com` returned 200. |
| DER certificate | Warns the file is not PEM, prints the conversion command, and prints no success line. |
| Malformed file | Warns the file is not readable, prints the repair instruction, and prints no success line. |
| No certificate mounted | Reports that the default trust store applies. |

Gates on this branch:

| Gate | Command | Result |
| - | - | - |
| Lint | `python -m ruff check .` | `All checks passed!` |
| Tests | `python -m pytest tests/guardrails -q` | `61 passed` |
| Shell syntax | `bash -n container/scripts/start.sh` | exit code 0 |

## Operator impact

The mount and the log line stay the correct verification. The line now means what
it says, so the pre-merge check in the #1914 plan gives a true answer.
