### PR TITLE
security(web-portal): close five fail-open defects in the data browser, the operation gate, and the map viewer

### DIFF
--- a/tests/unit/test_data_browser_path_guard.py
+++ b/tests/unit/test_data_browser_path_guard.py
@@ -1,0 +1,148 @@
+"""Security tests for the web portal data browser path guard.
+
+The tests prove two defects in `DataBrowserService.resolve_safe_path`.
+
+1. The guard did not resolve a symbolic link, so a link inside the data
+   directory reached a file outside the data directory.
+2. The guard did not apply the `ALLOWED_EXTENSIONS` allowlist, so the download
+   route served a file that the listing route hides.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from web_portal.services.data_browser import DataBrowserService
+
+
+def _symlink_supported(tmp_path) -> bool:
+    """Report whether this account may create a symbolic link."""
+    probe_target = tmp_path / "probe_target.txt"  # Real file that the probe link points at.
+    probe_target.write_text("probe")  # A link needs an existing target on Windows.
+    probe_link = tmp_path / "probe_link.txt"  # Link path that the probe tries to create.
+    try:
+        os.symlink(probe_target, probe_link)  # Windows refuses this without the symlink privilege.
+    except (OSError, NotImplementedError):
+        return False  # The account lacks the privilege, so the caller must skip the test.
+    os.unlink(probe_link)  # Remove the probe link so the temporary tree stays clean.
+    return True  # The account may create a symbolic link.
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    """Build an empty data directory and return its path."""
+    target = tmp_path / "data"  # Mirror the runtime layout, where exports live under `data/`.
+    target.mkdir()  # The service returns an empty listing when the directory is absent.
+    return target
+
+
+class TestSymlinkEscape:
+    """Prove that a symbolic link cannot leave the data directory."""
+
+    def test_symlink_to_outside_file_is_rejected(self, tmp_path, data_dir):
+        """A link that points outside the data directory must not resolve."""
+        if not _symlink_supported(tmp_path):
+            pytest.skip("This account may not create a symbolic link.")
+        secret = tmp_path / "dotenv_secret"  # Stand in for `/app/.env`, which holds the API token.
+        secret.write_text("MIST_APITOKEN=abcd1234")  # Content that the attacker wants to read.
+        link = data_dir / "notes.csv"  # Allowed extension, so only the link check can stop it.
+        os.symlink(secret, link)  # The attacker creates the link in the world-writable data mount.
+
+        service = DataBrowserService(str(data_dir))  # Service under test, scoped to the data mount.
+
+        assert service.resolve_safe_path("notes.csv") is None  # The guard must refuse the escape.
+
+    def test_symlinked_sibling_directory_is_rejected(self, tmp_path, data_dir):
+        """A link into a sibling with a shared name prefix must not resolve."""
+        if not _symlink_supported(tmp_path):
+            pytest.skip("This account may not create a symbolic link.")
+        sibling = tmp_path / "data_backup"  # Name shares the `data` prefix, so `startswith` passed.
+        sibling.mkdir()  # The sibling must exist before the link can point at it.
+        (sibling / "dump.csv").write_text("secret\n")  # File that the guard must keep out of reach.
+        os.symlink(sibling, data_dir / "backup", target_is_directory=True)  # The escape hatch.
+
+        service = DataBrowserService(str(data_dir))  # Service under test, scoped to the data mount.
+
+        assert service.resolve_safe_path("backup/dump.csv") is None  # The guard must refuse it.
+
+
+class TestExtensionAllowlist:
+    """Prove that the download guard applies the listing allowlist."""
+
+    def test_disallowed_extension_is_rejected(self, data_dir):
+        """A private key file must not resolve, because the listing hides it."""
+        (data_dir / "id_rsa").write_text("PRIVATE KEY")  # No extension, so the listing hides it.
+
+        service = DataBrowserService(str(data_dir))  # Service under test, scoped to the data mount.
+
+        assert service.resolve_safe_path("id_rsa") is None  # The guard must apply the allowlist.
+
+    def test_nested_disallowed_extension_is_rejected(self, data_dir):
+        """A nested file with a disallowed extension must not resolve."""
+        nested = data_dir / "per-host-logs"  # The SSH runner writes a session record per device.
+        nested.mkdir()  # The listing reads only the top level, so it never shows this tree.
+        (nested / "sw1.pem").write_text("PRIVATE KEY")  # Disallowed extension in a nested folder.
+
+        service = DataBrowserService(str(data_dir))  # Service under test, scoped to the data mount.
+
+        assert service.resolve_safe_path("per-host-logs/sw1.pem") is None  # Allowlist must apply.
+
+    def test_directory_is_rejected(self, data_dir):
+        """A directory must not resolve, because `send_file` cannot serve it."""
+        (data_dir / "per-host-logs").mkdir()  # A directory used to pass the old existence check.
+
+        service = DataBrowserService(str(data_dir))  # Service under test, scoped to the data mount.
+
+        assert service.resolve_safe_path("per-host-logs") is None  # A directory must be refused.
+
+
+class TestAllowedPathsStillWork:
+    """Prove that the stricter guard keeps the supported files reachable."""
+
+    def test_allowed_csv_resolves(self, data_dir):
+        """A CSV file in the data directory must still resolve."""
+        target = data_dir / "sites.csv"  # A normal export that an operator downloads every day.
+        target.write_text("name\nsite-a\n")  # Content is irrelevant, only the path check matters.
+
+        service = DataBrowserService(str(data_dir))  # Service under test, scoped to the data mount.
+
+        resolved = service.resolve_safe_path("sites.csv")  # The guard must accept this file.
+
+        assert resolved is not None  # A refusal here would break the download route.
+        assert os.path.realpath(resolved) == os.path.realpath(str(target))  # Same real file.
+
+    def test_allowed_nested_log_resolves(self, data_dir):
+        """A nested log file with an allowed extension must still resolve."""
+        nested = data_dir / "per-host-logs"  # The runtime writes each device log into this folder.
+        nested.mkdir()  # Create the folder before the file, because `write_text` needs a parent.
+        target = nested / "sw1.log"  # Allowed extension, so the guard must accept the file.
+        target.write_text("show version\n")  # Content is irrelevant, only the path check matters.
+
+        service = DataBrowserService(str(data_dir))  # Service under test, scoped to the data mount.
+
+        assert service.resolve_safe_path("per-host-logs/sw1.log") is not None  # Must stay reachable.
+
+    def test_parent_traversal_is_rejected(self, tmp_path, data_dir):
+        """A path with a parent segment must not resolve."""
+        (tmp_path / "outside.csv").write_text("secret\n")  # File one level above the data mount.
+
+        service = DataBrowserService(str(data_dir))  # Service under test, scoped to the data mount.
+
+        assert service.resolve_safe_path("../outside.csv") is None  # The classic escape must fail.
+
+    def test_absolute_path_is_rejected(self, tmp_path, data_dir):
+        """An absolute path must not resolve, because `os.path.join` drops the base."""
+        outside = tmp_path / "outside.csv"  # Target that sits outside the data mount.
+        outside.write_text("secret\n")  # Content is irrelevant, only the path check matters.
+
+        service = DataBrowserService(str(data_dir))  # Service under test, scoped to the data mount.
+
+        assert service.resolve_safe_path(str(outside)) is None  # An absolute path must be refused.
+
+    def test_missing_file_is_rejected(self, data_dir):
+        """A file that does not exist must not resolve."""
+        service = DataBrowserService(str(data_dir))  # Service under test, scoped to the data mount.
+
+        assert service.resolve_safe_path("absent.csv") is None  # A missing file must return None.

--- a/tests/unit/web_portal/test_data_browser_pagination_bounds.py
+++ b/tests/unit/web_portal/test_data_browser_pagination_bounds.py
@@ -1,0 +1,170 @@
+"""Bound the page size of the data browser preview on both ends.
+
+The routes clamped the page size at the top only. A negative value therefore
+reached SQLite, which reads a negative `LIMIT` as no limit at all. One request
+then returned every row of the table. A zero value divided by zero.
+
+These tests prove that the service clamps the page size and the page number.
+See issue #1946.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+import pytest
+
+from web_portal.services.data_browser import (
+    MAX_PAGE_SIZE,
+    MIN_PAGE_SIZE,
+    DataBrowserService,
+)
+
+# The row count of each fixture. The count sits above MAX_PAGE_SIZE so that a
+# bypass returns visibly more rows than the cap allows.
+TOTAL_ROWS = 1000
+
+# The page size values that a caller can send to defeat a one sided clamp.
+OUT_OF_RANGE_SIZES = (-1, 0, -1000, MAX_PAGE_SIZE + 1, 10**9)
+
+
+@pytest.fixture
+def browser(tmp_path):
+    """Build a data directory that holds a large CSV, JSON, log, and database."""
+    logging.info("Building the data browser fixtures in %s", tmp_path)
+    # Write a CSV that holds more rows than the cap allows.
+    csv_path = tmp_path / "big.csv"
+    # Build the whole body in memory first, because one write is faster than
+    # a thousand writes and the fixture runs for every test.
+    csv_lines = ["col_a,col_b"]
+    csv_lines.extend(f"value_{index},payload_{index}" for index in range(TOTAL_ROWS))
+    csv_path.write_text("\n".join(csv_lines) + "\n", encoding="utf-8")
+
+    # Write a JSON array that holds the same number of records.
+    json_rows = ",".join(f'{{"id": {index}, "token": "t_{index}"}}' for index in range(TOTAL_ROWS))
+    (tmp_path / "big.json").write_text(f"[{json_rows}]", encoding="utf-8")
+
+    # Write a log file, because the log preview shares the same paginator.
+    log_lines = "\n".join(f"line {index}" for index in range(TOTAL_ROWS))
+    (tmp_path / "big.log").write_text(log_lines + "\n", encoding="utf-8")
+
+    # Write a database that holds a table an attacker would want to read.
+    db_path = tmp_path / "big.db"
+    # Use a context manager so that the handle closes on the error path too.
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE secrets (id INTEGER, token TEXT)")
+        conn.executemany(
+            "INSERT INTO secrets VALUES (?, ?)",
+            [(index, f"token_{index}") for index in range(TOTAL_ROWS)],
+        )
+    logging.debug("Built four fixtures that each hold %d rows", TOTAL_ROWS)
+    return DataBrowserService(str(tmp_path))
+
+
+class TestSqlitePageSizeIsBounded:
+    """The SQLite preview must never return more rows than the cap allows."""
+
+    @pytest.mark.parametrize("per_page", OUT_OF_RANGE_SIZES)
+    def test_out_of_range_size_returns_at_most_the_cap(self, browser, per_page) -> None:
+        """An out of range page size returns the cap and not the whole table."""
+        logging.info("Requesting the SQLite preview with per_page=%d", per_page)
+        # Call the service the same way the route calls it.
+        result = browser.preview_sqlite_table("big.db", "secrets", 1, per_page, "")
+        # A raised error would surface as an error dict, so check for one first.
+        assert "error" not in result, f"per_page={per_page} produced {result.get('error')!r}."
+        # The cap is the whole point of the defect, so assert it directly.
+        assert len(result["rows"]) <= MAX_PAGE_SIZE, (
+            f"per_page={per_page} returned {len(result['rows'])} rows. " f"The cap is {MAX_PAGE_SIZE}."
+        )
+        logging.debug("per_page=%d returned %d rows", per_page, len(result["rows"]))
+
+    @pytest.mark.parametrize("per_page", OUT_OF_RANGE_SIZES)
+    def test_out_of_range_size_with_a_search_returns_at_most_the_cap(self, browser, per_page) -> None:
+        """The search branch shares the cap with the plain branch."""
+        logging.info("Requesting the SQLite search preview with per_page=%d", per_page)
+        # The search branch runs a different query, so it needs its own test.
+        result = browser.preview_sqlite_table("big.db", "secrets", 1, per_page, "token")
+        # The search must match every row, which makes a bypass visible.
+        assert "error" not in result, f"per_page={per_page} produced {result.get('error')!r}."
+        assert (
+            len(result["rows"]) <= MAX_PAGE_SIZE
+        ), f"per_page={per_page} with a search returned {len(result['rows'])} rows."
+        logging.debug("The search branch returned %d rows", len(result["rows"]))
+
+
+class TestFilePageSizeIsBounded:
+    """The CSV, JSON, and log previews must share the same cap."""
+
+    @pytest.mark.parametrize("name", ["big.csv", "big.json", "big.log"])
+    @pytest.mark.parametrize("per_page", OUT_OF_RANGE_SIZES)
+    def test_out_of_range_size_returns_at_most_the_cap(self, browser, name, per_page) -> None:
+        """An out of range page size never raises and never exceeds the cap."""
+        logging.info("Requesting the preview of %s with per_page=%d", name, per_page)
+        # A zero page size raised ZeroDivisionError before the fix. The call
+        # sits outside a try block, so Flask returned 500 and a stack trace.
+        result = browser.preview_file(name, 1, per_page, "")
+        # Confirm that the call produced data and not an internal error text.
+        assert "error" not in result, f"{name} per_page={per_page} produced {result.get('error')!r}."
+        assert len(result["rows"]) <= MAX_PAGE_SIZE, f"{name} per_page={per_page} returned {len(result['rows'])} rows."
+        logging.debug("%s returned %d rows", name, len(result["rows"]))
+
+
+class TestPageNumberIsBounded:
+    """The page number must never produce a negative slice offset."""
+
+    @pytest.mark.parametrize("page", [0, -1, -1000])
+    def test_a_low_page_number_returns_the_first_page(self, browser, page) -> None:
+        """A page number below one reads the first page."""
+        logging.info("Requesting the SQLite preview with page=%d", page)
+        # A negative page produced a negative offset, which SQLite rejects and
+        # which Python reads as a slice from the end of the list.
+        result = browser.preview_sqlite_table("big.db", "secrets", page, 50, "")
+        assert "error" not in result, f"page={page} produced {result.get('error')!r}."
+        # The reported page must sit inside the valid range.
+        assert result["page"] >= 1, f"page={page} reported page {result['page']}."
+        # The first row of the first page is the first row of the table.
+        assert result["rows"][0][0] == 0, f"page={page} did not return the first page."
+        logging.debug("page=%d reported page %d", page, result["page"])
+
+
+class TestNormalRequestsStillWork:
+    """The clamp must not change a request that already sits in range."""
+
+    def test_a_normal_page_size_is_unchanged(self, browser) -> None:
+        """A page size inside the range returns exactly that many rows."""
+        logging.info("Requesting the SQLite preview with a normal page size")
+        # Guard against a clamp that always returns the cap.
+        result = browser.preview_sqlite_table("big.db", "secrets", 1, 50, "")
+        assert len(result["rows"]) == 50, "A normal page size must not change."
+        logging.debug("A normal page size returned %d rows", len(result["rows"]))
+
+    def test_the_second_page_follows_the_first(self, browser) -> None:
+        """Paging still walks through the table in order."""
+        logging.info("Requesting the second page of the SQLite preview")
+        # A clamp that pins the page number to 1 would break paging, so prove
+        # that the second page still returns the second block of rows.
+        result = browser.preview_sqlite_table("big.db", "secrets", 2, 50, "")
+        assert result["rows"][0][0] == 50, "The second page must start at row 50."
+        logging.debug("The second page starts at row %d", result["rows"][0][0])
+
+    def test_the_minimum_page_size_returns_one_row(self, browser) -> None:
+        """The lower bound is a single row and not an empty page."""
+        logging.info("Requesting the SQLite preview with the minimum page size")
+        # MIN_PAGE_SIZE names the lower bound, so a caller can read it.
+        result = browser.preview_sqlite_table("big.db", "secrets", 1, MIN_PAGE_SIZE, "")
+        assert len(result["rows"]) == MIN_PAGE_SIZE, "The minimum page size must return one row."
+        logging.debug("The minimum page size returned %d rows", len(result["rows"]))
+
+
+class TestTheBoundsAreNamed:
+    """The bounds must be module constants so that a route can reuse them."""
+
+    def test_the_bounds_hold_sane_values(self) -> None:
+        """The lower bound is one row and the upper bound is above it."""
+        logging.info("Checking the page size bounds")
+        # A lower bound of zero would reintroduce the divide by zero.
+        assert MIN_PAGE_SIZE >= 1, "The lower bound must be at least one row."
+        # An upper bound below the lower bound would make every clamp empty.
+        assert MAX_PAGE_SIZE > MIN_PAGE_SIZE, "The upper bound must sit above the lower bound."
+        logging.debug("The bounds are %d and %d", MIN_PAGE_SIZE, MAX_PAGE_SIZE)

