### PR TITLE
fix(runtime): release the socket, the thread, and the HTTP body on four error paths

### DIFF
--- a/src/capture/_packet_capture_exec.py
+++ b/src/capture/_packet_capture_exec.py
@@ -25,6 +25,10 @@ from typing import Any, cast  # WHY: opaque manager plus typed cast for untyped 
 from src.capture.packet_capture_download import PacketCaptureDownloadManager  # WHY: shared parser/downloader
 from src.capture.site_capture_loop import SiteCaptureLoopRunner  # WHY: shared loop-runner
 
+# WHY: a dropped WebSocket never delivers the Mist end-of-capture signal. The cap turns a permanent hang into a
+# reported timeout. One hour covers the longest supported Mist capture window with room to spare.
+_STREAM_MAX_SECONDS = 3600
+
 
 def _pc() -> Any:
     """Return the ``packet_capture`` module for test-patchable name lookup.
@@ -379,19 +383,34 @@ class PacketCaptureExec:
         print("-" * 80)  # WHY: visual separator
 
     def read_stream_packets(self, channel: str, capture_id: str) -> None:
-        """Read and count packets from WebSocket stream."""
+        """Read and count packets from WebSocket stream until the end signal or the deadline."""
         if self.websocket_manager is None:  # WHY: guard against uninitialized stream
             logging.error("WebSocket manager not available for stream reading")  # WHY: audit
             return  # WHY: nothing to read
         state = {"count": 0, "start": _pc().time.time()}  # WHY: mutable state shared with helper
+        # WHY: a dropped socket or a lost end-of-capture signal never returns True from the drain helper. Without a
+        # deadline the loop spins until the operator sends Ctrl-C, and an SSH session with no terminal cannot.
+        deadline = state["start"] + _STREAM_MAX_SECONDS  # WHY: hard wall-clock cap on the whole stream.
+        logging.info("Reading capture stream %s with a %s second cap", capture_id, _STREAM_MAX_SECONDS)  # WHY: audit.
         try:  # WHY: catch Ctrl-C to print summary
-            while True:  # WHY: infinite drain. Helper returns when capture ends
+            while _pc().time.time() < deadline:  # WHY: bounded drain. The helper returns True when capture ends.
                 if self._drain_stream_batch(channel, capture_id, state):  # WHY: batch drain returns True on end
+                    logging.debug("Capture stream %s ended with %s packets", capture_id, state["count"])  # WHY: result
                     return  # WHY: capture ended cleanly
                 _pc().time.sleep(0.1)  # WHY: gentle CPU yield between batches
+            self._report_stream_timeout(capture_id, state)  # WHY: the deadline expired, so tell the operator why.
         except KeyboardInterrupt:  # WHY: user aborted monitoring
             print("\n\n! Monitoring stopped by user")  # WHY: user confirmation
             print(f"  Total packets received: {state['count']}")  # WHY: expose summary
+
+    @staticmethod
+    def _report_stream_timeout(capture_id: str, state: dict[str, Any]) -> None:
+        """Tell the operator that the stream reached the time cap before the end signal arrived."""
+        print(f"\n! Capture stream stopped after {_STREAM_MAX_SECONDS} seconds with no end signal")  # WHY: notice.
+        print(f"  Total packets received: {state['count']}")  # WHY: expose the partial result.
+        logging.warning(  # WHY: audit the timeout so a support bundle shows the cause.
+            "Capture stream %s hit the %s second cap after %s packets", capture_id, _STREAM_MAX_SECONDS, state["count"]
+        )
 
     def _drain_stream_batch(self, channel: str, capture_id: str, state: dict[str, Any]) -> bool:
         """Drain one batch of WebSocket messages. Return True when the capture end signal is seen."""

--- a/src/capture/client_pcap_downloader.py
+++ b/src/capture/client_pcap_downloader.py
@@ -318,15 +318,17 @@ class ClientPacketCaptureDownloader:
         local_path = target / row.filename  # WHY: join via pathlib for cross-platform safety.
         logging.info("Downloading PCAP %s from %s", row.capture_id, row.pcap_url)  # WHY: audit before HTTP.
         try:  # WHY: transfer + write must not crash the batch.
-            response = requests.get(row.pcap_url, stream=True, timeout=_DEFAULT_TIMEOUT_SEC)  # WHY: stream.
-            if response.status_code != _HTTP_OK:  # WHY: guard non-200 responses before write.
-                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
-                logger.error("    Failed %s: HTTP %s", row.filename, response.status_code)  # WHY: feedback.
-                logging.error("Download failed %s: %s", row.capture_id, response.status_code)  # WHY: audit.
-                return False  # WHY: skip write on failure.
-            with open(local_path, "wb") as pcap_file:  # WHY: binary write for PCAP payload.
-                for chunk in response.iter_content(chunk_size=_STREAM_CHUNK_BYTES):  # WHY: chunked stream.
-                    pcap_file.write(chunk)  # WHY: persist each chunk incrementally.
+            # WHY: the context manager closes the streamed body on every path. Without it a non-200 reply or a
+            # mid-stream error keeps the socket checked out of the pool, and a large batch exhausts the pool.
+            with requests.get(row.pcap_url, stream=True, timeout=_DEFAULT_TIMEOUT_SEC) as response:
+                if response.status_code != _HTTP_OK:  # WHY: guard non-200 responses before write.
+                    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
+                    logger.error("    Failed %s: HTTP %s", row.filename, response.status_code)  # WHY: feedback.
+                    logging.error("Download failed %s: %s", row.capture_id, response.status_code)  # WHY: audit.
+                    return False  # WHY: skip write on failure.
+                with open(local_path, "wb") as pcap_file:  # WHY: binary write for PCAP payload.
+                    for chunk in response.iter_content(chunk_size=_STREAM_CHUNK_BYTES):  # WHY: chunked stream.
+                        pcap_file.write(chunk)  # WHY: persist each chunk incrementally.
             size_mb = local_path.stat().st_size / _BYTES_PER_MB  # WHY: compute size for user feedback.
             # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("    Downloaded %s (%.2f MB)", row.filename, size_mb)  # WHY: operator success line.

--- a/src/ssh/cli_shell_manager.py
+++ b/src/ssh/cli_shell_manager.py
@@ -33,6 +33,8 @@ except ImportError:  # pyte not installed
     pyte = None  # type: ignore[assignment]
     _has_pyte = False
 
+_RECEIVER_JOIN_TIMEOUT_SEC = 5.0  # WHY: bound the shutdown wait so a stuck socket cannot hang the menu.
+
 
 class CLIShellManager:
     """Manage interactive CLI shell sessions for network devices.