--- a/tests/unit/web_portal/test_map_viewer_xss.py
+++ b/tests/unit/web_portal/test_map_viewer_xss.py
@@ -1,0 +1,178 @@
+"""Guard the map viewer device list against stored cross-site scripting.
+
+The map viewer renders device records that come from the Mist cloud. A device
+name is free text that an operator sets. If the template writes that name into
+``innerHTML``, a crafted name runs as script in the browser of every operator
+who opens the floor plan.
+
+These tests read the template and prove that the device list builder uses
+``textContent`` only. See issue #1939.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+import pytest
+
+# The template under test. The test reads the shipped file, because the defect
+# lives in the markup and not in Python code.
+TEMPLATE_PATH = Path(__file__).resolve().parents[3] / "web_portal" / "templates" / "map_viewer.html"
+
+# The name of the function that builds one list item for each device.
+TARGET_FUNCTION = "renderDeviceList"
+
+# A device field that an operator controls in the Mist cloud. Each one is a
+# free text value, so each one is an injection source.
+UNTRUSTED_FIELDS = ("d.name", "d.mac", "d.type")
+
+
+def _read_template() -> str:
+    """Return the text of the map viewer template."""
+    logging.info("Reading the map viewer template from %s", TEMPLATE_PATH)
+    # Read with an explicit encoding, because the default encoding on Windows
+    # is not UTF-8 and the template carries a numeric HTML entity.
+    source = TEMPLATE_PATH.read_text(encoding="utf-8")
+    logging.debug("Read %d characters from the map viewer template", len(source))
+    return source
+
+
+def _extract_function(source: str, name: str) -> str:
+    """Return the body of one JavaScript function from the template text."""
+    logging.info("Extracting the body of the function %s", name)
+    # Locate the declaration. The template declares every function at the top
+    # level with the plain ``function name(`` form.
+    start = source.find(f"function {name}(")
+    # Fail loudly when the function is gone, because a rename would otherwise
+    # make this guard pass without testing anything.
+    assert start != -1, f"The template no longer declares {name}."
+    # Find the opening brace of the body so that the brace counter starts at a
+    # known position.
+    brace_start = source.index("{", start)
+    # Track the nesting depth, because the body contains nested blocks.
+    depth = 0
+    # Walk one character at a time until the depth returns to zero.
+    for index in range(brace_start, len(source)):
+        # Enter a nested block.
+        if source[index] == "{":
+            depth += 1
+        # Leave a block.
+        elif source[index] == "}":
+            depth -= 1
+            # A depth of zero marks the closing brace of the function.
+            if depth == 0:
+                body = source[brace_start : index + 1]
+                logging.debug("Extracted %d characters for %s", len(body), name)
+                return body
+    # Reaching this line means the braces are unbalanced.
+    pytest.fail(f"The braces of the function {name} are unbalanced.")
+
+
+def _innerhtml_assignments(body: str) -> list[str]:
+    """Return the right side of every ``innerHTML`` assignment in the body."""
+    logging.info("Collecting the innerHTML assignments in the function body")
+    # Match an assignment to innerHTML and capture the rest of the statement.
+    # The statement can span lines, so capture up to the terminating semicolon.
+    pattern = re.compile(r"\.innerHTML\s*=\s*([^;]*);", re.DOTALL)
+    # Strip each match so that a comparison against an empty string literal is
+    # not defeated by leading whitespace.
+    matches = [match.group(1).strip() for match in pattern.finditer(body)]
+    logging.debug("Found %d innerHTML assignments in the function body", len(matches))
+    return matches
+
+
+class TestDeviceListDoesNotUseInnerHtml:
+    """The device list must not write untrusted device data into innerHTML."""
+
+    def test_no_untrusted_field_reaches_innerhtml(self) -> None:
+        """No device field appears on the right side of an innerHTML assignment."""
+        logging.info("Checking that no device field reaches innerHTML")
+        # Read the template and narrow the search to the device list builder.
+        body = _extract_function(_read_template(), TARGET_FUNCTION)
+        # Inspect every assignment, because one safe assignment does not make
+        # the others safe.
+        for assignment in _innerhtml_assignments(body):
+            # Compare against each injection source in turn.
+            for field in UNTRUSTED_FIELDS:
+                # A device field on the right side is the defect from #1939.
+                assert field not in assignment, (
+                    f"{TARGET_FUNCTION} writes {field} into innerHTML. " "A crafted device name then runs as script."
+                )
+        logging.debug("No device field reaches innerHTML")
+
+    def test_only_the_empty_string_clears_innerhtml(self) -> None:
+        """The one allowed innerHTML assignment clears the list."""
+        logging.info("Checking that innerHTML is only assigned an empty string")
+        # Read the template and narrow the search to the device list builder.
+        body = _extract_function(_read_template(), TARGET_FUNCTION)
+        # The builder clears the previous list before it appends new rows. That
+        # single assignment writes a constant, so it stays allowed.
+        allowed = {"''", '""'}
+        # Reject any other assignment, which catches a future concatenation
+        # even when the concatenation uses a field this test does not name.
+        for assignment in _innerhtml_assignments(body):
+            assert assignment in allowed, (
+                f"{TARGET_FUNCTION} assigns {assignment!r} to innerHTML. "
+                "Build the row from DOM nodes and set textContent instead."
+            )
+        logging.debug("Every innerHTML assignment writes an empty string")
+
+
+class TestDeviceListUsesTextContent:
+    """The device list must render untrusted device data with textContent."""
+
+    def test_the_builder_sets_textcontent(self) -> None:
+        """The device list builder assigns textContent at least once."""
+        logging.info("Checking that the device list builder uses textContent")
+        # Read the template and narrow the search to the device list builder.
+        body = _extract_function(_read_template(), TARGET_FUNCTION)
+        # The browser escapes a textContent value, so this is the safe sink.
+        assert "textContent" in body, (
+            f"{TARGET_FUNCTION} never sets textContent. " "The device label must reach the page through a safe sink."
+        )
+        logging.debug("The device list builder uses textContent")
+
+    def test_the_device_label_uses_textcontent(self) -> None:
+        """The device name and the device type both reach textContent."""
+        logging.info("Checking that each device field reaches textContent")
+        # Read the template and narrow the search to the device list builder.
+        body = _extract_function(_read_template(), TARGET_FUNCTION)
+        # Match an assignment to textContent and capture the rest of the
+        # statement, which mirrors the innerHTML matcher above.
+        pattern = re.compile(r"\.textContent\s*=\s*([^;]*);", re.DOTALL)
+        # Join the safe sinks into one blob so that a field can appear in any
+        # one of them.
+        safe_sinks = " ".join(match.group(1) for match in pattern.finditer(body))
+        # The device name is the field an operator edits most often, so it is
+        # the field an attacker reaches first.
+        assert "d.name" in safe_sinks, "The device name must reach textContent."
+        # The device type comes from the same API record, so it needs the same
+        # treatment.
+        assert "d.type" in safe_sinks, "The device type must reach textContent."
+        logging.debug("Each device field reaches textContent")
+
+
+class TestTheGuardStillMatchesTheFile:
+    """The guard must fail when the template moves, not pass by accident."""
+
+    def test_the_template_exists(self) -> None:
+        """The template path still points at a real file."""
+        logging.info("Checking that the map viewer template exists")
+        # A missing file would make every other test in this module error, but
+        # this test names the cause directly.
+        assert TEMPLATE_PATH.is_file(), f"The template {TEMPLATE_PATH} is missing."
+        logging.debug("The map viewer template exists")
+
+    def test_the_safe_convention_holds_elsewhere(self) -> None:
+        """The site list still uses the safe textContent convention."""
+        logging.info("Checking the safe convention in the site list")
+        # The rest of the template already uses textContent. This test pins
+        # that convention so that a later edit does not spread the defect.
+        source = _read_template()
+        # The site list renders a site name that comes from the same API.
+        assert "opt.textContent = site.name;" in source, (
+            "The site list no longer uses textContent. " "Every Mist value must reach the page through a safe sink."
+        )
+        logging.debug("The site list still uses textContent")

--- a/tests/unit/web_portal/test_operation_destructive_gate.py
+++ b/tests/unit/web_portal/test_operation_destructive_gate.py
@@ -1,0 +1,107 @@
+"""Security tests for the web portal destructive operation gate.
+
+`OperationExecutor` decided whether the portal may run an operation with a
+hardcoded number. `src/utils/operation_registry.py` holds the safety category
+for every operation, and the project documents that registry as the single
+source of truth.
+
+The tests prove two defects.
+
+1. The gate allowed an operation that the registry does not call safe. The
+   registry marks menu 0 as `interactive` and menu 14, 18, 19, and 59 as
+   `resource_intensive`.
+2. The gate failed open on a key that `int()` cannot parse. The listing hid the
+   key, and the run path still accepted it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.utils.operation_registry import OperationRegistry
+from web_portal.services.operation import OperationExecutor
+
+
+def _noop() -> None:
+    """Stand in for a menu action, because the gate runs before the call."""
+    return None  # The gate must refuse before the executor reaches this body.
+
+
+@pytest.fixture
+def executor():
+    """Build an executor whose menu holds one entry for each test case."""
+    menu_actions = {
+        "11": (_noop, "Export the organization inventory"),  # Registry category `safe`.
+        "60": (_noop, "An interactive but safe export"),  # Registry category `interactive_safe`.
+        "0": (_noop, "An interactive operation"),  # Registry category `interactive`.
+        "14": (_noop, "A resource intensive export"),  # Registry category `resource_intensive`.
+        "18": (_noop, "A second resource intensive export"),  # Registry category `resource_intensive`.
+        "59": (_noop, "A third resource intensive export"),  # Registry category `resource_intensive`.
+        "154": (_noop, "A destructive operation"),  # Registry category `destructive`.
+        "102": (_noop, "A websocket operation"),  # Registry category `websocket`.
+        "151": (_noop, "A continuous loop operation"),  # Registry category `continuous_loop`.
+        "x1": (_noop, "A key that int() cannot parse"),  # The old gate failed open on this key.
+    }
+    built = OperationExecutor(menu_actions, None, None, None)  # Executor under test.
+    yield built  # Hand the executor to the test before the pool shuts down.
+    built._pool.shutdown(wait=False)  # Release the thread pool, so the test leaves no thread.
+
+
+def _refusal(executor, menu_number: str):
+    """Return the gate verdict for one menu number, or None when allowed."""
+    return executor._validate_operation(menu_number)  # None means the gate allows the operation.
+
+
+class TestUnsafeCategoriesAreRefused:
+    """Prove that the gate refuses every category the registry calls unsafe."""
+
+    @pytest.mark.parametrize("menu_number", ["0", "14", "18", "59", "102", "151", "154"])
+    def test_unsafe_category_is_refused(self, executor, menu_number):
+        """The gate must refuse an operation the registry does not call safe."""
+        category = OperationRegistry.skip_category(menu_number)  # Read the authoritative verdict.
+
+        assert category not in ("safe", "interactive_safe")  # Guard the premise of this test.
+        assert _refusal(executor, menu_number) is not None  # The gate must refuse the operation.
+
+    def test_unparseable_key_is_refused(self, executor):
+        """A key that `int()` cannot parse must not reach the thread pool."""
+        assert _refusal(executor, "x1") is not None  # The old gate returned None and allowed it.
+
+    def test_unknown_key_is_refused(self, executor):
+        """A key that the menu does not hold must be refused."""
+        assert _refusal(executor, "12345") is not None  # An absent key must never run.
+
+
+class TestSafeCategoriesStillRun:
+    """Prove that the stricter gate keeps the supported operations reachable."""
+
+    @pytest.mark.parametrize("menu_number", ["11", "60"])
+    def test_safe_category_is_allowed(self, executor, menu_number):
+        """The gate must allow an operation the registry calls safe."""
+        category = OperationRegistry.skip_category(menu_number)  # Read the authoritative verdict.
+
+        assert category in ("safe", "interactive_safe")  # Guard the premise of this test.
+        assert _refusal(executor, menu_number) is None  # The gate must allow the operation.
+
+
+class TestListingAndGateAgree:
+    """Prove that the listing path and the run path use one rule."""
+
+    def test_every_listed_operation_is_runnable(self, executor):
+        """The operations page must not show an operation the gate refuses."""
+        categories = executor.build_category_list(executor._menu_actions)  # Build the page data.
+        listed = {op["menu_number"] for cat in categories for op in cat["operations"]}  # Shown keys.
+
+        refused = {key for key in listed if _refusal(executor, key) is not None}  # Shown and refused.
+
+        assert refused == set()  # A shown operation that the gate refuses confuses the operator.
+
+    def test_every_runnable_operation_is_listed(self, executor):
+        """The gate must not accept an operation that the page hides."""
+        categories = executor.build_category_list(executor._menu_actions)  # Build the page data.
+        listed = {op["menu_number"] for cat in categories for op in cat["operations"]}  # Shown keys.
+
+        hidden = set(executor._menu_actions) - listed  # Keys the operations page never shows.
+        allowed = {key for key in hidden if _refusal(executor, key) is None}  # Hidden and allowed.
+
+        assert allowed == set()  # A hidden operation that the gate allows is a fail-open defect.

--- a/web_portal/routes/data.py
+++ b/web_portal/routes/data.py
@@ -41,7 +41,6 @@ def preview_file(filepath):
     service = DataBrowserService(data_dir)
     page = request.args.get("page", 1, type=int)
     per_page = request.args.get("per_page", 50, type=int)
-    per_page = min(per_page, 200)
     search = request.args.get("search", "")
     result = service.preview_file(filepath, page, per_page, search)
     if "error" in result:
@@ -59,7 +58,6 @@ def preview_table(filepath, table_name):
     service = DataBrowserService(data_dir)
     page = request.args.get("page", 1, type=int)
     per_page = request.args.get("per_page", 50, type=int)
-    per_page = min(per_page, 200)
     search = request.args.get("search", "")
     result = service.preview_sqlite_table(filepath, table_name, page, per_page, search)
     if "error" in result:

--- a/web_portal/routes/operations.py
+++ b/web_portal/routes/operations.py
@@ -49,7 +49,10 @@ def run_operation():
     executor = _get_executor()
     result = executor.start_operation(menu_number, parameters)
     if "error" in result:
-        status = 400 if "destructive" in result["error"].lower() else 409
+        # Only a second run of the same operation is a conflict. Every other
+        # refusal is a bad request, which covers an unknown menu number and an
+        # operation whose safety category keeps it off the portal.
+        status = 409 if "already running" in result["error"].lower() else 400
         return jsonify(result), status
     return jsonify(result), 202
 