@@ -165,11 +167,39 @@ class CLIShellManager:
             return  # Stop after a failed send.
 
     @staticmethod
-    def _shell_start_receiver(ws: Any, stream: Any, screen: Any, debug: bool) -> None:
-        """Start the background thread that reads WebSocket output and renders it into the terminal."""
-        threading.Thread(
-            target=functools.partial(CLIShellManager._shell_receive_loop, ws, stream, screen, debug)
-        ).start()  # functools.partial binds the shared session state to the thread target.
+    def _shell_start_receiver(ws: Any, stream: Any, screen: Any, debug: bool) -> threading.Thread:
+        """Start the background thread that reads WebSocket output and renders it into the terminal.
+
+        The thread is a daemon thread. A non-daemon thread blocks the interpreter
+        exit while it waits inside ``ws.recv()``. MistHelper then hangs after the
+        operator leaves the shell. The caller receives the thread so that it can
+        join the thread after it closes the socket.
+        """
+        logging.info("Starting the CLI shell receive thread")  # WHY: audit the thread start.
+        receiver = threading.Thread(  # WHY: the receive loop must not block the keyboard listener.
+            target=functools.partial(CLIShellManager._shell_receive_loop, ws, stream, screen, debug),
+            name="cli-shell-receiver",  # WHY: a named thread makes a stack dump readable.
+            daemon=True,  # WHY: a daemon thread never blocks the interpreter exit.
+        )
+        receiver.start()  # WHY: begin reading frames from the remote PTY.
+        logging.debug("CLI shell receive thread started (alive=%s)", receiver.is_alive())  # WHY: result summary.
+        return receiver  # WHY: the caller joins this thread during shutdown.
+
+    @staticmethod
+    def _shell_shutdown(ws: Any, receiver: threading.Thread) -> None:
+        """Close the WebSocket and join the receive thread after the shell session ends.
+
+        Without this cleanup each shell session leaks one open socket and one
+        live thread. A long NOC shift opens many sessions and the process then
+        reaches the open file limit.
+        """
+        logging.info("Closing the CLI shell WebSocket")  # WHY: audit before the close.
+        try:  # WHY: the socket may already be closed by the exit key handler.
+            ws.close()  # WHY: closing wakes the blocked recv() so the receive thread can end.
+        except Exception as close_error:  # noqa: BLE001 - cleanup must never mask the session outcome.
+            logging.debug("CLI shell WebSocket close failed: %s", close_error)  # WHY: trace only.
+        receiver.join(timeout=_RECEIVER_JOIN_TIMEOUT_SEC)  # WHY: bound the wait so a stuck socket cannot hang exit.
+        logging.debug("CLI shell shutdown done (receiver_alive=%s)", receiver.is_alive())  # WHY: result summary.
 
     @staticmethod
     def _run_interactive(shell_url: str, debug: bool = False) -> None:
@@ -187,14 +217,17 @@ class CLIShellManager:
         screen = pyte.Screen(80, 40)  # Virtual screen.
         stream = pyte.Stream(screen)  # Terminal stream.
         CLIShellManager._shell_resize_terminal(ws, debug)  # Send initial terminal dimensions to the remote PTY.
-        CLIShellManager._shell_start_receiver(ws, stream, screen, debug)  # Start the background receiver thread.
-        time.sleep(1)  # Wait for connect before waking the prompt.
-        ws.send_binary(bytes(map(ord, "\00\n\n")))  # Send a wakeup. Bytes (not bytearray) matches send_binary.
-        if debug:  # Debug mode.
-            logging.debug("[DEBUG] Sent wakeup sequence to Juniper SSRs")  # WHY: trace wakeup handshake (was print()).
-        mh.KeyboardListener().listen(  # Block on keyboard input, forwarding each key to the PTY.
-            on_release=functools.partial(CLIShellManager._shell_send_key, ws, debug),
-            delay_second_char=0,
-            delay_other_chars=0,
-            lower=False,
-        )
+        receiver = CLIShellManager._shell_start_receiver(ws, stream, screen, debug)  # Start the receive thread.
+        try:  # WHY: every exit path must close the socket and join the receive thread.
+            time.sleep(1)  # Wait for connect before waking the prompt.
+            ws.send_binary(bytes(map(ord, "\00\n\n")))  # Send a wakeup. Bytes (not bytearray) matches send_binary.
+            if debug:  # Debug mode.
+                logging.debug("[DEBUG] Sent wakeup sequence to Juniper SSRs")  # WHY: trace wakeup handshake.
+            mh.KeyboardListener().listen(  # Block on keyboard input, forwarding each key to the PTY.
+                on_release=functools.partial(CLIShellManager._shell_send_key, ws, debug),
+                delay_second_char=0,
+                delay_other_chars=0,
+                lower=False,
+            )
+        finally:  # WHY: a KeyboardInterrupt or a send failure must still release the socket and the thread.
+            CLIShellManager._shell_shutdown(ws, receiver)  # WHY: close the socket, then join the receive thread.

--- a/src/ssh/connection/connector.py
+++ b/src/ssh/connection/connector.py
@@ -103,6 +103,7 @@ class SshConnector:
         if client is None:  # WHY: build failure already logged + printed.
             return None, None  # WHY: propagate the sentinel to the caller.
         if not self._attempt_authenticated_connect(client, hostname, port, username, password):
+            self._release_client(client, hostname, port)  # WHY: a failed login leaves the transport thread alive.
             return None, None  # WHY: connect failure already logged + printed.
         self.logger.debug("SshConnector.connect succeeded for %s:%s", hostname, port)  # WHY: audit trail.
         return client, self.managed_known_hosts_path  # WHY: caller wires client into its runner state.