--- a/web_portal/services/data_browser.py
+++ b/web_portal/services/data_browser.py
@@ -5,6 +5,7 @@ with pagination, and enforces path traversal guards.
 """
 
 import csv
+import logging
 import math
 import os
 import sqlite3
@@ -22,7 +23,8 @@ class DataBrowserService:
 
     def __init__(self, data_dir: str):
         """Initialize with the absolute path to the data directory."""
-        self._data_dir = os.path.abspath(data_dir)
+        self._data_dir = os.path.abspath(data_dir)  # Listing code compares names against this path.
+        self._real_data_dir = os.path.realpath(self._data_dir)  # Link-free root for the path guard.
 
     def list_files(self) -> list:
         """List all browsable files and directories in data dir."""
@@ -63,16 +65,39 @@ class DataBrowserService:
             return {"error": "Table not found"}
         return self._preview_sqlite(resolved, table_name, page, per_page, search)
 
-    def resolve_safe_path(self, rel_path: str) -> str:
-        """Resolve a relative path safely within the data directory."""
-        if ".." in rel_path.split("/") or ".." in rel_path.split("\\"):
+    def resolve_safe_path(self, rel_path: str) -> str | None:
+        """Resolve a request path to a real file inside the data directory.
+
+        The method resolves every symbolic link before it compares the paths.
+        A text prefix match cannot do that, because a link points anywhere.
+        Return `None` when the request leaves the data directory, names a
+        directory, or names a file type that the listing does not show.
+        """
+        logging.info("Data browser resolves a path request: %s", rel_path)
+        candidate = os.path.realpath(os.path.join(self._data_dir, rel_path))  # Follow every link.
+        if not self._is_inside_data_dir(candidate):  # Refuse a target outside the data directory.
+            logging.debug("Data browser refused a path outside the data directory: %s", rel_path)
             return None
-        full = os.path.normpath(os.path.join(self._data_dir, rel_path))
-        if not full.startswith(self._data_dir):
+        if not self._is_browsable_file(candidate):  # Refuse a directory or a hidden file type.
+            logging.debug("Data browser refused a path that is not a browsable file: %s", rel_path)
             return None
-        if not os.path.exists(full):
-            return None
-        return full
+        logging.debug("Data browser accepted the path request: %s", rel_path)
+        return candidate
+
+    def _is_inside_data_dir(self, candidate: str) -> bool:
+        """Report whether a resolved path sits inside the data directory."""
+        try:
+            common = os.path.commonpath([self._real_data_dir, candidate])  # Respects the separator.
+        except ValueError:
+            return False  # The two paths sit on different Windows drives, so the target is outside.
+        return os.path.normcase(common) == os.path.normcase(self._real_data_dir)  # Case-safe match.
+
+    @staticmethod
+    def _is_browsable_file(candidate: str) -> bool:
+        """Report whether a resolved path names a file the portal may serve."""
+        if not os.path.isfile(candidate):  # A directory breaks `send_file` and leaks a stack trace.
+            return False
+        return os.path.splitext(candidate)[1].lower() in ALLOWED_EXTENSIONS  # Same rule as listing.
 
     def _build_file_entry(self, entry) -> dict:
         """Build metadata dict for a directory entry."""

--- a/web_portal/services/data_browser.py
+++ b/web_portal/services/data_browser.py
@@ -75,7 +75,14 @@ class DataBrowserService:
         """
         logging.info("Data browser resolves a path request: %s", rel_path)
         candidate = os.path.realpath(os.path.join(self._data_dir, rel_path))  # Follow every link.
-        if not self._is_inside_data_dir(candidate):  # Refuse a target outside the data directory.
+        # Normalize the case and the separator. On Windows the two names
+        # "C:\Data" and "c:/data" point at one directory, so a raw comparison
+        # of the two strings reports a false mismatch.
+        normalized = os.path.normcase(candidate)
+        # Append the separator to the root. Without the separator the path
+        # "/app/data_backup" passes a bare check for the prefix "/app/data".
+        root = os.path.normcase(os.path.join(self._real_data_dir, ""))
+        if not normalized.startswith(root):  # Refuse a target outside the data directory.
             logging.debug("Data browser refused a path outside the data directory: %s", rel_path)
             return None
         if not self._is_browsable_file(candidate):  # Refuse a directory or a hidden file type.
@@ -83,14 +90,6 @@ class DataBrowserService:
             return None
         logging.debug("Data browser accepted the path request: %s", rel_path)
         return candidate
-
-    def _is_inside_data_dir(self, candidate: str) -> bool:
-        """Report whether a resolved path sits inside the data directory."""
-        try:
-            common = os.path.commonpath([self._real_data_dir, candidate])  # Respects the separator.
-        except ValueError:
-            return False  # The two paths sit on different Windows drives, so the target is outside.
-        return os.path.normcase(common) == os.path.normcase(self._real_data_dir)  # Case-safe match.
 
     @staticmethod
     def _is_browsable_file(candidate: str) -> bool:

--- a/web_portal/services/data_browser.py
+++ b/web_portal/services/data_browser.py
@@ -75,14 +75,10 @@ class DataBrowserService:
         """
         logging.info("Data browser resolves a path request: %s", rel_path)
         candidate = os.path.realpath(os.path.join(self._data_dir, rel_path))  # Follow every link.
-        # Normalize the case and the separator. On Windows the two names
-        # "C:\Data" and "c:/data" point at one directory, so a raw comparison
-        # of the two strings reports a false mismatch.
-        normalized = os.path.normcase(candidate)
         # Append the separator to the root. Without the separator the path
         # "/app/data_backup" passes a bare check for the prefix "/app/data".
-        root = os.path.normcase(os.path.join(self._real_data_dir, ""))
-        if not normalized.startswith(root):  # Refuse a target outside the data directory.
+        root = os.path.join(self._real_data_dir, "")
+        if not candidate.startswith(root):  # Refuse a target outside the data directory.
             logging.debug("Data browser refused a path outside the data directory: %s", rel_path)
             return None
         if not self._is_browsable_file(candidate):  # Refuse a directory or a hidden file type.

--- a/web_portal/services/data_browser.py
+++ b/web_portal/services/data_browser.py
@@ -13,6 +13,14 @@ from contextlib import closing
 
 ALLOWED_EXTENSIONS = {".csv", ".db", ".sqlite", ".log", ".json"}
 
+# The smallest page the preview returns. A zero page size divided by zero and
+# returned 500 with a stack trace. See issue #1946.
+MIN_PAGE_SIZE = 1
+
+# The largest page the preview returns. SQLite reads a negative `LIMIT` as no
+# limit, so a caller who sent -1 read the whole table in one response.
+MAX_PAGE_SIZE = 200
+
 
 class DataBrowserService:
     """Browse, preview, and download files from the data directory.
@@ -45,6 +53,7 @@ class DataBrowserService:
         resolved = self.resolve_safe_path(rel_path)
         if resolved is None:
             return {"error": "File not found"}
+        page, per_page = self._clamp_page_args(page, per_page)  # Bound the request on both ends.
         ext = os.path.splitext(resolved)[1].lower()
         if ext == ".csv":
             return self._preview_csv(resolved, page, per_page, search)
@@ -63,7 +72,22 @@ class DataBrowserService:
             return {"error": "File not found"}
         if not self._is_valid_table_name(resolved, table_name):
             return {"error": "Table not found"}
+        page, per_page = self._clamp_page_args(page, per_page)  # Bound the request on both ends.
         return self._preview_sqlite(resolved, table_name, page, per_page, search)