@@ -178,8 +179,25 @@ class SshConnector:
             self.logger.exception("TOFU enrollment failed for %s:%s: %s", hostname, port, enroll_error)  # WHY: audit.
             # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             self.logger.error("[ERROR] Host key enrollment failed: %s", enroll_error)
+            self._release_client(client, hostname, port)  # WHY: the client holds a socket that nothing else closes.
             return None  # WHY: caller treats None as a hard connection failure.
         return client  # WHY: client is ready to attempt authentication.
+
+    def _release_client(self, client: SSHClient, hostname: str, port: int) -> None:
+        """Close a paramiko client that the connect flow abandons after a failure.
+
+        Paramiko starts a transport thread and holds a socket inside
+        ``SSHClient.connect``. An authentication failure leaves both alive. Only
+        ``close()`` stops the thread and releases the socket. Without this call a
+        batch run against many hosts leaks one socket for each failed login.
+        """
+        self.logger.info("Releasing the abandoned SSH client for %s:%s", hostname, port)  # WHY: audit the cleanup.
+        try:  # WHY: close() raises when the transport never started, and that must not mask the real failure.
+            client.close()  # WHY: stop the paramiko transport thread and release the socket.
+        except Exception as close_error:  # noqa: BLE001 - cleanup must never replace the original connect failure.
+            self.logger.debug("SSH client close failed for %s:%s: %s", hostname, port, close_error)  # WHY: trace only.
+            return  # WHY: the client is unusable either way, so the caller needs no further signal.
+        self.logger.debug("SSH client closed for %s:%s", hostname, port)  # WHY: post-action result summary.
 
     # ------------------------------------------------------------------
     # Known-hosts management (all moved out of EnhancedSSHRunner)

--- a/tests/unit/capture/test_client_pcap_downloader.py
+++ b/tests/unit/capture/test_client_pcap_downloader.py
@@ -129,10 +129,12 @@ def test_download_one_writes_file_on_200(tmp_path: Path) -> None:
     response = MagicMock()
     response.status_code = 200
     response.iter_content.return_value = [b"AB", b"CD"]
+    response.__enter__.return_value = response  # WHY: the downloader now closes the body through a with block.
     with patch.object(mod.requests, "get", return_value=response):
         ok = ClientPacketCaptureDownloader._download_one(row, tmp_path)
     assert ok is True
     assert (tmp_path / "cap.pcap").read_bytes() == b"ABCD"
+    response.__exit__.assert_called_once()  # WHY: the streamed body must close on the success path too.
 
 
 def test_download_one_returns_false_on_non_200(tmp_path: Path) -> None:
@@ -140,10 +142,12 @@ def test_download_one_returns_false_on_non_200(tmp_path: Path) -> None:
     row = _CaptureRow("cap-1", "https://x/cap.pcap", "10", "cap.pcap")
     response = MagicMock()
     response.status_code = 404
+    response.__enter__.return_value = response  # WHY: the downloader now closes the body through a with block.
     with patch.object(mod.requests, "get", return_value=response):
         ok = ClientPacketCaptureDownloader._download_one(row, tmp_path)
     assert ok is False
     assert not (tmp_path / "cap.pcap").exists()
+    response.__exit__.assert_called_once()  # WHY: a non-200 reply must not leave the socket checked out.
 
 
 def test_download_one_returns_false_on_exception(tmp_path: Path) -> None:

--- a/tests/unit/prod_readiness/test_resource_cleanup_on_error_paths.py
+++ b/tests/unit/prod_readiness/test_resource_cleanup_on_error_paths.py
@@ -1,0 +1,176 @@
+"""Prove that four error paths release the resource that they opened.
+
+Each test drives one failure path and then asserts that the code closed the
+socket, the thread, or the HTTP body that the happy path would have closed.
+Before the fix each test fails, because the failure path dropped the handle.
+"""
+
+from __future__ import annotations
+
+import threading  # WHY: the CLI shell test inspects the receive thread state.
+import time  # WHY: the capture stream test measures the loop deadline.
+from typing import Any  # WHY: the fakes stand in for loosely typed SDK objects.
+
+import pytest  # WHY: fixtures plus the monkeypatch helper.
+
+from src.capture import _packet_capture_exec as capture_exec  # WHY: unit under test for the stream cap.
+from src.capture import client_pcap_downloader as pcap_dl  # WHY: unit under test for the streamed body.
+from src.ssh import cli_shell_manager as shell_mod  # WHY: unit under test for the receive thread.
+from src.ssh.connection import connector as connector_mod  # WHY: unit under test for the paramiko client.
+
+
+class _FakeSshClient:
+    """Record whether the connect flow closed this paramiko client stand-in."""
+
+    def __init__(self) -> None:
+        self.closed = False  # WHY: the assertion reads this flag.
+
+    def close(self) -> None:
+        """Mark the client closed the way paramiko releases its transport."""
+        self.closed = True  # WHY: record the cleanup call.
+
+    def set_missing_host_key_policy(self, _policy: Any) -> None:
+        """Accept the reject policy the way paramiko accepts it."""
+        return None  # WHY: the test needs no policy behaviour.
+
+    def get_host_keys(self) -> Any:
+        """Return an empty host key store, because the test never enrolls a key."""
+        return {}  # WHY: the enrollment path raises before it reads this store.
+
+
+def _build_connector(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Return an SshConnector whose preflight always passes."""
+    instance = connector_mod.SshConnector.__new__(connector_mod.SshConnector)  # WHY: skip the real constructor.
+    instance.logger = connector_mod.logging.getLogger("test-connector")  # WHY: the helpers log through this.
+    instance.managed_known_hosts_path = "known_hosts"  # WHY: the success path returns this value.
+    monkeypatch.setattr(instance, "_preflight", lambda *_args, **_kwargs: True)  # WHY: bypass input validation.
+    return instance  # WHY: the tests drive connect() on this object.
+
+
+def test_failed_authentication_closes_the_ssh_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed login must close the paramiko client, because the transport thread stays alive."""
+    connector = _build_connector(monkeypatch)  # WHY: an instance with a passing preflight.
+    fake_client = _FakeSshClient()  # WHY: stands in for the paramiko SSHClient.
+    monkeypatch.setattr(connector, "_build_client_with_tofu", lambda *_a, **_k: fake_client)  # WHY: skip TOFU.
+    monkeypatch.setattr(connector, "_attempt_authenticated_connect", lambda *_a, **_k: False)  # WHY: force failure.
+
+    client, kh_path = connector.connect("switch1.example.net", "noc", "wrong-password", 22)  # WHY: drive failure.
+
+    assert client is None  # WHY: the caller must still see the failure sentinel.
+    assert kh_path is None  # WHY: no known-hosts path is handed out on failure.
+    assert fake_client.closed is True  # WHY: the leak fix must close the abandoned client.
+
+
+def test_failed_host_key_enrollment_closes_the_ssh_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed host key enrollment must close the client that the builder created."""
+    connector = _build_connector(monkeypatch)  # WHY: an instance with a passing preflight.
+    fake_client = _FakeSshClient()  # WHY: the builder returns this object.
+    monkeypatch.setattr(connector_mod, "SSHClient", lambda: fake_client)  # WHY: intercept the client construction.
+    monkeypatch.setattr(connector, "_load_known_hosts", lambda _client: None)  # WHY: no real known-hosts file.
+
+    def _raise_enrollment_error(*_args: Any, **_kwargs: Any) -> None:
+        """Fail the way an unreachable host fails during the key fetch."""
+        raise OSError("host unreachable")  # WHY: the real failure raises from the socket layer.
+
+    monkeypatch.setattr(connector, "_trust_host_on_first_use", _raise_enrollment_error)  # WHY: force the error path.
+
+    result = connector._build_client_with_tofu("switch1.example.net", 22)  # WHY: drive the enrollment failure.
+
+    assert result is None  # WHY: the caller must still see the failure sentinel.
+    assert fake_client.closed is True  # WHY: the leak fix must close the abandoned client.
+
+
+class _FakeResponse:
+    """Record whether the downloader closed the streamed HTTP body."""
+
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code  # WHY: the downloader branches on this value.
+        self.closed = False  # WHY: the assertion reads this flag.
+
+    def __enter__(self) -> _FakeResponse:
+        """Support the context manager form that the fix uses."""
+        return self  # WHY: requests returns the response itself.
+
+    def __exit__(self, *_exc: Any) -> None:
+        """Close the body the way requests closes it on block exit."""
+        self.closed = True  # WHY: record the cleanup call.
+
+    def iter_content(self, chunk_size: int) -> list[bytes]:
+        """Return no chunks, because the failure test never reaches the write."""
+        assert chunk_size > 0  # nosec B101  # WHY: guard against a zero chunk size regression.
+        return []  # WHY: no body content is needed for this test.
+
+
+def test_non_200_pcap_download_closes_the_streamed_response(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    """A non-200 PCAP reply must close the streamed body, because the socket stays checked out."""
+    fake_response = _FakeResponse(status_code=404)  # WHY: the Mist pre-signed URL expired.
+    monkeypatch.setattr(pcap_dl.requests, "get", lambda *_a, **_k: fake_response)  # WHY: no real HTTP call.
+    row = pcap_dl._CaptureRow(  # WHY: the minimum row that the downloader reads.
+        capture_id="cap-1",
+        filename="cap-1.pcap",
+        vlan_id="10",
+        pcap_url="https://example.invalid/cap-1.pcap",
+    )
+
+    succeeded = pcap_dl.ClientPacketCaptureDownloader._download_one(row, tmp_path)  # WHY: drive the non-200 path.
+
+    assert succeeded is False  # WHY: the caller must still count this row as a failure.
+    assert fake_response.closed is True  # WHY: the leak fix must close the streamed body.
+
+
+class _StubWebSocketManager:
+    """A stream source that never sends the Mist end-of-capture signal."""
+
+    def __init__(self) -> None:
+        self.results_lock = threading.Lock()  # WHY: the drain helper takes this lock.
+        self.command_results: dict[str, Any] = {}  # WHY: an empty dict means no packets arrive.
+
+
+def test_capture_stream_stops_at_the_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The packet stream loop must stop at a deadline, because a dropped socket sends no end signal."""
+    executor = capture_exec.PacketCaptureExec.__new__(capture_exec.PacketCaptureExec)  # WHY: skip the constructor.
+    manager = type("_Manager", (), {"websocket_manager": _StubWebSocketManager()})()  # WHY: minimal parent stub.
+    executor._mm = manager  # WHY: the executor reads the manager through this attribute.
+    monkeypatch.setattr(capture_exec, "_STREAM_MAX_SECONDS", 0.3)  # WHY: shrink the cap so the test stays fast.
+
+    started = time.time()  # WHY: measure how long the bounded loop runs.
+    executor.read_stream_packets("/sites/s1/pcaps", "cap-1")  # WHY: drive the never-ending stream.
+    elapsed = time.time() - started  # WHY: the loop must return on its own.
+
+    assert elapsed < 5.0  # WHY: an unbounded loop never returns, so this bound proves the fix.
+
+
+def test_cli_shell_receiver_is_a_daemon_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI shell receive thread must be a daemon, because a blocked recv() blocks the interpreter exit."""
+    monkeypatch.setattr(  # WHY: replace the blocking receive loop with an immediate return.
+        shell_mod.CLIShellManager, "_shell_receive_loop", staticmethod(lambda *_a, **_k: None)
+    )
+
+    receiver = shell_mod.CLIShellManager._shell_start_receiver(object(), object(), object(), False)  # WHY: start it.
+
+    assert isinstance(receiver, threading.Thread)  # WHY: the caller needs the handle to join the thread.
+    assert receiver.daemon is True  # WHY: a non-daemon thread hangs the process exit.
+    receiver.join(timeout=5)  # WHY: keep the test suite free of a stray thread.
+
+
+class _FakeWebSocket:
+    """Record whether the shell shutdown closed the WebSocket."""
+
+    def __init__(self) -> None:
+        self.closed = False  # WHY: the assertion reads this flag.
+
+    def close(self) -> None:
+        """Close the socket the way the websocket library closes it."""
+        self.closed = True  # WHY: record the cleanup call.
+
+
+def test_cli_shell_shutdown_closes_the_websocket_and_joins_the_thread() -> None:
+    """The shell shutdown must close the socket and join the thread, because each session leaks one of each."""
+    fake_ws = _FakeWebSocket()  # WHY: stands in for the live WebSocket.
+    receiver = threading.Thread(target=lambda: None, daemon=True)  # WHY: a thread that ends at once.
+    receiver.start()  # WHY: the shutdown helper joins a started thread.
+
+    shell_mod.CLIShellManager._shell_shutdown(fake_ws, receiver)  # WHY: drive the cleanup path.
+
+    assert fake_ws.closed is True  # WHY: the leak fix must close the socket.
+    assert receiver.is_alive() is False  # WHY: the join must reap the receive thread.


### PR DESCRIPTION
## Summary

This pull request closes four runtime resource defects. Each defect opens a resource and then drops the handle on a failure path. A production readiness audit found all four.

Closes #1934
Closes #1935
Closes #1936
Closes #1937

## The four defects and the fix for each

### 1. A failed SSH login leaks the paramiko client (#1934)

`SshConnector.connect` dropped the `SSHClient` on two failure paths. Paramiko keeps a transport thread and a socket alive after an authentication failure. A batch run against 300 switches with a wrong password leaked 300 sockets and 300 threads.

The fix adds `_release_client`, and the connect flow calls it on both failure paths. The helper wraps `close()` in its own `try` block, because a close can raise when the transport never started, and that must not replace the real connect error.

### 2. The CLI shell receive thread hangs the interpreter (#1935)

`_shell_start_receiver` started a non-daemon thread, kept no reference to it, and never joined it. The thread blocks inside `ws.recv()`, so the interpreter could not exit. `_run_interactive` also never closed the WebSocket.

The fix starts a named daemon thread and returns the handle. `_run_interactive` now wraps the keyboard listener in `try` and `finally`. The `finally` block calls the new `_shell_shutdown`, which closes the socket first and then joins the thread with a five second cap. Closing the socket wakes the blocked read so the thread can end.

### 3. A failed PCAP download leaks the streamed body (#1936)

`_download_one` called `requests.get(stream=True)` and returned early on a non-200 reply. The library keeps the connection checked out of the pool until the body is read or closed. Each failed row leaked one socket.

The fix wraps the request in a `with` block. The block closes the body on the early return, on the exception, and on the success path.

### 4. The packet stream loop never times out (#1937)

`read_stream_packets` used `while True` with no cap. A dropped WebSocket never delivers the Mist end-of-capture signal, so the loop spun forever. An operator on the container SSH runner has no reliable way to send Ctrl-C.

The fix adds the `_STREAM_MAX_SECONDS` constant, set to one hour, and turns the loop condition into a wall-clock deadline check. A new `_report_stream_timeout` helper prints the packet count and logs a warning, so the operator learns why the stream stopped.

## Tests

`tests/unit/prod_readiness/test_resource_cleanup_on_error_paths.py` holds six tests, one for each fixed path.

I verified that each test proves the defect. On the base revision all six fail. After the fix all six pass.

I also updated two tests in `tests/unit/capture/test_client_pcap_downloader.py`. Both now assert that the streamed body closes.

## Verification

| Gate | Command | Result |
| - | - | - |
| Tests | `python -m pytest tests/unit/ssh tests/unit/capture tests/unit/prod_readiness tests/unit/test_packet_capture.py -q` | 508 passed |
| Lint | `python -m ruff check .` | All checks passed |
| Format | `python -m black <changed files>` | 6 files left unchanged |

One pre-existing failure is out of scope. `test_has_pyte_flag_reflects_import_state` fails because the `pyte` package is not installed in this environment. I confirmed that the same test fails on the base revision.

## Notes for the reviewer

- No change touches `MistHelper.py`.
- Every added line carries an inline comment that states the reason for the line.
- Each new operation logs at the `info` level before the action and at the `debug` level after it with a result summary.
- All log messages use ASCII characters only.