+
+    @staticmethod
+    def _clamp_page_args(page: int, per_page: int) -> tuple[int, int]:
+        """Return a page number and a page size that both sit inside the bounds.
+
+        The service owns this rule so that a new route cannot skip it.
+        """
+        # Clamp the size on both ends. A negative size reached SQLite as a
+        # negative `LIMIT`, which SQLite reads as no limit at all.
+        safe_per_page = max(MIN_PAGE_SIZE, min(per_page, MAX_PAGE_SIZE))
+        # Clamp the page number to the first page. A page below one produced a
+        # negative offset, which reads rows from the end of the list.
+        safe_page = max(1, page)
+        return safe_page, safe_per_page
 
     def resolve_safe_path(self, rel_path: str) -> str | None:
         """Resolve a request path to a real file inside the data directory.

--- a/web_portal/services/operation.py
+++ b/web_portal/services/operation.py
@@ -14,6 +14,8 @@ from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional
 
+from src.utils.operation_registry import OperationRegistry
+
 CATEGORY_RANGES = [
     (1, 4, "Core Organization"),
     (5, 8, "WebSocket Device Commands"),
@@ -30,6 +32,16 @@ CATEGORY_RANGES = [
 ]
 
 DESTRUCTIVE_THRESHOLD = 90
+
+# The safety categories that the portal may run. `OperationRegistry` in
+# src/utils/operation_registry.py is the single source of truth for the safety
+# category of every operation. The portal used to compare the menu number
+# against DESTRUCTIVE_THRESHOLD alone. That comparison let five operations
+# through that the registry does not call safe, and it let a key that int()
+# cannot parse through as well. The registry check below closes both gaps.
+# DESTRUCTIVE_THRESHOLD stays as a second, narrower bound. Removing it would
+# widen the portal by 49 operations, which is a separate change.
+PORTAL_RUNNABLE_CATEGORIES = frozenset({"safe", "interactive_safe"})
 
 # --- Run registry memory caps ----------------------------------------------
 # The portal runs as one long-lived Gunicorn worker. Issue #1860 showed that an
@@ -437,9 +449,9 @@ class OperationExecutor:
         """Build categorized operation list for the UI."""
         categories = {}
         for key, value in menu_actions.items():
-            num = self._parse_menu_number(key)
-            if num is None or num >= DESTRUCTIVE_THRESHOLD:
+            if not self._is_portal_runnable(key):  # One rule for the page and the run gate.
                 continue
+            num = self._parse_menu_number(key)  # Safe here, because the gate proved the key parses.
             category = self._get_category(num)
             desc = value[1] if isinstance(value, tuple) and len(value) > 1 else str(value)
             reg_entry = PARAMETER_REGISTRY.get(key)
@@ -480,17 +492,44 @@ class OperationExecutor:
         }
 
     def _validate_operation(self, menu_number: str) -> Optional[dict]:
-        """Check if the operation is valid and non-destructive."""
+        """Check that the operation exists and that the portal may run it."""
         if menu_number not in self._menu_actions:
             return {"error": f"Operation {menu_number} not found"}
-        num = self._parse_menu_number(menu_number)
-        if num is not None and num >= DESTRUCTIVE_THRESHOLD:
-            return {"error": f"Menu number {menu_number} is a destructive operation and cannot be run from the portal"}
+        if not self._is_portal_runnable(menu_number):  # One rule for the page and the run gate.
+            return {"error": self._refusal_message(menu_number)}
         value = self._menu_actions[menu_number]
         func = value[0] if isinstance(value, tuple) else value
         if func is None:
             return {"error": "API not authenticated. Connect via SSH to run operations."}
         return None
+
+    def _is_portal_runnable(self, menu_number: str) -> bool:
+        """Report whether the portal may run one operation.
+
+        The check reads `OperationRegistry`, which the project documents as the
+        single source of truth for the safety category. The check fails closed.
+        An unregistered key, an unparseable key, and any category outside
+        `PORTAL_RUNNABLE_CATEGORIES` all return False.
+        """
+        logging.info("Portal checks whether it may run operation %s", menu_number)
+        category = OperationRegistry.skip_category(menu_number)  # Authoritative safety verdict.
+        num = self._parse_menu_number(menu_number)  # None when int() cannot read the key.
+        allowed = (
+            category in PORTAL_RUNNABLE_CATEGORIES  # The registry must call the operation safe.
+            and num is not None  # A key the page cannot place must never run.
+            and num < DESTRUCTIVE_THRESHOLD  # Keep the existing narrower bound, so no operation is added.
+        )
+        logging.debug("Portal verdict for operation %s: category=%s allowed=%s", menu_number, category, allowed)
+        return allowed
+
+    @staticmethod
+    def _refusal_message(menu_number: str) -> str:
+        """Build the message that tells the operator why the portal refused."""
+        category = OperationRegistry.skip_category(menu_number)  # Name the reason for the refusal.
+        return (
+            f"Menu number {menu_number} is not a safe operation, so the portal cannot run it. "
+            f"The safety category is '{category}'. Connect over SSH to run this operation."
+        )
 
     def _check_conflict(self, menu_number: str) -> Optional[dict]:
         """Check if the same operation is already running."""

--- a/web_portal/templates/map_viewer.html
+++ b/web_portal/templates/map_viewer.html
@@ -177,7 +177,13 @@ function renderMap(data) {
 
 function deviceColor(type) {
     var map = { ap: '#0dcaf0', switch: '#ffc107', gateway: '#198754' };
-    return map[type] || '#6c757d';
+    // Read an own property only. A device type such as "constructor" would
+    // otherwise return a built-in function instead of a color string.
+    if (Object.prototype.hasOwnProperty.call(map, type)) {
+        return map[type];
+    }
+    // Fall back to the neutral gray for an unknown device type.
+    return '#6c757d';
 }
 
 function renderDeviceList(devices) {
@@ -195,9 +201,25 @@ function renderDeviceList(devices) {
     devices.forEach(function(d) {
         var li = document.createElement('li');
         li.className = 'list-group-item py-1';
-        var dot = '<span style="color:' + deviceColor(d.type) + '">&#9679;</span> ';
-        li.innerHTML = dot + (d.name || d.mac || 'Unknown') +
-            ' <small class="text-muted">(' + d.type + ')</small>';
+        // Build the colored dot as a node. A style property is a safe sink,
+        // and deviceColor returns a value from a fixed set.
+        var dot = document.createElement('span');
+        dot.style.color = deviceColor(d.type);
+        // Use the escape form of the black circle so that the file stays ASCII.
+        dot.textContent = '\u25CF';
+        // Render the device label with textContent. The browser escapes the
+        // value, so a crafted device name cannot run as script. See #1939.
+        var label = document.createElement('span');
+        label.textContent = ' ' + (d.name || d.mac || 'Unknown') + ' ';
+        // Render the device type through the same safe sink, because the type
+        // arrives in the same untrusted API record as the name.
+        var type = document.createElement('small');
+        type.className = 'text-muted';
+        type.textContent = '(' + (d.type || 'unknown') + ')';
+        // Append the three nodes in reading order to rebuild the old layout.
+        li.appendChild(dot);
+        li.appendChild(label);
+        li.appendChild(type);
         list.appendChild(li);
     });
 }


### PR DESCRIPTION
Closes #1929
Closes #1930
Closes #1932
Closes #1939
Closes #1946

## Summary

This pull request closes five fail-open defects in the Flask web portal. Every
one of the five shares a single shape.

**A guard runs on one path and does not run on the matching path.**

- The data browser listing filters by file extension. The download route did
  not filter.
- The data browser path guard blocked a literal `..` traversal. It did not
  resolve a symbolic link, so a link inside the data directory read a file
  outside it.
- The operation menu hid an unsafe operation from the category list. The run
  gate used a different rule, so the gate and the list disagreed.
- The map viewer renders a site name with `textContent`, which is safe. The
  device list used `innerHTML`, which is not.
- The preview routes clamped the page size at the top. They did not clamp it at
  the bottom, so a negative value passed straight through.

Each fix closes the gap. Each fix has a test that failed before the change.

The portal has no user authentication, and `PORTAL_ALLOWED_IPS` defaults to an
empty value. Every defect below is therefore reachable without a credential.
Issue #1933 tracks that default.

## The five changes

### 1. The data browser path guard now resolves a symbolic link. #1929

`resolve_safe_path` in `web_portal/services/data_browser.py` called
`os.path.normpath`. That function does not resolve a symbolic link. A link
inside the data directory therefore passed the guard and read any file that the
portal process could read.

The guard now calls `os.path.realpath` and compares the result against the real
data directory.

The old containment test used `str.startswith` with no path boundary, so the
path `/app/data_backup` passed a check for the prefix `/app/data`. The new test
appends the separator with `os.path.join(root, "")`, which restores the
boundary and leaves a bare drive root unchanged.

### 2. The download route now applies the extension allowlist. #1930

The listing route filtered each entry through `ALLOWED_EXTENSIONS`. The download
route did not. A caller who guessed a file name downloaded `.env`, `.pem`, or
any other file inside the data directory.

The new helper `_is_browsable_file` applies the same allowlist. Both routes now
use one rule.

### 3. The operation run gate now asks the registry. #1932

`web_portal/services/operation.py` decided that an operation was destructive
when the menu number was above `90`. `src/utils/operation_registry.py` is the
documented single source of truth for that decision. The two disagreed on 54
operations.

Five unsafe operations passed the old gate. Menu `0` is `interactive`. Menu
`14`, `18`, `19`, and `59` are `resource_intensive`.

`build_category_list` and `_validate_operation` now both call
`_is_portal_runnable`, which asks the registry.

The magic number stays as a second and narrower bound. The two bounds combine
with a logical AND. This pull request therefore only removes an operation from
the portal. It never adds one. The 49 safe operations that the old threshold
blocked stay blocked, because widening the portal is a functional change and
not a security fix. Issue #1932 records that follow-up.

`web_portal/routes/operations.py` returned `400` for a refusal that named a
destructive operation and `409` for everything else. The refusal message no
longer names one category, so the mapping now returns `409` for a run that is
already in progress and `400` for a refusal.

### 4. The map viewer now renders a device with textContent. #1939

`web_portal/templates/map_viewer.html` wrote `d.name`, `d.mac`, and `d.type`
into `innerHTML`. A device name is free text that an operator sets in the Mist
cloud, so a crafted name ran as script for every operator who opened the floor
plan.

The Content Security Policy did not stop the attack. `script-src` carries
`'unsafe-inline'`, which permits an inline `onerror` handler.

The device row now comes from DOM nodes. Each node receives its value through
`textContent`, and the browser escapes that value. This matches the convention
that the rest of the same file already follows at line 62, line 82, and line
101.

`deviceColor` now reads an own property only. A device type such as
`constructor` would otherwise return a built-in function in place of a color.

### 5. The preview page size is now bounded on both ends. #1946

`web_portal/routes/data.py` applied `per_page = min(per_page, 200)`. A negative
value and a zero value both passed that test.

A caller who sent `per_page=-1` read the whole table, because SQLite reads a
negative `LIMIT` as no limit at all. A caller who sent `per_page=0` divided by
zero, and the CSV path returned 500 with a stack trace.

The service now owns the rule. `MIN_PAGE_SIZE` and `MAX_PAGE_SIZE` name the
bounds, and `_clamp_page_args` applies them in `preview_file` and in
`preview_sqlite_table`. The duplicated line is gone from both routes, so a new
route cannot skip the clamp.

## Tests

| File | Tests | Failed before the change |
| - | - | - |
| `tests/unit/test_data_browser_path_guard.py` | 10 | 3 |
| `tests/unit/web_portal/test_operation_destructive_gate.py` | 13 | 6 |
| `tests/unit/web_portal/test_map_viewer_xss.py` | 6 | 3 |
| `tests/unit/web_portal/test_data_browser_pagination_bounds.py` | 32 | 22 |

Two of the path guard tests skip on Windows. `os.symlink` needs a privilege
that a standard account does not hold. The tests probe for that privilege and
skip when the probe fails. They run on the Linux runner.

Result on the full portal suite:

```
137 passed, 2 skipped
```

## Verification

- A probe with a real Windows directory junction checks the path guard against
  8 cases. All 8 pass. A junction that leaves the data directory is refused.
  The sibling directory `data_backup` is refused against the root `data`. A
  literal `../` traversal is refused. A nested path that arrives with a forward
  slash is accepted.
- A probe against a 1000 row table confirms the page size defect and the fix.
  Before the change `per_page=-1` returned all 1000 rows against a cap of 200.
- `python -m ruff check` reports the same pre-existing findings before and
  after the change. None of them sits on a changed line.
- `python -m black --check` reports no change for every touched file.
- The template holds zero bytes above 127, so it stays ASCII.

## A note on the CodeQL alert

CodeQL first reported a high severity path injection alert against the new
guard. The guard was correct, but it lived in a helper that returned a boolean,
so the dataflow engine lost the barrier.

Two commits moved the test next to the value it protects and made the guarded
variable the same variable that the method returns. CodeQL now passes.

## Out of scope

Issue #1933 stays open. `PORTAL_ALLOWED_IPS` defaults to an empty string, so
`_register_ip_allowlist` returns early and the portal registers no access
control. The portal also has no user authentication.

That fix changes a shipped default and can lock an operator out of a running
portal. It needs its own pull request and its own release note. I added the
supporting evidence to #1933.
