### PR TITLE
test: raise coverage on six high-risk modules and fix a brittle test

### DIFF
--- a/tests/unit/capture/test_client_pcap_downloader_network_paths.py
+++ b/tests/unit/capture/test_client_pcap_downloader_network_paths.py
@@ -1,0 +1,427 @@
+"""Tests for the ClientPacketCaptureDownloader steps that reach the network.
+
+Why:
+    ``tests/unit/capture/test_client_pcap_downloader.py`` covers the pure
+    helpers, the single-file download, and the ``run`` guard chain. It does not
+    cover the two SDK fetch methods, the four step orchestrators, the batch
+    accumulator, or the offline guard. Those lines hold the Mist API calls, the
+    broad error handlers that keep the menu alive, and the directory creation
+    that precedes every write. This module covers them. Every Mist call and
+    every HTTP call is mocked, so no test reaches the live cloud.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.capture import client_pcap_downloader as cpd
+from src.capture.client_pcap_downloader import ClientPacketCaptureDownloader, _CaptureRow
+
+
+@pytest.fixture
+def downloader() -> ClientPacketCaptureDownloader:
+    """Return a downloader with a mock session and a fixed org identifier.
+
+    Why:
+        Passing the org identifier skips the lazy ``ConfigUtils`` lookup, which
+        would otherwise import MistHelper during construction.
+    """
+    # WHY: a mock session records the SDK arguments without opening a connection.
+    return ClientPacketCaptureDownloader(MagicMock(), org_id="org-1")
+
+
+@pytest.fixture
+def fake_mist_helper() -> Iterator[MagicMock]:
+    """Install a fake MistHelper module for the duration of one test.
+
+    Why:
+        The three lazy factories run ``import MistHelper``. A real import pulls
+        in the whole entry point, which is slow and has side effects. A stub in
+        ``sys.modules`` satisfies the import statement without that cost.
+    """
+    stub = MagicMock()  # WHY: stand in for the MistHelper entry point module.
+    original = sys.modules.get("MistHelper")  # WHY: remember any real module to restore later.
+    sys.modules["MistHelper"] = stub  # WHY: the import statement reads sys.modules first.
+    try:
+        yield stub  # WHY: hand the stub to the test so it can assert on the returned facade.
+    finally:
+        if original is None:  # WHY: no real module was loaded before this test.
+            sys.modules.pop("MistHelper", None)  # WHY: leave the module table as it was found.
+        else:
+            sys.modules["MistHelper"] = original  # WHY: restore the real module for other tests.
+
+
+class TestInit:
+    """Cover construction, which resolves the org identifier."""
+
+    def test_a_supplied_org_is_used_verbatim(self) -> None:
+        """A caller-supplied org must not trigger the cached lookup."""
+        with patch.object(cpd, "_get_config_utils") as config_factory:
+            instance = ClientPacketCaptureDownloader(MagicMock(), org_id="org-7")
+        config_factory.assert_not_called()  # WHY: an unattended run must not prompt.
+        assert instance._org_id == "org-7"  # WHY: the supplied value must survive construction.
+
+    def test_a_missing_org_falls_back_to_the_cached_lookup(self) -> None:
+        """An absent org must resolve through the shared cache, not fail."""
+        config_utils = MagicMock()  # WHY: stand in for the MistHelper ConfigUtils facade.
+        config_utils.get_cached_or_prompted_org_id.return_value = "org-cached"  # WHY: cached value.
+        with patch.object(cpd, "_get_config_utils", return_value=config_utils):
+            instance = ClientPacketCaptureDownloader(MagicMock())  # WHY: drive the fallback branch.
+        assert instance._org_id == "org-cached"  # WHY: the cached value must reach the instance.
+
+
+class TestFetchWirelessClients:
+    """Cover the client search call and its offline and error guards."""
+
+    def test_an_absent_sdk_returns_an_empty_list(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """Offline tooling must degrade to an abort, not an AttributeError."""
+        # WHY: the module sets this flag to False when the SDK import fails.
+        with patch.object(cpd, "MISTAPI_AVAILABLE", False):
+            assert downloader._fetch_wireless_clients("site-1") == []
+
+    def test_the_search_call_carries_the_window_and_the_page_limit(
+        self, downloader: ClientPacketCaptureDownloader
+    ) -> None:
+        """A missing window or limit would scan the wrong range or page too slowly."""
+        fake_sdk = MagicMock()  # WHY: stand in for the whole mistapi package.
+        fake_sdk.get_all.return_value = []  # WHY: the paging result is not under test here.
+        with patch.object(cpd, "mistapi", fake_sdk), patch.object(cpd, "MISTAPI_AVAILABLE", True):
+            downloader._fetch_wireless_clients("site-1")  # WHY: drive the search call.
+        search = fake_sdk.api.v1.sites.clients.searchSiteWirelessClients  # WHY: the call under test.
+        # WHY: the seven-day window and the page size are both part of the documented contract.
+        search.assert_called_once_with(downloader._session, "site-1", duration="7d", limit=1000)
+
+    def test_a_none_page_becomes_an_empty_list(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """The SDK returns None for an empty response, which callers must not index."""
+        fake_sdk = MagicMock()  # WHY: stand in for the whole mistapi package.
+        fake_sdk.get_all.return_value = None  # WHY: reproduce the SDK boundary case.
+        with patch.object(cpd, "mistapi", fake_sdk), patch.object(cpd, "MISTAPI_AVAILABLE", True):
+            assert downloader._fetch_wireless_clients("site-1") == []
+
+    def test_a_search_failure_returns_an_empty_list(
+        self, downloader: ClientPacketCaptureDownloader, caplog: Any
+    ) -> None:
+        """A network failure must abort the step, not crash the menu dispatcher."""
+        caplog.set_level("ERROR")  # WHY: the handler reports the failure at ERROR level.
+        fake_sdk = MagicMock()  # WHY: stand in for the whole mistapi package.
+        # WHY: the search call is the first network hop, so it fails on its own.
+        fake_sdk.api.v1.sites.clients.searchSiteWirelessClients.side_effect = RuntimeError("dns fail")
+        with patch.object(cpd, "mistapi", fake_sdk), patch.object(cpd, "MISTAPI_AVAILABLE", True):
+            assert downloader._fetch_wireless_clients("site-1") == []
+        assert "dns fail" in caplog.text  # WHY: the operator needs the cause to triage.
+
+    def test_a_paging_failure_returns_an_empty_list(
+        self, downloader: ClientPacketCaptureDownloader, caplog: Any
+    ) -> None:
+        """A failure inside ``get_all`` must reach the same handler as a call failure."""
+        caplog.set_level("ERROR")  # WHY: the handler reports the failure at ERROR level.
+        fake_sdk = MagicMock()  # WHY: stand in for the whole mistapi package.
+        # WHY: paging is a second network hop, so it fails independently of the search.
+        fake_sdk.get_all.side_effect = ValueError("truncated page")
+        with patch.object(cpd, "mistapi", fake_sdk), patch.object(cpd, "MISTAPI_AVAILABLE", True):
+            assert downloader._fetch_wireless_clients("site-1") == []
+        assert "truncated page" in caplog.text  # WHY: the paging failure must stay attributable.
+
+
+class TestFetchCaptures:
+    """Cover the capture listing call and its offline and error guards."""
+
+    def test_an_absent_sdk_returns_an_empty_list(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """Offline tooling must degrade to an abort, not an AttributeError."""
+        with patch.object(cpd, "MISTAPI_AVAILABLE", False):
+            assert downloader._fetch_captures("site-1", "aa:bb:cc:dd:ee:ff") == []
+
+    def test_the_mac_filter_is_sent_without_punctuation(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """Mist rejects a punctuated MAC in the query filter, so the colons must go."""
+        fake_sdk = MagicMock()  # WHY: stand in for the whole mistapi package.
+        fake_sdk.get_all.return_value = []  # WHY: the paging result is not under test here.
+        with patch.object(cpd, "mistapi", fake_sdk), patch.object(cpd, "MISTAPI_AVAILABLE", True):
+            downloader._fetch_captures("site-1", "aa:bb:cc:dd:ee:ff")  # WHY: drive the listing call.
+        _, kwargs = fake_sdk.api.v1.sites.pcaps.listSitePacketCaptures.call_args  # WHY: read the filter.
+        # WHY: a punctuated value would silently match nothing and look like an empty result.
+        assert kwargs["client_mac"] == "aabbccddeeff"
+
+    def test_a_listing_failure_returns_an_empty_list(
+        self, downloader: ClientPacketCaptureDownloader, caplog: Any
+    ) -> None:
+        """A network failure must abort the step, not crash the menu dispatcher."""
+        caplog.set_level("ERROR")  # WHY: the handler reports the failure at ERROR level.
+        fake_sdk = MagicMock()  # WHY: stand in for the whole mistapi package.
+        # WHY: the listing call is the first network hop, so it fails on its own.
+        fake_sdk.api.v1.sites.pcaps.listSitePacketCaptures.side_effect = RuntimeError("bad gateway")
+        with patch.object(cpd, "mistapi", fake_sdk), patch.object(cpd, "MISTAPI_AVAILABLE", True):
+            assert downloader._fetch_captures("site-1", "aa:bb:cc:dd:ee:ff") == []
+        assert "bad gateway" in caplog.text  # WHY: the operator needs the cause to triage.
+
+
+class TestStepOrchestrators:
+    """Cover the four step methods and their abort guards."""
+
+    def test_step_one_returns_none_when_no_site_is_chosen(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """A cancelled site prompt must abort the whole flow."""
+        prompt_utils = MagicMock()  # WHY: stand in for the MistHelper PromptUtils facade.
+        prompt_utils.select_site_with_logging.return_value = ""  # WHY: an empty pick cancels.
+        with patch.object(cpd, "_get_prompt_utils", return_value=prompt_utils):
+            assert downloader._step1_select_site() is None  # WHY: None signals abort.
+
+    def test_step_one_normalizes_the_chosen_site_to_a_string(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """The picker returns a loosely typed value that later steps use as a path segment."""
+        prompt_utils = MagicMock()  # WHY: stand in for the MistHelper PromptUtils facade.
+        prompt_utils.select_site_with_logging.return_value = 12345  # WHY: mimic a non-string pick.
+        with patch.object(cpd, "_get_prompt_utils", return_value=prompt_utils):
+            result = downloader._step1_select_site()  # WHY: drive the normalization branch.
+        assert result == "12345"  # WHY: a non-string would break the later URL interpolation.
+
+    def test_step_two_aborts_when_no_clients_are_returned(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """A site with no recent clients must abort before the prompt runs."""
+        with (
+            patch.object(downloader, "_fetch_wireless_clients", return_value=[]),
+            patch.object(downloader, "_prompt_client_choice") as prompt_spy,
+        ):
+            assert downloader._step2_select_client("site-1") is None  # WHY: None signals abort.
+        prompt_spy.assert_not_called()  # WHY: an empty table gives the operator nothing to pick.
+
+    def test_step_two_returns_the_resolved_mac(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """A valid pick must reach the caller as a normalized MAC."""
+        clients = [{"mac": "aabbccddeeff", "hostname": "laptop"}]  # WHY: one selectable row.
+        with (
+            patch.object(downloader, "_fetch_wireless_clients", return_value=clients),
+            patch.object(downloader, "_prompt_client_choice", return_value="aa:bb:cc:dd:ee:ff"),
+        ):
+            assert downloader._step2_select_client("site-1") == "aa:bb:cc:dd:ee:ff"
+
+    def test_step_three_aborts_when_no_captures_exist(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """A client with no captures must abort before the grouping runs."""
+        with (
+            patch.object(downloader, "_fetch_captures", return_value=[]),
+            patch.object(downloader, "_prompt_vlan_choice") as prompt_spy,
+        ):
+            assert downloader._step3_select_vlan("site-1", "aa:bb:cc:dd:ee:ff") == []
+        prompt_spy.assert_not_called()  # WHY: an empty table gives the operator nothing to pick.
+
+    def test_step_three_groups_before_prompting(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """The prompt must receive VLAN buckets, not the raw capture list."""
+        # WHY: two captures on one VLAN must collapse into a single bucket for the prompt.
+        captures = [
+            {"id": "c1", "pcap_url": "https://host/c1.pcap", "vlan_id": 10, "filename": "c1.pcap"},
+            {"id": "c2", "pcap_url": "https://host/c2.pcap", "vlan_id": 10, "filename": "c2.pcap"},
+        ]
+        with (
+            patch.object(downloader, "_fetch_captures", return_value=captures),
+            patch.object(downloader, "_prompt_vlan_choice", return_value=[]) as prompt_spy,
+        ):
+            downloader._step3_select_vlan("site-1", "aa:bb:cc:dd:ee:ff")  # WHY: drive the grouping.
+        grouped = prompt_spy.call_args[0][0]  # WHY: read the argument the prompt received.
+        assert list(grouped.keys()) == ["10"]  # WHY: one VLAN key, not two capture rows.
+        assert len(grouped["10"]) == 2  # WHY: both captures must land in the same bucket.
+
+    def test_step_four_creates_the_target_directory_before_downloading(
+        self, downloader: ClientPacketCaptureDownloader, tmp_path: Path
+    ) -> None:
+        """A download into a missing directory would fail, so the directory comes first."""
+        rows = [_CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap")]  # WHY: one row.
+        target = tmp_path / "packet_captures" / "aa_bb_cc_dd_ee_ff" / "vlan_10"  # WHY: expected path.
+        with (
+            # WHY: redirect the hard-coded data root so the test writes under tmp_path.
+            patch.object(cpd, "capture_dir", return_value=target),
+            patch.object(downloader, "_download_all", return_value=1) as download_spy,
+        ):
+            downloader._step4_download("aa:bb:cc:dd:ee:ff", rows)  # WHY: drive the directory creation.
+        assert target.is_dir()  # WHY: the writer needs the directory to exist before it opens a file.
+        download_spy.assert_called_once_with(rows, target)  # WHY: the batch must target that directory.
+
+    def test_step_four_is_safe_to_repeat(self, downloader: ClientPacketCaptureDownloader, tmp_path: Path) -> None:
+        """A repeat run must not fail on an existing directory."""
+        rows = [_CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap")]  # WHY: one row.
+        target = tmp_path / "vlan_10"  # WHY: a path the test creates ahead of time.
+        target.mkdir(parents=True)  # WHY: mimic the directory left by an earlier run.
+        with (
+            patch.object(cpd, "capture_dir", return_value=target),
+            patch.object(downloader, "_download_all", return_value=1),
+        ):
+            downloader._step4_download("aa:bb:cc:dd:ee:ff", rows)  # WHY: must not raise.
+        assert target.is_dir()  # WHY: the existing directory must survive the repeat run.
+
+
+class TestDownloadAll:
+    """Cover the batch accumulator, which must survive a partial failure."""
+
+    def test_the_count_matches_the_successful_writes(
+        self, downloader: ClientPacketCaptureDownloader, tmp_path: Path
+    ) -> None:
+        """A mixed batch must report only the files that reached the disk."""
+        rows = [
+            _CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap"),  # WHY: this one succeeds.
+            _CaptureRow("c2", "https://host/c2.pcap", "10", "c2.pcap"),  # WHY: this one fails.
+            _CaptureRow("c3", "https://host/c3.pcap", "10", "c3.pcap"),  # WHY: this one succeeds.
+        ]
+        # WHY: a per-row result list proves the accumulator counts, not the row total.
+        with patch.object(ClientPacketCaptureDownloader, "_download_one", side_effect=[True, False, True]):
+            assert downloader._download_all(rows, tmp_path) == 2
+
+    def test_a_failed_row_does_not_stop_the_batch(
+        self, downloader: ClientPacketCaptureDownloader, tmp_path: Path
+    ) -> None:
+        """One bad pre-signed URL must not abandon the remaining captures."""
+        rows = [
+            _CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap"),  # WHY: this one fails first.
+            _CaptureRow("c2", "https://host/c2.pcap", "10", "c2.pcap"),  # WHY: this one must still run.
+        ]
+        with patch.object(ClientPacketCaptureDownloader, "_download_one", side_effect=[False, True]) as download_spy:
+            downloader._download_all(rows, tmp_path)  # WHY: drive both rows.
+        assert download_spy.call_count == 2  # WHY: the loop must reach the second row.
+
+    def test_an_empty_batch_returns_zero(self, downloader: ClientPacketCaptureDownloader, tmp_path: Path) -> None:
+        """An empty batch must report zero, not raise on the accumulator."""
+        assert downloader._download_all([], tmp_path) == 0  # WHY: the loop body never runs.
+
+
+class TestDownloadOneResourceHandling:
+    """Cover the streaming write, which owns a file handle and an HTTP response."""
+
+    def test_the_request_streams_with_a_timeout(self, tmp_path: Path) -> None:
+        """A download without a timeout can hang the menu forever."""
+        response = MagicMock()  # WHY: stand in for the requests response object.
+        response.status_code = 200  # WHY: drive the success path to reach the write.
+        response.iter_content.return_value = [b"payload"]  # WHY: one chunk is enough.
+        row = _CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap")  # WHY: one row.
+        with patch.object(cpd.requests, "get", return_value=response) as get_spy:
+            assert ClientPacketCaptureDownloader._download_one(row, tmp_path) is True
+        _, kwargs = get_spy.call_args  # WHY: read the request keywords.
+        assert kwargs["stream"] is True  # WHY: a large PCAP must not load fully into memory.
+        assert kwargs["timeout"] == 300  # WHY: a hung transfer must eventually fail.
+
+    def test_a_non_200_response_leaves_no_partial_file(self, tmp_path: Path) -> None:
+        """A rejected download must not leave a zero-byte file that looks like a capture."""
+        response = MagicMock()  # WHY: stand in for the requests response object.
+        response.status_code = 403  # WHY: an expired pre-signed URL returns a client error.
+        row = _CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap")  # WHY: one row.
+        with patch.object(cpd.requests, "get", return_value=response):
+            assert ClientPacketCaptureDownloader._download_one(row, tmp_path) is False
+        # WHY: the guard returns before the open call, so no file may appear.
+        assert not (tmp_path / "c1.pcap").exists()
+
+    def test_every_chunk_reaches_the_file(self, tmp_path: Path) -> None:
+        """A dropped chunk would produce a truncated capture that looks valid."""
+        response = MagicMock()  # WHY: stand in for the requests response object.
+        response.status_code = 200  # WHY: drive the success path to reach the write.
+        response.iter_content.return_value = [b"aaa", b"bbb", b"ccc"]  # WHY: three chunks.
+        row = _CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap")  # WHY: one row.
+        with patch.object(cpd.requests, "get", return_value=response):
+            ClientPacketCaptureDownloader._download_one(row, tmp_path)  # WHY: drive the write loop.
+        # WHY: the concatenated chunks must match the payload byte for byte.
+        assert (tmp_path / "c1.pcap").read_bytes() == b"aaabbbccc"
+
+    def test_a_mid_stream_failure_is_reported_as_a_failure(self, tmp_path: Path, caplog: Any) -> None:
+        """A connection reset partway through must return False, not raise."""
+        caplog.set_level("ERROR")  # WHY: the handler reports the failure at ERROR level.
+        response = MagicMock()  # WHY: stand in for the requests response object.
+        response.status_code = 200  # WHY: the transfer starts before it fails.
+        # WHY: raising from the chunk iterator reproduces a reset partway through the body.
+        response.iter_content.side_effect = OSError("connection reset")
+        row = _CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap")  # WHY: one row.
+        with patch.object(cpd.requests, "get", return_value=response):
+            assert ClientPacketCaptureDownloader._download_one(row, tmp_path) is False
+        assert "connection reset" in caplog.text  # WHY: the operator needs the cause to triage.
+
+
+class TestLazyFactories:
+    """Cover the three deferred imports that break the capture-to-MistHelper cycle."""
+
+    def test_the_config_factory_returns_the_config_facade(self, fake_mist_helper: MagicMock) -> None:
+        """A wrong facade would break the cached org lookup at construction time."""
+        # WHY: identity proves the factory reaches through to the entry point attribute.
+        assert cpd._get_config_utils() is fake_mist_helper.ConfigUtils
+
+    def test_the_input_factory_returns_the_input_facade(self, fake_mist_helper: MagicMock) -> None:
+        """A wrong facade would lose the EOF-safe input wrapper the SSH mode needs."""
+        assert cpd._get_input_utils() is fake_mist_helper.InputUtils
+
+    def test_the_prompt_factory_returns_the_prompt_facade(self, fake_mist_helper: MagicMock) -> None:
+        """A wrong facade would break the site picker in step one."""
+        assert cpd._get_prompt_utils() is fake_mist_helper.PromptUtils
+
+
+class TestPromptClientChoice:
+    """Cover the client prompt, which accepts an index or a MAC."""
+
+    def test_a_blank_entry_cancels_the_step(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """A blank entry is the documented cancel signal, so it must return None."""
+        input_utils = MagicMock()  # WHY: stand in for the MistHelper InputUtils facade.
+        input_utils.safe_input.return_value = ""  # WHY: reproduce the blank cancel entry.
+        with patch.object(cpd, "_get_input_utils", return_value=input_utils):
+            assert downloader._prompt_client_choice([{"mac": "aabbccddeeff"}]) is None
+
+    def test_the_prompt_declares_its_menu_context(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """The context string attributes an EOF exit to the right menu in the log."""
+        input_utils = MagicMock()  # WHY: stand in for the MistHelper InputUtils facade.
+        input_utils.safe_input.return_value = ""  # WHY: cancel at once, the parse is tested elsewhere.
+        with patch.object(cpd, "_get_input_utils", return_value=input_utils):
+            downloader._prompt_client_choice([])  # WHY: drive the prompt call.
+        _, kwargs = input_utils.safe_input.call_args  # WHY: read the prompt keywords.
+        assert kwargs["context"] == "menu_197_client"  # WHY: the audit trail depends on this value.
+
+    def test_an_index_entry_reaches_the_resolver(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """A non-blank entry must pass through to the parse helper unchanged."""
+        clients = [{"mac": "aa:bb:cc:dd:ee:ff"}]  # WHY: one selectable row.
+        input_utils = MagicMock()  # WHY: stand in for the MistHelper InputUtils facade.
+        input_utils.safe_input.return_value = "1"  # WHY: pick the first row by index.
+        with patch.object(cpd, "_get_input_utils", return_value=input_utils):
+            result = downloader._prompt_client_choice(clients)  # WHY: drive the resolve branch.
+        assert result == "aa:bb:cc:dd:ee:ff"  # WHY: the resolver must return the normalized MAC.
+
+
+class TestPromptVlanChoice:
+    """Cover the VLAN prompt, which must abort when no capture has a URL."""
+
+    def test_an_empty_grouping_returns_no_rows(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """Captures that are still running have no URL, so the prompt must abort."""
+        input_utils = MagicMock()  # WHY: stand in for the MistHelper InputUtils facade.
+        with patch.object(cpd, "_get_input_utils", return_value=input_utils):
+            assert downloader._prompt_vlan_choice({}) == []
+        # WHY: prompting for a choice among zero rows would strand the operator.
+        input_utils.safe_input.assert_not_called()
+
+    def test_the_prompt_declares_its_menu_context(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """The context string attributes an EOF exit to the right menu in the log."""
+        grouped = {"10": [_CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap")]}  # WHY: one bucket.
+        input_utils = MagicMock()  # WHY: stand in for the MistHelper InputUtils facade.
+        input_utils.safe_input.return_value = ""  # WHY: cancel at once, the parse is tested elsewhere.
+        with patch.object(cpd, "_get_input_utils", return_value=input_utils):
+            downloader._prompt_vlan_choice(grouped)  # WHY: drive the prompt call.
+        _, kwargs = input_utils.safe_input.call_args  # WHY: read the prompt keywords.
+        assert kwargs["context"] == "menu_197_vlan"  # WHY: the audit trail depends on this value.
+
+    def test_the_resolver_sees_the_vlan_keys_in_sorted_order(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """An unsorted list would make the row numbers shift between runs."""
+        # WHY: an out-of-order dictionary proves the method sorts rather than relying on insertion.
+        grouped = {
+            "30": [_CaptureRow("c3", "https://host/c3.pcap", "30", "c3.pcap")],
+            "10": [_CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap")],
+            "20": [_CaptureRow("c2", "https://host/c2.pcap", "20", "c2.pcap")],
+        }
+        input_utils = MagicMock()  # WHY: stand in for the MistHelper InputUtils facade.
+        input_utils.safe_input.return_value = "1"  # WHY: pick the first row after sorting.
+        with patch.object(cpd, "_get_input_utils", return_value=input_utils):
+            rows = downloader._prompt_vlan_choice(grouped)  # WHY: drive the sort and the resolve.
+        assert [row.capture_id for row in rows] == ["c1"]  # WHY: VLAN 10 must rank first.
+
+    def test_a_valid_pick_returns_every_row_in_the_bucket(self, downloader: ClientPacketCaptureDownloader) -> None:
+        """Picking a VLAN downloads the whole bucket, not one capture."""
+        grouped = {
+            "10": [
+                _CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap"),  # WHY: first in bucket.
+                _CaptureRow("c2", "https://host/c2.pcap", "10", "c2.pcap"),  # WHY: second in bucket.
+            ]
+        }
+        input_utils = MagicMock()  # WHY: stand in for the MistHelper InputUtils facade.
+        input_utils.safe_input.return_value = "1"  # WHY: pick the only VLAN row.
+        with patch.object(cpd, "_get_input_utils", return_value=input_utils):
+            rows = downloader._prompt_vlan_choice(grouped)  # WHY: drive the resolve branch.
+        assert len(rows) == 2  # WHY: both captures on the VLAN must queue for download.

--- a/tests/unit/capture/test_client_pcap_downloader_network_paths.py
+++ b/tests/unit/capture/test_client_pcap_downloader_network_paths.py
@@ -282,13 +282,23 @@ class TestDownloadAll:
         assert downloader._download_all([], tmp_path) == 0  # WHY: the loop body never runs.
 
 
+def _streaming_response(status_code: int) -> MagicMock:
+    """Build a response mock that works as a plain object and as a context manager."""
+    response = MagicMock()  # WHY: stand in for the requests response object.
+    # WHY: the downloader wraps the request in a with block to release the connection.
+    # WHY: binding __enter__ to the same object keeps one place to set the attributes.
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False  # WHY: a False result never swallows an exception.
+    response.status_code = status_code  # WHY: the caller chooses the branch under test.
+    return response  # WHY: each test then sets its own body behavior.
+
+
 class TestDownloadOneResourceHandling:
     """Cover the streaming write, which owns a file handle and an HTTP response."""
 
     def test_the_request_streams_with_a_timeout(self, tmp_path: Path) -> None:
         """A download without a timeout can hang the menu forever."""
-        response = MagicMock()  # WHY: stand in for the requests response object.
-        response.status_code = 200  # WHY: drive the success path to reach the write.
+        response = _streaming_response(200)  # WHY: drive the success path to reach the write.
         response.iter_content.return_value = [b"payload"]  # WHY: one chunk is enough.
         row = _CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap")  # WHY: one row.
         with patch.object(cpd.requests, "get", return_value=response) as get_spy:
@@ -299,8 +309,7 @@ class TestDownloadOneResourceHandling:
 
     def test_a_non_200_response_leaves_no_partial_file(self, tmp_path: Path) -> None:
         """A rejected download must not leave a zero-byte file that looks like a capture."""
-        response = MagicMock()  # WHY: stand in for the requests response object.
-        response.status_code = 403  # WHY: an expired pre-signed URL returns a client error.
+        response = _streaming_response(403)  # WHY: an expired pre-signed URL returns a client error.
         row = _CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap")  # WHY: one row.
         with patch.object(cpd.requests, "get", return_value=response):
             assert ClientPacketCaptureDownloader._download_one(row, tmp_path) is False
@@ -309,8 +318,7 @@ class TestDownloadOneResourceHandling:
 
     def test_every_chunk_reaches_the_file(self, tmp_path: Path) -> None:
         """A dropped chunk would produce a truncated capture that looks valid."""
-        response = MagicMock()  # WHY: stand in for the requests response object.
-        response.status_code = 200  # WHY: drive the success path to reach the write.
+        response = _streaming_response(200)  # WHY: drive the success path to reach the write.
         response.iter_content.return_value = [b"aaa", b"bbb", b"ccc"]  # WHY: three chunks.
         row = _CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap")  # WHY: one row.
         with patch.object(cpd.requests, "get", return_value=response):
@@ -321,14 +329,33 @@ class TestDownloadOneResourceHandling:
     def test_a_mid_stream_failure_is_reported_as_a_failure(self, tmp_path: Path, caplog: Any) -> None:
         """A connection reset partway through must return False, not raise."""
         caplog.set_level("ERROR")  # WHY: the handler reports the failure at ERROR level.
-        response = MagicMock()  # WHY: stand in for the requests response object.
-        response.status_code = 200  # WHY: the transfer starts before it fails.
+        response = _streaming_response(200)  # WHY: the transfer starts before it fails.
         # WHY: raising from the chunk iterator reproduces a reset partway through the body.
         response.iter_content.side_effect = OSError("connection reset")
         row = _CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap")  # WHY: one row.
         with patch.object(cpd.requests, "get", return_value=response):
             assert ClientPacketCaptureDownloader._download_one(row, tmp_path) is False
         assert "connection reset" in caplog.text  # WHY: the operator needs the cause to triage.
+
+    def test_a_mid_stream_failure_still_releases_the_connection(self, tmp_path: Path) -> None:
+        """A leaked connection exhausts the pool and stalls a large batch."""
+        response = _streaming_response(200)  # WHY: the transfer starts before it fails.
+        response.iter_content.side_effect = OSError("connection reset")  # WHY: reset mid body.
+        row = _CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap")  # WHY: one row.
+        with patch.object(cpd.requests, "get", return_value=response):
+            ClientPacketCaptureDownloader._download_one(row, tmp_path)  # WHY: drive the failure.
+        # WHY: the with block must call __exit__ so the socket returns to the pool.
+        assert response.__exit__.called
+
+    def test_a_successful_download_releases_the_connection(self, tmp_path: Path) -> None:
+        """A connection held after a clean transfer still exhausts the pool."""
+        response = _streaming_response(200)  # WHY: drive the success path to reach the write.
+        response.iter_content.return_value = [b"payload"]  # WHY: one chunk is enough.
+        row = _CaptureRow("c1", "https://host/c1.pcap", "10", "c1.pcap")  # WHY: one row.
+        with patch.object(cpd.requests, "get", return_value=response):
+            assert ClientPacketCaptureDownloader._download_one(row, tmp_path) is True
+        assert response.__exit__.called  # WHY: the socket must return to the pool.
+        assert (tmp_path / "c1.pcap").read_bytes() == b"payload"  # WHY: prove the write ran.
 
 
 class TestLazyFactories:

--- a/tests/unit/export/test_count_exporter_workflows.py
+++ b/tests/unit/export/test_count_exporter_workflows.py
@@ -1,0 +1,236 @@
+"""Tests for the CountExporter workflow paths that reach the Mist API.
+
+Why:
+    ``tests/unit/export/test_count_exporter.py`` covers the operation table and
+    the selection prompt. It does not cover ``_run``, the three scope entry
+    points, or the MSP prompt. Those lines hold the API call, the error
+    handler, and the abort guards that keep the menu alive. This module covers
+    them. Every Mist call is mocked, so no test reaches the live cloud.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import mistapi
+import pytest
+
+from src.export.count_exporter import _MSP_OPS, _ORG_OPS, _SITE_OPS, CountExporter, _CountOp
+
+
+@pytest.fixture
+def fake_mh() -> Any:
+    """Return a MistHelper stand-in with every collaborator the exporter reads.
+
+    Why:
+        The exporter resolves ``apisession``, ``InputUtils``, ``ConfigUtils``,
+        ``SiteDeviceExporter``, and ``DataExporter`` through a lazy
+        ``importlib.import_module("MistHelper")`` call. One stub covers all of
+        them and records what the exporter wrote.
+    """
+    module = MagicMock()  # WHY: a MagicMock auto-creates each attribute the exporter reads.
+    module.apisession = MagicMock()  # WHY: the SDK call receives this as its first argument.
+    return module  # WHY: each test patches import_module to return this object.
+
+
+class TestRunErrorHandling:
+    """Cover ``_run``, which owns the SDK call and its error handler."""
+
+    def test_run_aborts_when_the_sdk_operation_is_missing(self, fake_mh: Any) -> None:
+        """An unresolvable operation must abort before any API call."""
+        # WHY: a module path that does not exist forces _resolve to return None.
+        missing = _CountOp("countNothing", "mistapi.api.v1.not_a_real_module")
+        with patch.object(importlib, "import_module", return_value=fake_mh):
+            CountExporter._run(missing, "org-1", "org-1")  # WHY: exercise the guard branch.
+        # WHY: the guard must return before the exporter writes anything.
+        fake_mh.DataExporter.write_with_format_selection.assert_not_called()
+
+    def test_run_passes_the_session_and_identifier_to_the_sdk(self, fake_mh: Any) -> None:
+        """Every count operation takes the session and one identifier positionally."""
+        sdk_callable = MagicMock(return_value={"result": []})  # WHY: stand in for the SDK function.
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(CountExporter, "_resolve", return_value=sdk_callable),
+            patch.object(mistapi, "get_all", return_value=[{"count": 2}]),
+        ):
+            CountExporter._run(_ORG_OPS[0], "org-1", "Org One")  # WHY: run the happy path.
+        # WHY: the contract is exactly two positional arguments, session first.
+        sdk_callable.assert_called_once_with(fake_mh.apisession, "org-1")
+
+    def test_run_builds_a_filename_from_the_operation_and_label(self, fake_mh: Any) -> None:
+        """A label with a space must not produce a filename with a space."""
+        sdk_callable = MagicMock(return_value={"result": []})  # WHY: stand in for the SDK function.
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(CountExporter, "_resolve", return_value=sdk_callable),
+            patch.object(mistapi, "get_all", return_value=[{"count": 2}]),
+        ):
+            CountExporter._run(_ORG_OPS[0], "org-1", "Head Office")  # WHY: label carries a space.
+        args, _ = fake_mh.DataExporter.write_with_format_selection.call_args  # WHY: read the filename.
+        # WHY: the exporter replaces each space so the path stays portable.
+        assert args[1] == f"{_ORG_OPS[0].operation}_Head_Office.csv"
+
+    def test_run_swallows_an_sdk_error_so_the_menu_survives(self, fake_mh: Any, caplog: Any) -> None:
+        """A network or SDK failure must be logged, not raised into the menu loop."""
+        caplog.set_level("ERROR")  # WHY: the handler reports the failure at ERROR level.
+        # WHY: raise from the SDK callable to drive the except branch.
+        sdk_callable = MagicMock(side_effect=RuntimeError("connection reset"))
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(CountExporter, "_resolve", return_value=sdk_callable),
+        ):
+            CountExporter._run(_ORG_OPS[0], "org-1", "Org One")  # WHY: must not raise.
+        # WHY: the operator needs the cause in the log to triage the failure.
+        assert "connection reset" in caplog.text
+
+    def test_run_swallows_a_paging_error(self, fake_mh: Any, caplog: Any) -> None:
+        """A failure inside ``get_all`` must reach the same handler as a call failure."""
+        caplog.set_level("ERROR")  # WHY: the handler reports the failure at ERROR level.
+        sdk_callable = MagicMock(return_value={"result": []})  # WHY: the first call succeeds.
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(CountExporter, "_resolve", return_value=sdk_callable),
+            # WHY: paging is a second network hop, so it fails independently of the call.
+            patch.object(mistapi, "get_all", side_effect=ValueError("bad page")),
+        ):
+            CountExporter._run(_ORG_OPS[0], "org-1", "Org One")  # WHY: must not raise.
+        # WHY: the paging failure must be attributed to the same operation.
+        assert "bad page" in caplog.text
+
+
+class TestOrgCounts:
+    """Cover ``org_counts``, the menu 235 entry point."""
+
+    def test_org_counts_returns_when_the_operator_declines_the_operation(self, fake_mh: Any) -> None:
+        """A declined operation must abort before the org prompt runs."""
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(CountExporter, "_choose", return_value=None),
+            patch.object(CountExporter, "_run") as run_spy,
+        ):
+            CountExporter.org_counts()  # WHY: drive the first guard branch.
+        run_spy.assert_not_called()  # WHY: no operation means no API call.
+        # WHY: the org resolver must not run once the operator has declined.
+        fake_mh.ConfigUtils.get_cached_or_prompted_org_id.assert_not_called()
+
+    def test_org_counts_returns_when_no_org_resolves(self, fake_mh: Any) -> None:
+        """An empty org identifier must abort before the API call."""
+        fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = ""  # WHY: empty means declined.
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(CountExporter, "_choose", return_value=_ORG_OPS[0]),
+            patch.object(CountExporter, "_run") as run_spy,
+        ):
+            CountExporter.org_counts()  # WHY: drive the empty-org guard.
+        run_spy.assert_not_called()  # WHY: the API path needs a real identifier.
+
+    def test_org_counts_runs_the_chosen_operation(self, fake_mh: Any) -> None:
+        """A resolved org must reach ``_run`` as both the identifier and the label."""
+        fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-42"  # WHY: resolved org.
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(CountExporter, "_choose", return_value=_ORG_OPS[0]),
+            patch.object(CountExporter, "_run") as run_spy,
+        ):
+            CountExporter.org_counts()  # WHY: drive the happy path.
+        # WHY: the org path has no friendly name, so the identifier doubles as the label.
+        run_spy.assert_called_once_with(_ORG_OPS[0], "org-42", "org-42")
+
+
+class TestSiteCounts:
+    """Cover ``site_counts``, the menu 236 entry point."""
+
+    def test_site_counts_returns_when_the_operator_declines_the_operation(self, fake_mh: Any) -> None:
+        """A declined operation must abort before the shared site resolver runs."""
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(CountExporter, "_choose", return_value=None),
+            patch.object(CountExporter, "_run") as run_spy,
+        ):
+            CountExporter.site_counts()  # WHY: drive the first guard branch.
+        run_spy.assert_not_called()  # WHY: no operation means no API call.
+        # WHY: the site resolver prompts the operator, so it must stay unused here.
+        fake_mh.SiteDeviceExporter._resolve_site_for_stats.assert_not_called()
+
+    def test_site_counts_returns_when_the_site_does_not_resolve(self, fake_mh: Any) -> None:
+        """A ``None`` from the shared site resolver must abort before the API call."""
+        fake_mh.SiteDeviceExporter._resolve_site_for_stats.return_value = None  # WHY: declined site.
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(CountExporter, "_choose", return_value=_SITE_OPS[0]),
+            patch.object(CountExporter, "_run") as run_spy,
+        ):
+            CountExporter.site_counts()  # WHY: drive the unresolved-site guard.
+        run_spy.assert_not_called()  # WHY: the API path needs a real site identifier.
+
+    def test_site_counts_passes_the_site_name_as_the_label(self, fake_mh: Any) -> None:
+        """The site name becomes the label, which shapes the output filename."""
+        # WHY: the shared resolver returns the identifier and the friendly name together.
+        fake_mh.SiteDeviceExporter._resolve_site_for_stats.return_value = ("site-7", "Branch Two")
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(CountExporter, "_choose", return_value=_SITE_OPS[0]),
+            patch.object(CountExporter, "_run") as run_spy,
+        ):
+            CountExporter.site_counts()  # WHY: drive the happy path.
+        # WHY: the site path has a friendly name, so the label differs from the identifier.
+        run_spy.assert_called_once_with(_SITE_OPS[0], "site-7", "Branch Two")
+
+
+class TestMspCounts:
+    """Cover ``msp_counts`` and ``_prompt_msp_id``, the menu 237 entry point."""
+
+    def test_msp_counts_returns_when_the_operator_declines_the_operation(self, fake_mh: Any) -> None:
+        """A declined operation must abort before the identifier prompt runs."""
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(CountExporter, "_choose", return_value=None),
+            patch.object(CountExporter, "_prompt_msp_id") as prompt_spy,
+            patch.object(CountExporter, "_run") as run_spy,
+        ):
+            CountExporter.msp_counts()  # WHY: drive the first guard branch.
+        prompt_spy.assert_not_called()  # WHY: no operation means no prompt.
+        run_spy.assert_not_called()  # WHY: no operation means no API call.
+
+    def test_msp_counts_returns_when_the_identifier_prompt_aborts(self, fake_mh: Any) -> None:
+        """A ``None`` identifier must abort before the API call."""
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(CountExporter, "_choose", return_value=_MSP_OPS[0]),
+            patch.object(CountExporter, "_prompt_msp_id", return_value=None),
+            patch.object(CountExporter, "_run") as run_spy,
+        ):
+            CountExporter.msp_counts()  # WHY: drive the declined-identifier guard.
+        run_spy.assert_not_called()  # WHY: the API path needs a real identifier.
+
+    def test_msp_counts_runs_the_chosen_operation(self, fake_mh: Any) -> None:
+        """A supplied identifier must reach ``_run`` as both the identifier and the label."""
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(CountExporter, "_choose", return_value=_MSP_OPS[0]),
+            patch.object(CountExporter, "_prompt_msp_id", return_value="msp-9"),
+            patch.object(CountExporter, "_run") as run_spy,
+        ):
+            CountExporter.msp_counts()  # WHY: drive the happy path.
+        # WHY: the MSP path has no friendly name, so the identifier doubles as the label.
+        run_spy.assert_called_once_with(_MSP_OPS[0], "msp-9", "msp-9")
+
+    def test_prompt_msp_id_returns_none_for_a_blank_answer(self, fake_mh: Any) -> None:
+        """A blank answer must abort, because the API path needs an identifier."""
+        fake_mh.InputUtils.safe_input.return_value = "   "  # WHY: whitespace collapses to empty.
+        with patch.object(importlib, "import_module", return_value=fake_mh):
+            assert CountExporter._prompt_msp_id() is None  # WHY: the guard must reject it.
+
+    def test_prompt_msp_id_trims_the_answer(self, fake_mh: Any) -> None:
+        """A pasted identifier keeps stray whitespace, so the prompt must trim it."""
+        fake_mh.InputUtils.safe_input.return_value = "  msp-9  "  # WHY: mimic a paste with padding.
+        with patch.object(importlib, "import_module", return_value=fake_mh):
+            assert CountExporter._prompt_msp_id() == "msp-9"  # WHY: trimmed value reaches the URL.
+
+    def test_prompt_msp_id_rejects_an_empty_answer(self, fake_mh: Any) -> None:
+        """An empty answer must not become part of an API path."""
+        fake_mh.InputUtils.safe_input.return_value = ""  # WHY: mimic an immediate Enter press.
+        with patch.object(importlib, "import_module", return_value=fake_mh):
+            assert CountExporter._prompt_msp_id() is None  # WHY: the guard must reject it.

--- a/tests/unit/export/test_site_webhook_deliveries_exporter.py
+++ b/tests/unit/export/test_site_webhook_deliveries_exporter.py
@@ -1,0 +1,250 @@
+"""Tests for SiteWebhookDeliveriesExporter, the menu 199 delivery-audit export.
+
+Why:
+    The module holds three risk areas that had no test. The webhook listing
+    reaches the Mist API. The selection guard indexes a list from operator
+    input. The export path wraps the search call in a broad error handler that
+    keeps the menu loop alive. This module covers all three. Every Mist call is
+    mocked, so no test reaches the live cloud.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import mistapi
+import pytest
+
+from src.export.site_webhook_deliveries_exporter import SiteWebhookDeliveriesExporter
+from src.utils.input_utils import InputUtils
+
+# WHY: two rows exercise both the in-range and the out-of-range selection guards.
+_WEBHOOKS: list[dict[str, Any]] = [
+    {"id": "wh-1", "name": "Alarms"},  # WHY: a normal row with both fields present.
+    {"id": "wh-2", "name": "Audit"},  # WHY: a second row makes index two valid.
+]
+
+
+@pytest.fixture
+def fake_mh() -> Any:
+    """Return a MistHelper stand-in with the collaborators the exporter reads.
+
+    Why:
+        The exporter resolves ``apisession``, ``SiteDeviceExporter``, and
+        ``DataExporter`` through a lazy ``importlib.import_module`` call. One
+        stub covers all three and records what the exporter wrote.
+    """
+    module = MagicMock()  # WHY: a MagicMock auto-creates each attribute the exporter reads.
+    module.apisession = MagicMock()  # WHY: the SDK calls receive this as their first argument.
+    return module  # WHY: each test patches import_module to return this object.
+
+
+class TestResolveWebhookChoice:
+    """Cover the selection guard, which converts operator input into a list index."""
+
+    def test_a_non_numeric_answer_is_rejected(self) -> None:
+        """A word must not reach ``int()``, which would raise into the menu loop."""
+        # WHY: the guard runs before any conversion, so no exception escapes.
+        assert SiteWebhookDeliveriesExporter._resolve_webhook_choice("first", _WEBHOOKS) is None
+
+    def test_an_empty_answer_is_rejected(self) -> None:
+        """An immediate Enter press must abort rather than select row one."""
+        # WHY: an empty string is not a digit, so the first guard catches it.
+        assert SiteWebhookDeliveriesExporter._resolve_webhook_choice("", _WEBHOOKS) is None
+
+    def test_zero_is_rejected(self) -> None:
+        """Index zero is the lower boundary and must not wrap to the last row."""
+        # WHY: Python would map index -1 to the last row, so the guard must reject zero.
+        assert SiteWebhookDeliveriesExporter._resolve_webhook_choice("0", _WEBHOOKS) is None
+
+    def test_one_past_the_end_is_rejected(self) -> None:
+        """The upper boundary must abort rather than raise IndexError."""
+        # WHY: the list holds two rows, so three is the first invalid selection.
+        assert SiteWebhookDeliveriesExporter._resolve_webhook_choice("3", _WEBHOOKS) is None
+
+    def test_the_first_row_resolves(self) -> None:
+        """The lowest valid selection maps to the zero-based first row."""
+        # WHY: the operator sees one-based numbering, so one must select index zero.
+        assert SiteWebhookDeliveriesExporter._resolve_webhook_choice("1", _WEBHOOKS) == ("wh-1", "Alarms")
+
+    def test_the_last_row_resolves(self) -> None:
+        """The highest valid selection maps to the final row."""
+        # WHY: the upper boundary must be inclusive, so two selects the second row.
+        assert SiteWebhookDeliveriesExporter._resolve_webhook_choice("2", _WEBHOOKS) == ("wh-2", "Audit")
+
+    def test_a_webhook_without_a_name_falls_back_to_its_identifier(self) -> None:
+        """A nameless webhook must still yield a label for the output filename."""
+        nameless = [{"id": "wh-3"}]  # WHY: the Mist API omits the name when it is unset.
+        # WHY: the identifier is the only stable label left, so the exporter reuses it.
+        assert SiteWebhookDeliveriesExporter._resolve_webhook_choice("1", nameless) == ("wh-3", "wh-3")
+
+    def test_a_webhook_without_an_identifier_yields_an_empty_string(self) -> None:
+        """A malformed row must not raise, because the caller logs and continues."""
+        malformed = [{"name": "Broken"}]  # WHY: mimic a row that lost its identifier.
+        # WHY: the exporter returns an empty identifier so the API call fails visibly.
+        assert SiteWebhookDeliveriesExporter._resolve_webhook_choice("1", malformed) == ("", "Broken")
+
+
+class TestSelectWebhookId:
+    """Cover the listing call and the empty-site guard."""
+
+    def test_a_site_without_webhooks_aborts(self, fake_mh: Any) -> None:
+        """A site with no webhooks has nothing to search, so the prompt must not run."""
+        with (
+            patch.object(mistapi, "get_all", return_value=[]),
+            patch.object(mistapi.api.v1.sites.webhooks, "listSiteWebhooks", return_value={"result": []}),
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(InputUtils, "safe_input") as prompt_spy,
+        ):
+            assert SiteWebhookDeliveriesExporter._select_webhook_id("site-1") is None
+        prompt_spy.assert_not_called()  # WHY: an empty list gives the operator nothing to pick.
+
+    def test_the_listing_call_receives_the_session_and_site(self, fake_mh: Any) -> None:
+        """The listing call must target the resolved site, not a cached one."""
+        with (
+            patch.object(mistapi, "get_all", return_value=_WEBHOOKS),
+            patch.object(mistapi.api.v1.sites.webhooks, "listSiteWebhooks", return_value={"result": []}) as list_spy,
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(InputUtils, "safe_input", return_value="1"),
+        ):
+            SiteWebhookDeliveriesExporter._select_webhook_id("site-1")  # WHY: drive the listing call.
+        # WHY: the contract is the session first and the site identifier second.
+        list_spy.assert_called_once_with(fake_mh.apisession, "site-1")
+
+    def test_a_valid_pick_returns_the_identifier_and_name(self, fake_mh: Any) -> None:
+        """A valid answer must flow through the guard to the caller unchanged."""
+        with (
+            patch.object(mistapi, "get_all", return_value=_WEBHOOKS),
+            patch.object(mistapi.api.v1.sites.webhooks, "listSiteWebhooks", return_value={"result": []}),
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(InputUtils, "safe_input", return_value="2"),
+        ):
+            result = SiteWebhookDeliveriesExporter._select_webhook_id("site-1")
+        assert result == ("wh-2", "Audit")  # WHY: the second row must reach the search call.
+
+
+class TestPersistSiteWebhookDeliveries:
+    """Cover the persistence path, including the empty-response branch."""
+
+    def test_an_empty_response_writes_nothing(self, fake_mh: Any) -> None:
+        """A webhook that never fired is legitimate and must not create a file."""
+        with patch.object(importlib, "import_module", return_value=fake_mh):
+            SiteWebhookDeliveriesExporter._persist_site_webhook_deliveries([], "Site", "Hook")
+        # WHY: a scheduled run must stay quiet rather than emit an empty file.
+        fake_mh.DataExporter.write_with_format_selection.assert_not_called()
+
+    def test_spaces_in_the_names_do_not_reach_the_filename(self, fake_mh: Any) -> None:
+        """A site or webhook name with a space must yield a portable filename."""
+        with patch.object(importlib, "import_module", return_value=fake_mh):
+            SiteWebhookDeliveriesExporter._persist_site_webhook_deliveries(
+                [{"status": 200}], "Head Office", "Alarm Hook"
+            )
+        args, _ = fake_mh.DataExporter.write_with_format_selection.call_args  # WHY: read the filename.
+        # WHY: the exporter replaces each space so the path stays portable across shells.
+        assert args[1] == "SiteWebhookDeliveries_Head_Office_Alarm_Hook.csv"
+
+    def test_the_operation_name_reaches_the_writer(self, fake_mh: Any) -> None:
+        """The operationId selects the primary key strategy, so it must reach the writer."""
+        with patch.object(importlib, "import_module", return_value=fake_mh):
+            SiteWebhookDeliveriesExporter._persist_site_webhook_deliveries([{"status": 200}], "Site", "Hook")
+        _, kwargs = fake_mh.DataExporter.write_with_format_selection.call_args  # WHY: read the keyword.
+        # WHY: a wrong name would pick the wrong primary key strategy and duplicate rows.
+        assert kwargs["api_function_name"] == "searchSiteWebhooksDeliveries"
+
+
+class TestDeliveries:
+    """Cover the menu entry point, its guards, and its error handler."""
+
+    def test_an_unresolved_site_aborts_before_the_webhook_prompt(self, fake_mh: Any) -> None:
+        """A declined site must abort before the exporter lists any webhook."""
+        fake_mh.SiteDeviceExporter._resolve_site_for_stats.return_value = None  # WHY: declined site.
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(SiteWebhookDeliveriesExporter, "_select_webhook_id") as select_spy,
+        ):
+            SiteWebhookDeliveriesExporter.deliveries()  # WHY: drive the first guard branch.
+        select_spy.assert_not_called()  # WHY: the listing call needs a site identifier.
+
+    def test_a_declined_webhook_aborts_before_the_search_call(self, fake_mh: Any) -> None:
+        """A declined webhook must abort before the delivery search runs."""
+        fake_mh.SiteDeviceExporter._resolve_site_for_stats.return_value = ("site-1", "Branch")
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(SiteWebhookDeliveriesExporter, "_select_webhook_id", return_value=None),
+            patch.object(mistapi.api.v1.sites.webhooks, "searchSiteWebhooksDeliveries") as search_spy,
+        ):
+            SiteWebhookDeliveriesExporter.deliveries()  # WHY: drive the second guard branch.
+        search_spy.assert_not_called()  # WHY: the search call needs a webhook identifier.
+
+    def test_the_search_call_receives_the_site_and_the_webhook(self, fake_mh: Any) -> None:
+        """The search must target the resolved site and the chosen webhook."""
+        fake_mh.SiteDeviceExporter._resolve_site_for_stats.return_value = ("site-1", "Branch")
+        with (
+            patch.object(mistapi, "get_all", return_value=[{"status": 200}]),
+            patch.object(
+                mistapi.api.v1.sites.webhooks,
+                "searchSiteWebhooksDeliveries",
+                return_value={"result": []},
+            ) as search_spy,
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(SiteWebhookDeliveriesExporter, "_select_webhook_id", return_value=("wh-2", "Audit")),
+            patch.object(SiteWebhookDeliveriesExporter, "_persist_site_webhook_deliveries"),
+        ):
+            SiteWebhookDeliveriesExporter.deliveries()  # WHY: drive the happy path.
+        # WHY: the contract is the session, then the site, then the webhook.
+        search_spy.assert_called_once_with(fake_mh.apisession, "site-1", "wh-2")
+
+    def test_the_site_and_webhook_names_reach_the_persist_call(self, fake_mh: Any) -> None:
+        """Both friendly names shape the filename, so both must survive the handoff."""
+        fake_mh.SiteDeviceExporter._resolve_site_for_stats.return_value = ("site-1", "Branch")
+        rows = [{"status": 200}]  # WHY: one row is enough to reach the persist call.
+        with (
+            patch.object(mistapi, "get_all", return_value=rows),
+            patch.object(
+                mistapi.api.v1.sites.webhooks,
+                "searchSiteWebhooksDeliveries",
+                return_value={"result": []},
+            ),
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(SiteWebhookDeliveriesExporter, "_select_webhook_id", return_value=("wh-2", "Audit")),
+            patch.object(SiteWebhookDeliveriesExporter, "_persist_site_webhook_deliveries") as persist_spy,
+        ):
+            SiteWebhookDeliveriesExporter.deliveries()  # WHY: drive the happy path.
+        # WHY: a lost name would produce a filename that the operator cannot attribute.
+        persist_spy.assert_called_once_with(rows, "Branch", "Audit")
+
+    def test_a_search_error_is_logged_and_not_raised(self, fake_mh: Any, caplog: Any) -> None:
+        """A network or SDK failure must be logged, not raised into the menu loop."""
+        caplog.set_level("ERROR")  # WHY: the handler reports the failure at ERROR level.
+        fake_mh.SiteDeviceExporter._resolve_site_for_stats.return_value = ("site-1", "Branch")
+        with (
+            patch.object(
+                mistapi.api.v1.sites.webhooks,
+                "searchSiteWebhooksDeliveries",
+                side_effect=RuntimeError("gateway timeout"),
+            ),
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(SiteWebhookDeliveriesExporter, "_select_webhook_id", return_value=("wh-2", "Audit")),
+        ):
+            SiteWebhookDeliveriesExporter.deliveries()  # WHY: must not raise.
+        assert "gateway timeout" in caplog.text  # WHY: the operator needs the cause to triage.
+
+    def test_a_paging_error_is_logged_and_not_raised(self, fake_mh: Any, caplog: Any) -> None:
+        """A failure inside ``get_all`` must reach the same handler as a call failure."""
+        caplog.set_level("ERROR")  # WHY: the handler reports the failure at ERROR level.
+        fake_mh.SiteDeviceExporter._resolve_site_for_stats.return_value = ("site-1", "Branch")
+        with (
+            # WHY: paging is a second network hop, so it fails independently of the call.
+            patch.object(mistapi, "get_all", side_effect=ValueError("truncated page")),
+            patch.object(
+                mistapi.api.v1.sites.webhooks,
+                "searchSiteWebhooksDeliveries",
+                return_value={"result": []},
+            ),
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(SiteWebhookDeliveriesExporter, "_select_webhook_id", return_value=("wh-2", "Audit")),
+        ):
+            SiteWebhookDeliveriesExporter.deliveries()  # WHY: must not raise.
+        assert "truncated page" in caplog.text  # WHY: the paging failure must stay attributable.

--- a/tests/unit/export/test_wan_client_events_exporter_paths.py
+++ b/tests/unit/export/test_wan_client_events_exporter_paths.py
@@ -1,0 +1,297 @@
+"""Tests for WanClientEventsExporter, the menu-wired WAN client events export.
+
+Why:
+    The exporter held four risk areas with no test. The top-level guard keeps a
+    failed fetch from crashing the menu loop. The site-name lookup opens a file
+    and must fall back when that file is corrupt or absent. The fetch must
+    normalize a ``None`` page into an empty list. The no-data path writes a real
+    sentinel file. This module covers all four. Every Mist call is mocked, so no
+    test reaches the live cloud.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.export.wan_client_events_exporter import (
+    _OUTPUT_CSV,
+    _PLACEHOLDER_HEADER,
+    _PLACEHOLDER_MESSAGE,
+    _SITE_LIST_CSV,
+    _UNKNOWN_SITE,
+    WanClientEventsExporter,
+    _SiteStamp,
+)
+
+
+def _build_exporter() -> WanClientEventsExporter:
+    """Return an exporter whose eight collaborators are all mocks.
+
+    Why:
+        The class takes every dependency by injection, so a test can drive each
+        branch without touching the network, the filesystem, or MistHelper.
+    """
+    return WanClientEventsExporter(  # WHY: each argument is a collaborator handle, not a value.
+        cache_utils=MagicMock(),  # WHY: seeds the SiteList cache before any prompt runs.
+        org_site_exporter=MagicMock(),  # WHY: supplies the org-scoped site collection to the cache.
+        prompt_utils=MagicMock(),  # WHY: owns the interactive site picker.
+        file_path_utils=MagicMock(),  # WHY: resolves canonical CSV paths under the data directory.
+        data_processing_utils=MagicMock(),  # WHY: flattens and escapes the vendor payload.
+        data_exporter=MagicMock(),  # WHY: persists the final rows through the chosen backend.
+        mistapi_module=MagicMock(),  # WHY: stands in for the vendor SDK entry points.
+        apisession=MagicMock(),  # WHY: the authenticated session each SDK call receives.
+    )
+
+
+@pytest.fixture
+def exporter() -> WanClientEventsExporter:
+    """Return a fresh exporter for one test.
+
+    Why:
+        The mocks record calls, so each test needs its own instance to keep the
+        assertions independent.
+    """
+    return _build_exporter()  # WHY: a new instance per test avoids shared call history.
+
+
+class TestEnsureSiteSelected:
+    """Cover site resolution, which decides whether the workflow continues."""
+
+    def test_a_supplied_site_skips_the_prompt(self, exporter: WanClientEventsExporter) -> None:
+        """A caller-supplied site must not trigger an interactive prompt."""
+        assert exporter._ensure_site_selected("site-1") == "site-1"  # WHY: value passes through.
+        # WHY: an unattended run must never block on a prompt it does not need.
+        exporter.prompt_utils.select_site_id_from_csv.assert_not_called()
+
+    def test_the_cache_is_seeded_before_any_resolution(self, exporter: WanClientEventsExporter) -> None:
+        """The SiteList cache is a precondition for both the picker and the lookup."""
+        exporter._ensure_site_selected("site-1")  # WHY: drive the precondition step.
+        # WHY: the cache call must name the canonical file and the site source.
+        exporter.cache_utils.check_and_generate_csv.assert_called_once_with(
+            _SITE_LIST_CSV, exporter.org_site_exporter.sites
+        )
+
+    def test_a_missing_site_triggers_the_prompt(self, exporter: WanClientEventsExporter) -> None:
+        """An absent site identifier must fall through to the interactive picker."""
+        exporter.prompt_utils.select_site_id_from_csv.return_value = "site-9"  # WHY: operator picks.
+        assert exporter._ensure_site_selected(None) == "site-9"  # WHY: the pick becomes the target.
+
+    def test_a_cancelled_prompt_returns_none(self, exporter: WanClientEventsExporter) -> None:
+        """A cancelled prompt must abort so the run writes no artifact."""
+        exporter.prompt_utils.select_site_id_from_csv.return_value = ""  # WHY: an empty pick cancels.
+        assert exporter._ensure_site_selected(None) is None  # WHY: None signals abort to the caller.
+
+
+class TestScanSiteListForName:
+    """Cover the CSV scan, which opens a real file handle."""
+
+    def test_a_matching_row_returns_its_name(self, tmp_path: Path) -> None:
+        """The scan must return the name of the row whose identifier matches."""
+        path = tmp_path / _SITE_LIST_CSV  # WHY: a real file exercises the open and the reader.
+        # WHY: two rows prove the scan selects by identifier and not by position.
+        path.write_text("id,name\nsite-1,Branch One\nsite-2,Branch Two\n", encoding="utf-8")
+        assert WanClientEventsExporter._scan_site_list_for_name(str(path), "site-2") == "Branch Two"
+
+    def test_a_missing_row_returns_the_fallback(self, tmp_path: Path) -> None:
+        """A site absent from the cache must still yield a stable label."""
+        path = tmp_path / _SITE_LIST_CSV  # WHY: a real file with no matching row.
+        path.write_text("id,name\nsite-1,Branch One\n", encoding="utf-8")  # WHY: no site-9 row.
+        # WHY: the fallback keeps the stamping stable when the cache is stale.
+        assert WanClientEventsExporter._scan_site_list_for_name(str(path), "site-9") == _UNKNOWN_SITE
+
+    def test_a_row_without_a_name_column_returns_the_fallback(self, tmp_path: Path) -> None:
+        """A cache written by an older release may lack the name column."""
+        path = tmp_path / _SITE_LIST_CSV  # WHY: a real file with a reduced header.
+        path.write_text("id,country_code\nsite-1,US\n", encoding="utf-8")  # WHY: name column absent.
+        # WHY: the reader yields None for the missing key, so the fallback must apply.
+        assert WanClientEventsExporter._scan_site_list_for_name(str(path), "site-1") == _UNKNOWN_SITE
+
+    def test_an_empty_file_returns_the_fallback(self, tmp_path: Path) -> None:
+        """An empty cache must not raise, because the export still has to run."""
+        path = tmp_path / _SITE_LIST_CSV  # WHY: a real but empty file.
+        path.write_text("", encoding="utf-8")  # WHY: mimic a truncated cache write.
+        # WHY: the reader yields no rows, so the scan falls through to the default.
+        assert WanClientEventsExporter._scan_site_list_for_name(str(path), "site-1") == _UNKNOWN_SITE
+
+
+class TestResolveSiteName:
+    """Cover the lookup wrapper, whose whole purpose is the fallback."""
+
+    def test_a_missing_cache_file_falls_back(self, exporter: WanClientEventsExporter, tmp_path: Path) -> None:
+        """A missing cache file must degrade to the fallback, not raise."""
+        missing = tmp_path / "absent.csv"  # WHY: a path that was never written.
+        exporter.file_path_utils.get_csv_path.return_value = str(missing)  # WHY: point at the gap.
+        # WHY: the exporter must produce output even when the cache is absent.
+        assert exporter._resolve_site_name("site-1") == _UNKNOWN_SITE
+
+    def test_a_path_lookup_failure_falls_back(self, exporter: WanClientEventsExporter) -> None:
+        """A failure inside the path helper must reach the same fallback."""
+        # WHY: the path helper touches the filesystem, so it can fail on its own.
+        exporter.file_path_utils.get_csv_path.side_effect = OSError("read-only volume")
+        assert exporter._resolve_site_name("site-1") == _UNKNOWN_SITE  # WHY: must not raise.
+
+    def test_a_resolved_name_is_returned(self, exporter: WanClientEventsExporter, tmp_path: Path) -> None:
+        """A healthy cache must yield the real name for the stamping step."""
+        path = tmp_path / _SITE_LIST_CSV  # WHY: a real file the scan can read.
+        path.write_text("id,name\nsite-1,Head Office\n", encoding="utf-8")  # WHY: one matching row.
+        exporter.file_path_utils.get_csv_path.return_value = str(path)  # WHY: point at the cache.
+        assert exporter._resolve_site_name("site-1") == "Head Office"  # WHY: the real name wins.
+
+
+class TestFetchEvents:
+    """Cover the fetch, which normalizes the vendor response."""
+
+    def test_the_endpoint_receives_the_session_and_the_page_limit(self, exporter: WanClientEventsExporter) -> None:
+        """The first-page call must carry the session, the site, and the page limit."""
+        endpoint = exporter.mistapi_module.api.v1.sites.wan_clients.searchSiteWanClientEvents
+        exporter.mistapi_module.get_all.return_value = []  # WHY: paging result is not under test here.
+        exporter._fetch_events("site-1")  # WHY: drive the first-page call.
+        # WHY: a missing limit would page one record at a time and hit the rate limiter.
+        endpoint.assert_called_once_with(exporter.apisession, "site-1", limit=1000)
+
+    def test_a_none_page_becomes_an_empty_list(self, exporter: WanClientEventsExporter) -> None:
+        """The SDK returns None for an empty response, which callers must not index."""
+        exporter.mistapi_module.get_all.return_value = None  # WHY: reproduce the SDK boundary case.
+        # WHY: the caller checks truthiness, so a None would work but an index would crash.
+        assert exporter._fetch_events("site-1") == []
+
+    def test_rows_pass_through_unchanged(self, exporter: WanClientEventsExporter) -> None:
+        """A populated page must reach the caller without loss."""
+        rows = [{"mac": "aa:bb"}, {"mac": "cc:dd"}]  # WHY: two rows prove nothing is dropped.
+        exporter.mistapi_module.get_all.return_value = rows  # WHY: mimic a full page.
+        assert exporter._fetch_events("site-1") == rows  # WHY: the fetch must not filter rows.
+
+
+class TestWriteNoDataPlaceholder:
+    """Cover the sentinel write, which creates a real file."""
+
+    def test_the_placeholder_carries_the_header_and_the_site(
+        self, exporter: WanClientEventsExporter, tmp_path: Path
+    ) -> None:
+        """Downstream readers expect a fixed schema plus the site that produced it."""
+        path = tmp_path / _OUTPUT_CSV  # WHY: a real path so the write is observable.
+        exporter.file_path_utils.get_csv_path.return_value = str(path)  # WHY: redirect the write.
+        exporter._write_no_data_placeholder(_SiteStamp("site-1", "Branch One"))  # WHY: drive the write.
+        with open(path, encoding="utf-8", newline="") as handle:  # WHY: read back what was written.
+            rows = list(csv.reader(handle))  # WHY: compare the exact rows, not a substring.
+        assert rows[0] == _PLACEHOLDER_HEADER  # WHY: the header must match the published schema.
+        # WHY: the body row lets an operator attribute the empty result to a site.
+        assert rows[1] == ["site-1", "Branch One", _PLACEHOLDER_MESSAGE]
+
+    def test_the_placeholder_overwrites_a_previous_run(self, exporter: WanClientEventsExporter, tmp_path: Path) -> None:
+        """A stale file from an earlier run must not leave orphan rows behind."""
+        path = tmp_path / _OUTPUT_CSV  # WHY: a real path that already holds data.
+        path.write_text("id,name\nold,row\nsecond,row\n", encoding="utf-8")  # WHY: seed stale content.
+        exporter.file_path_utils.get_csv_path.return_value = str(path)  # WHY: redirect the write.
+        exporter._write_no_data_placeholder(_SiteStamp("site-1", "Branch One"))  # WHY: drive the write.
+        with open(path, encoding="utf-8", newline="") as handle:  # WHY: read back what was written.
+            rows = list(csv.reader(handle))  # WHY: count the rows to prove truncation.
+        assert len(rows) == 2  # WHY: exactly the header plus the sentinel body row.
+
+
+class TestStampEvents:
+    """Cover the stamping step, which adds the join keys."""
+
+    def test_every_row_gets_both_identifiers(self) -> None:
+        """Downstream joins need the identifier, and operators need the name."""
+        events: list[dict[str, Any]] = [{"mac": "aa:bb"}, {"mac": "cc:dd"}]  # WHY: two raw rows.
+        stamped = WanClientEventsExporter._stamp_events(events, _SiteStamp("site-1", "Branch One"))
+        # WHY: a row without the identifier cannot join back to the site table.
+        assert all(row["site_id"] == "site-1" for row in stamped)
+        # WHY: a row without the name forces the operator into a second lookup.
+        assert all(row["site_name"] == "Branch One" for row in stamped)
+
+    def test_an_empty_list_stays_empty(self) -> None:
+        """An empty input must not raise, because the caller guards on truthiness."""
+        # WHY: the loop body never runs, so the function returns the same empty list.
+        assert WanClientEventsExporter._stamp_events([], _SiteStamp("site-1", "Branch One")) == []
+
+
+class TestFinalizeExport:
+    """Cover the finalize chain, which persists the run."""
+
+    def test_the_operation_name_reaches_the_writer(self, exporter: WanClientEventsExporter) -> None:
+        """The operationId selects the primary key strategy, so it must reach the writer."""
+        sanitized = [{"mac": "aa:bb", "site_id": "site-1"}]  # WHY: one sanitized row is enough.
+        exporter.data_processing_utils.flatten_nested_fields.return_value = sanitized
+        exporter.data_processing_utils.escape_multiline.return_value = sanitized
+        exporter._finalize_export([{"mac": "aa:bb"}])  # WHY: drive the full finalize chain.
+        _, kwargs = exporter.data_exporter.write_with_format_selection.call_args  # WHY: read the keyword.
+        # WHY: a wrong name would pick the wrong strategy and duplicate rows across runs.
+        assert kwargs["api_function_name"] == "searchSiteWanClientEvents"
+
+    def test_the_flatten_output_feeds_the_escape_step(self, exporter: WanClientEventsExporter) -> None:
+        """The two sanitize steps must run in order, not in parallel on raw rows."""
+        flattened = [{"mac": "aa:bb"}]  # WHY: the intermediate value under test.
+        exporter.data_processing_utils.flatten_nested_fields.return_value = flattened
+        exporter.data_processing_utils.escape_multiline.return_value = flattened
+        exporter._flatten_and_sanitize([{"mac": "aa:bb", "nested": {"a": 1}}])  # WHY: drive both steps.
+        # WHY: escaping raw rows would leave nested values unescaped in the output.
+        exporter.data_processing_utils.escape_multiline.assert_called_once_with(flattened)
+
+
+class TestExecute:
+    """Cover the public entry point, its abort guard, and its error handler."""
+
+    def test_a_cancelled_site_writes_nothing(self, exporter: WanClientEventsExporter) -> None:
+        """A cancelled site selection must abort before any API call."""
+        exporter.prompt_utils.select_site_id_from_csv.return_value = ""  # WHY: an empty pick cancels.
+        exporter.execute()  # WHY: drive the abort guard with no supplied site.
+        endpoint = exporter.mistapi_module.api.v1.sites.wan_clients.searchSiteWanClientEvents
+        endpoint.assert_not_called()  # WHY: no site means no endpoint to query.
+        # WHY: an aborted run must leave the output directory untouched.
+        exporter.data_exporter.write_with_format_selection.assert_not_called()
+
+    def test_an_empty_result_writes_the_placeholder_not_the_dataset(
+        self, exporter: WanClientEventsExporter, tmp_path: Path
+    ) -> None:
+        """An endpoint that returns nothing must produce the sentinel, not a data file."""
+        exporter.mistapi_module.get_all.return_value = []  # WHY: reproduce an empty response.
+        # WHY: both the name lookup and the placeholder write resolve through this helper.
+        exporter.file_path_utils.get_csv_path.return_value = str(tmp_path / _OUTPUT_CSV)
+        exporter.execute("site-1")  # WHY: drive the empty-result branch.
+        # WHY: the backend writer must stay unused so no empty dataset is persisted.
+        exporter.data_exporter.write_with_format_selection.assert_not_called()
+        assert (tmp_path / _OUTPUT_CSV).exists()  # WHY: the sentinel artifact must still appear.
+
+    def test_a_fetch_failure_is_logged_and_not_raised(self, exporter: WanClientEventsExporter, caplog: Any) -> None:
+        """A network or SDK failure must be logged, not raised into the menu loop."""
+        caplog.set_level("ERROR")  # WHY: the handler reports the failure at ERROR level.
+        endpoint = exporter.mistapi_module.api.v1.sites.wan_clients.searchSiteWanClientEvents
+        endpoint.side_effect = RuntimeError("gateway timeout")  # WHY: drive the except branch.
+        exporter.execute("site-1")  # WHY: must not raise.
+        assert "gateway timeout" in caplog.text  # WHY: the operator needs the cause to triage.
+
+    def test_a_write_failure_is_logged_and_not_raised(self, exporter: WanClientEventsExporter, caplog: Any) -> None:
+        """A backend write failure must reach the same guard as a fetch failure."""
+        caplog.set_level("ERROR")  # WHY: the handler reports the failure at ERROR level.
+        rows = [{"mac": "aa:bb"}]  # WHY: a non-empty result reaches the finalize stage.
+        exporter.mistapi_module.get_all.return_value = rows  # WHY: mimic a populated page.
+        exporter.data_processing_utils.flatten_nested_fields.return_value = rows
+        exporter.data_processing_utils.escape_multiline.return_value = rows
+        # WHY: a full disk or a locked database fails at the write, not at the fetch.
+        exporter.data_exporter.write_with_format_selection.side_effect = OSError("disk full")
+        exporter.execute("site-1")  # WHY: must not raise.
+        assert "disk full" in caplog.text  # WHY: the operator needs the cause to triage.
+
+    def test_a_successful_run_stamps_and_persists_the_rows(
+        self, exporter: WanClientEventsExporter, tmp_path: Path
+    ) -> None:
+        """The happy path must stamp the site onto each row before persisting it."""
+        path = tmp_path / _SITE_LIST_CSV  # WHY: a real cache so the real name resolves.
+        path.write_text("id,name\nsite-1,Head Office\n", encoding="utf-8")  # WHY: one matching row.
+        exporter.file_path_utils.get_csv_path.return_value = str(path)  # WHY: point at the cache.
+        rows = [{"mac": "aa:bb"}]  # WHY: one row is enough to observe the stamping.
+        exporter.mistapi_module.get_all.return_value = rows  # WHY: mimic a populated page.
+        exporter.data_processing_utils.flatten_nested_fields.return_value = rows
+        exporter.data_processing_utils.escape_multiline.return_value = rows
+        exporter.execute("site-1")  # WHY: drive the full happy path.
+        # WHY: the stamp runs before the flatten, so the flatten input carries both keys.
+        flattened_input = exporter.data_processing_utils.flatten_nested_fields.call_args[0][0]
+        assert flattened_input[0]["site_name"] == "Head Office"  # WHY: the real name must be stamped.
+        exporter.data_exporter.write_with_format_selection.assert_called_once()  # WHY: one write.

--- a/tests/unit/org/test_org_config_migration_conflicts.py
+++ b/tests/unit/org/test_org_config_migration_conflicts.py
@@ -1,0 +1,747 @@
+"""Tests for the org config migration conflict detection and the ID remapping.
+
+Why:
+    ``src/org/org_config_migration_manager.py`` drives menus 176 and 177. The
+    import path writes into a live org, so the conflict detection is the last
+    guard before a duplicate network or an overlapping subnet reaches the Mist
+    cloud. The ID remapping is the second guard, because a stale reference from
+    the source org points a gateway template at an object that does not exist
+    in the destination. This module covers both guards and the boundary cases
+    that a malformed bundle produces. No test reaches the Mist API.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.org import org_config_migration_manager as ocm
+from src.org.org_config_migration_manager import OrgConfigMigrationManager
+
+
+@pytest.fixture
+def manager() -> OrgConfigMigrationManager:
+    """Return a manager with mock collaborators and an empty cache.
+
+    Why:
+        The conflict checks and the remapping read only instance state. Mock
+        collaborators keep the constructor from reaching the network.
+    """
+    # WHY: the session, the org resolver, and the input wrapper stay unused here.
+    return OrgConfigMigrationManager(MagicMock(), MagicMock(), MagicMock())
+
+
+class TestNormalizedName:
+    """Cover the name reader that every name conflict check depends on."""
+
+    def test_a_name_is_lowercased(self) -> None:
+        """Mist treats two names that differ only in case as two objects."""
+        # WHY: a case-sensitive compare would let a near-duplicate through.
+        assert OrgConfigMigrationManager._normalized_name({"name": "Corp-LAN"}) == "corp-lan"
+
+    def test_a_missing_name_becomes_an_empty_string(self) -> None:
+        """A bundle can hold an unnamed object, and a None would raise on lower."""
+        assert OrgConfigMigrationManager._normalized_name({}) == ""
+
+    def test_a_null_name_becomes_an_empty_string(self) -> None:
+        """The Mist API returns a null name for a partially built object."""
+        assert OrgConfigMigrationManager._normalized_name({"name": None}) == ""
+
+
+class TestCheckNameConflict:
+    """Cover the first guard, which stops a duplicate name before the create call."""
+
+    def test_a_matching_name_is_reported(self, manager: OrgConfigMigrationManager) -> None:
+        """A duplicate name would fail the create call or shadow a live object."""
+        existing = [{"name": "Corp-LAN", "id": "dest-1"}]  # WHY: one object already in the org.
+        conflict = manager._check_name_conflict({"name": "Corp-LAN"}, existing)
+        assert conflict is not None  # WHY: the guard must report, not stay silent.
+        assert conflict["reason"] == "name_match"  # WHY: the report groups by this reason.
+
+    def test_the_match_ignores_the_case(self, manager: OrgConfigMigrationManager) -> None:
+        """A case-only difference is still a duplicate to the operator."""
+        existing = [{"name": "corp-lan", "id": "dest-1"}]  # WHY: the stored name is lowercase.
+        conflict = manager._check_name_conflict({"name": "CORP-LAN"}, existing)
+        assert conflict is not None  # WHY: the compare must fold the case.
+
+    def test_the_existing_identifier_is_preserved(self, manager: OrgConfigMigrationManager) -> None:
+        """The remap table needs the destination identifier to fix later references."""
+        existing = [{"name": "Corp-LAN", "id": "dest-1"}]  # WHY: one object already in the org.
+        conflict = manager._check_name_conflict({"name": "Corp-LAN"}, existing)
+        assert conflict is not None  # WHY: guard the index below.
+        # WHY: without this identifier a later VPN reference would keep the source value.
+        assert conflict["existing_id"] == "dest-1"
+
+    def test_a_unique_name_reports_no_conflict(self, manager: OrgConfigMigrationManager) -> None:
+        """A clean name must not be blocked, or the import stalls on every object."""
+        existing = [{"name": "Corp-LAN", "id": "dest-1"}]  # WHY: a different existing object.
+        assert manager._check_name_conflict({"name": "Guest-LAN"}, existing) is None
+
+    def test_an_unnamed_new_object_reports_no_conflict(self, manager: OrgConfigMigrationManager) -> None:
+        """An empty name would match every other unnamed object in the org."""
+        existing = [{"name": None, "id": "dest-1"}]  # WHY: an unnamed existing object.
+        assert manager._check_name_conflict({}, existing) is None
+
+    def test_an_empty_org_reports_no_conflict(self, manager: OrgConfigMigrationManager) -> None:
+        """A first import into a fresh org must not be blocked."""
+        assert manager._check_name_conflict({"name": "Corp-LAN"}, []) is None
+
+
+class TestCheckNetworkSubnetOverlap:
+    """Cover the subnet guard, which stops an overlapping route from reaching the org."""
+
+    def test_an_overlapping_subnet_is_reported(self, manager: OrgConfigMigrationManager) -> None:
+        """Two overlapping subnets create a routing ambiguity in the gateway."""
+        # WHY: the existing block contains the whole new block.
+        existing = [{"name": "Corp", "subnet": "10.0.0.0/16"}]
+        conflict = manager._check_network_subnet_overlap({"subnet": "10.0.1.0/24"}, existing)
+        assert conflict is not None  # WHY: the guard must report the overlap.
+        assert conflict["reason"] == "subnet_overlap"  # WHY: the report groups by this reason.
+
+    def test_an_adjacent_subnet_reports_no_conflict(self, manager: OrgConfigMigrationManager) -> None:
+        """Two touching blocks share no address, so they must both import.
+
+        Why:
+            This is the boundary case. An off-by-one in the overlap test would
+            block every legitimate adjacent network.
+        """
+        # WHY: 10.0.1.0/24 ends at 10.0.1.255 and 10.0.2.0/24 starts at 10.0.2.0.
+        existing = [{"name": "Corp", "subnet": "10.0.1.0/24"}]
+        assert manager._check_network_subnet_overlap({"subnet": "10.0.2.0/24"}, existing) is None
+
+    def test_an_identical_subnet_is_reported(self, manager: OrgConfigMigrationManager) -> None:
+        """An exact repeat is the most common real overlap."""
+        existing = [{"name": "Corp", "subnet": "10.0.1.0/24"}]  # WHY: the same block.
+        assert manager._check_network_subnet_overlap({"subnet": "10.0.1.0/24"}, existing) is not None
+
+    def test_a_new_supernet_is_reported(self, manager: OrgConfigMigrationManager) -> None:
+        """A wider new block that swallows an existing one is still an overlap."""
+        # WHY: the new block contains the existing block, which is the reverse direction.
+        existing = [{"name": "Corp", "subnet": "10.0.1.0/24"}]
+        assert manager._check_network_subnet_overlap({"subnet": "10.0.0.0/8"}, existing) is not None
+
+    def test_a_missing_new_subnet_reports_no_conflict(self, manager: OrgConfigMigrationManager) -> None:
+        """A network without a subnet has no address range to compare."""
+        existing = [{"name": "Corp", "subnet": "10.0.1.0/24"}]  # WHY: a valid existing block.
+        assert manager._check_network_subnet_overlap({"name": "No-Subnet"}, existing) is None
+
+    def test_an_invalid_new_subnet_reports_no_conflict(self, manager: OrgConfigMigrationManager) -> None:
+        """A malformed bundle value must not crash the whole import."""
+        existing = [{"name": "Corp", "subnet": "10.0.1.0/24"}]  # WHY: a valid existing block.
+        # WHY: a /99 prefix is out of range, so the parser raises ValueError.
+        assert manager._check_network_subnet_overlap({"subnet": "10.0.1.0/99"}, existing) is None
+
+    def test_host_bits_are_tolerated(self, manager: OrgConfigMigrationManager) -> None:
+        """Operators write a host address with a prefix, and strict parsing would reject it."""
+        existing = [{"name": "Corp", "subnet": "10.0.1.0/24"}]  # WHY: the same block, canonical.
+        # WHY: 10.0.1.5/24 has host bits set, which only a non-strict parse accepts.
+        assert manager._check_network_subnet_overlap({"subnet": "10.0.1.5/24"}, existing) is not None
+
+    def test_an_existing_entry_without_a_subnet_is_skipped(self, manager: OrgConfigMigrationManager) -> None:
+        """A partially built existing object must not stop the scan."""
+        # WHY: the first entry has no subnet, so the loop must reach the second.
+        existing = [{"name": "Empty"}, {"name": "Corp", "subnet": "10.0.1.0/24"}]
+        conflict = manager._check_network_subnet_overlap({"subnet": "10.0.1.0/24"}, existing)
+        assert conflict is not None  # WHY: the real overlap must still be found.
+
+    def test_an_invalid_existing_subnet_is_skipped(self, manager: OrgConfigMigrationManager) -> None:
+        """One corrupt existing record must not hide a real overlap behind it."""
+        # WHY: the first entry fails to parse, so the loop must reach the second.
+        existing = [{"name": "Bad", "subnet": "not-a-cidr"}, {"name": "Corp", "subnet": "10.0.1.0/24"}]
+        conflict = manager._check_network_subnet_overlap({"subnet": "10.0.1.0/24"}, existing)
+        assert conflict is not None  # WHY: the real overlap must still be found.
+
+    def test_the_detail_names_both_networks(self, manager: OrgConfigMigrationManager) -> None:
+        """The operator needs both names to decide which object to keep."""
+        existing = [{"name": "Corp", "subnet": "10.0.0.0/16"}]  # WHY: the blocking object.
+        conflict = manager._check_network_subnet_overlap({"subnet": "10.0.1.0/24"}, existing)
+        assert conflict is not None  # WHY: guard the index below.
+        assert "10.0.1.0/24" in conflict["detail"]  # WHY: the new block must be named.
+        assert "Corp" in conflict["detail"]  # WHY: the blocking object must be named.
+
+
+class TestCheckServiceAddressOverlap:
+    """Cover the address guard, which scans a list of addresses on both sides."""
+
+    def test_an_overlapping_address_is_reported(self, manager: OrgConfigMigrationManager) -> None:
+        """Two services that share an address create an ambiguous policy match."""
+        existing = [{"name": "Web", "addresses": ["10.0.0.0/16"]}]  # WHY: a wide existing block.
+        new_obj = {"addresses": ["10.0.1.5/32"]}  # WHY: a host inside that block.
+        conflict = manager._check_service_address_overlap(new_obj, existing)
+        assert conflict is not None  # WHY: the guard must report the overlap.
+        assert conflict["reason"] == "address_overlap"  # WHY: the report groups by this reason.
+
+    def test_an_empty_address_list_reports_no_conflict(self, manager: OrgConfigMigrationManager) -> None:
+        """A service defined by a port alone has no address to compare."""
+        existing = [{"name": "Web", "addresses": ["10.0.0.0/16"]}]  # WHY: a valid existing block.
+        assert manager._check_service_address_overlap({"addresses": []}, existing) is None
+
+    def test_a_missing_address_field_reports_no_conflict(self, manager: OrgConfigMigrationManager) -> None:
+        """A bundle can omit the field entirely, and a None would break the loop."""
+        existing = [{"name": "Web", "addresses": ["10.0.0.0/16"]}]  # WHY: a valid existing block.
+        assert manager._check_service_address_overlap({"name": "Ports-Only"}, existing) is None
+
+    def test_the_scan_reaches_every_new_address(self, manager: OrgConfigMigrationManager) -> None:
+        """Stopping at the first clean address would miss a later overlap."""
+        existing = [{"name": "Web", "addresses": ["192.168.5.0/24"]}]  # WHY: matches the third.
+        # WHY: only the third address overlaps, so the loop must reach it.
+        new_obj = {"addresses": ["10.0.0.0/24", "172.16.0.0/24", "192.168.5.10/32"]}
+        assert manager._check_service_address_overlap(new_obj, existing) is not None
+
+    def test_an_invalid_new_address_is_skipped(self, manager: OrgConfigMigrationManager) -> None:
+        """A hostname in an address field must not crash the whole import."""
+        existing = [{"name": "Web", "addresses": ["10.0.0.0/16"]}]  # WHY: a valid existing block.
+        # WHY: the first value fails to parse, so the loop must reach the second.
+        new_obj = {"addresses": ["not-an-ip", "10.0.1.5/32"]}
+        assert manager._check_service_address_overlap(new_obj, existing) is not None
+
+    def test_an_invalid_existing_address_is_skipped(self, manager: OrgConfigMigrationManager) -> None:
+        """One corrupt existing address must not hide a real overlap beside it."""
+        # WHY: the first existing address fails to parse, so the scan must continue.
+        existing = [{"name": "Web", "addresses": ["bad-value", "10.0.0.0/16"]}]
+        new_obj = {"addresses": ["10.0.1.5/32"]}  # WHY: a host inside the second block.
+        assert manager._check_service_address_overlap(new_obj, existing) is not None
+
+    def test_an_existing_service_without_addresses_is_skipped(self, manager: OrgConfigMigrationManager) -> None:
+        """A port-only existing service has nothing to compare against."""
+        existing = [{"name": "Ports-Only"}]  # WHY: no address field at all.
+        new_obj = {"addresses": ["10.0.1.5/32"]}  # WHY: a valid new address.
+        assert manager._check_service_address_overlap(new_obj, existing) is None
+
+    def test_the_detail_names_both_services(self, manager: OrgConfigMigrationManager) -> None:
+        """The operator needs both names to decide which object to keep."""
+        existing = [{"name": "Web", "addresses": ["10.0.0.0/16"]}]  # WHY: the blocking service.
+        conflict = manager._check_service_address_overlap({"addresses": ["10.0.1.5/32"]}, existing)
+        assert conflict is not None  # WHY: guard the index below.
+        assert "10.0.1.5/32" in conflict["detail"]  # WHY: the new address must be named.
+        assert "Web" in conflict["detail"]  # WHY: the blocking service must be named.
+
+
+class TestNeedsSubnetCheck:
+    """Cover the metadata lookup that gates the IP overlap scan."""
+
+    def test_networks_need_the_check(self, manager: OrgConfigMigrationManager) -> None:
+        """Networks carry a subnet, so an overlap is possible."""
+        assert manager._needs_subnet_check("networks") is True
+
+    def test_services_need_the_check(self, manager: OrgConfigMigrationManager) -> None:
+        """Services carry an address list, so an overlap is possible."""
+        assert manager._needs_subnet_check("services") is True
+
+    def test_vpns_do_not_need_the_check(self, manager: OrgConfigMigrationManager) -> None:
+        """A VPN holds no address field, so an IP scan would waste time."""
+        assert manager._needs_subnet_check("vpns") is False
+
+    def test_an_unknown_type_does_not_need_the_check(self, manager: OrgConfigMigrationManager) -> None:
+        """An unknown key must return False rather than raise on the lookup."""
+        assert manager._needs_subnet_check("no_such_type") is False
+
+
+class TestDetectConflicts:
+    """Cover the guard that runs the name check before the address check."""
+
+    def test_a_name_conflict_short_circuits_the_subnet_check(self, manager: OrgConfigMigrationManager) -> None:
+        """A named duplicate blocks the import, so an extra IP scan is wasted work."""
+        # WHY: the object matches by name and would also overlap by subnet.
+        manager._existing = {"networks": [{"name": "Corp", "subnet": "10.0.0.0/16", "id": "d1"}]}
+        conflict = manager._detect_conflicts({"name": "Corp", "subnet": "10.0.1.0/24"}, "networks")
+        assert conflict is not None  # WHY: guard the index below.
+        assert conflict["reason"] == "name_match"  # WHY: the name check must win the race.
+
+    def test_a_subnet_conflict_is_found_when_the_name_is_clean(self, manager: OrgConfigMigrationManager) -> None:
+        """A renamed object with the same range is the case the subnet guard exists for."""
+        # WHY: the names differ, so only the subnet scan can catch this one.
+        manager._existing = {"networks": [{"name": "Corp", "subnet": "10.0.0.0/16", "id": "d1"}]}
+        conflict = manager._detect_conflicts({"name": "Branch", "subnet": "10.0.1.0/24"}, "networks")
+        assert conflict is not None  # WHY: guard the index below.
+        assert conflict["reason"] == "subnet_overlap"  # WHY: the subnet guard must catch it.
+
+    def test_a_type_without_an_ip_field_skips_the_subnet_check(self, manager: OrgConfigMigrationManager) -> None:
+        """A VPN with a clean name must import without an IP scan."""
+        manager._existing = {"vpns": [{"name": "Hub", "id": "d1"}]}  # WHY: a different name.
+        assert manager._detect_conflicts({"name": "Spoke"}, "vpns") is None
+
+    def test_an_unseen_type_reports_no_conflict(self, manager: OrgConfigMigrationManager) -> None:
+        """A type the cache never loaded must not raise on the dictionary read."""
+        manager._existing = {}  # WHY: the cache is empty, as it is before the fetch.
+        assert manager._detect_conflicts({"name": "Corp"}, "networks") is None
+
+
+class TestStripSourceFields:
+    """Cover the field filter that prevents a source identifier from reaching the create call."""
+
+    def test_the_source_identifiers_are_removed(self, manager: OrgConfigMigrationManager) -> None:
+        """Sending a source identifier makes the create call fail or overwrite an object."""
+        obj = {
+            "id": "src-1",  # WHY: belongs to the source org.
+            "org_id": "src-org",  # WHY: belongs to the source org.
+            "created_time": 1,  # WHY: the destination sets its own timestamp.
+            "modified_time": 2,  # WHY: the destination sets its own timestamp.
+            "for_site": True,  # WHY: a site scope does not carry across orgs.
+            "name": "Corp-LAN",  # WHY: this field must survive.
+        }
+        assert manager._strip_source_fields(obj) == {"name": "Corp-LAN"}
+
+    def test_the_original_object_is_not_changed(self, manager: OrgConfigMigrationManager) -> None:
+        """The caller still needs the source identifier to build the remap entry."""
+        obj = {"id": "src-1", "name": "Corp-LAN"}  # WHY: the identifier must survive the call.
+        manager._strip_source_fields(obj)  # WHY: drive the filter.
+        assert obj["id"] == "src-1"  # WHY: an in-place delete would break the remap table.
+
+    def test_an_empty_object_stays_empty(self, manager: OrgConfigMigrationManager) -> None:
+        """An empty object must return cleanly rather than raise on the loop."""
+        assert manager._strip_source_fields({}) == {}
+
+
+class TestRemapping:
+    """Cover the reference repair that keeps a bundle self-consistent after import."""
+
+    def test_a_remap_entry_is_recorded(self, manager: OrgConfigMigrationManager) -> None:
+        """A missing entry leaves every later reference pointing at the source org."""
+        manager._build_remap_entry("source-object-id", "dest-object-id")  # WHY: drive the record.
+        assert manager._remap_table["source-object-id"] == "dest-object-id"
+
+    def test_a_vpn_network_identifier_is_swapped(self, manager: OrgConfigMigrationManager) -> None:
+        """A stale network identifier points the VPN at an object the org does not hold."""
+        manager._remap_table = {"src-net": "dest-net"}  # WHY: the mapping the import built.
+        obj: dict[str, Any] = {"networks": {"corp": {"id": "src-net"}}}  # WHY: one reference.
+        manager._remap_vpn_networks(obj)  # WHY: drive the swap.
+        assert obj["networks"]["corp"]["id"] == "dest-net"
+
+    def test_an_unmapped_vpn_identifier_is_left_alone(self, manager: OrgConfigMigrationManager) -> None:
+        """Blanking an unmapped reference would silently drop a network from the VPN."""
+        manager._remap_table = {}  # WHY: no mapping exists for this reference.
+        obj: dict[str, Any] = {"networks": {"corp": {"id": "src-net"}}}  # WHY: one reference.
+        manager._remap_vpn_networks(obj)  # WHY: drive the fallback branch.
+        assert obj["networks"]["corp"]["id"] == "src-net"  # WHY: the original must survive.
+
+    def test_a_vpn_entry_without_an_identifier_survives(self, manager: OrgConfigMigrationManager) -> None:
+        """Dropping an entry without an identifier would lose part of the VPN config."""
+        manager._remap_table = {"src-net": "dest-net"}  # WHY: the mapping the import built.
+        obj: dict[str, Any] = {"networks": {"corp": {"vlan_id": 10}}}  # WHY: no identifier.
+        manager._remap_vpn_networks(obj)  # WHY: drive the preserve branch.
+        assert obj["networks"]["corp"] == {"vlan_id": 10}  # WHY: the entry must survive intact.
+
+    def test_a_malformed_vpn_networks_value_is_ignored(self, manager: OrgConfigMigrationManager) -> None:
+        """A list where a dictionary belongs must not crash the whole import."""
+        obj: dict[str, Any] = {"networks": ["not-a-dict"]}  # WHY: reproduce the bad shape.
+        manager._remap_vpn_networks(obj)  # WHY: the call must return, not raise.
+        assert obj["networks"] == ["not-a-dict"]  # WHY: the guard must not rewrite the value.
+
+    def test_a_gateway_template_network_identifier_is_swapped(self, manager: OrgConfigMigrationManager) -> None:
+        """A gateway template references networks by identifier, same as a VPN."""
+        manager._remap_table = {"src-net": "dest-net"}  # WHY: the mapping the import built.
+        obj: dict[str, Any] = {"networks": {"corp": {"id": "src-net"}}}  # WHY: one reference.
+        manager._remap_gateway_template_refs(obj)  # WHY: drive the swap.
+        assert obj["networks"]["corp"]["id"] == "dest-net"
+
+    def test_a_malformed_gateway_template_value_is_ignored(self, manager: OrgConfigMigrationManager) -> None:
+        """A list where a dictionary belongs must not crash the whole import."""
+        obj: dict[str, Any] = {"networks": ["not-a-dict"]}  # WHY: reproduce the bad shape.
+        manager._remap_gateway_template_refs(obj)  # WHY: the call must return, not raise.
+        assert obj["networks"] == ["not-a-dict"]  # WHY: the guard must not rewrite the value.
+
+    def test_a_device_profile_template_identifier_is_swapped(self, manager: OrgConfigMigrationManager) -> None:
+        """A device profile points at one gateway template by identifier."""
+        manager._remap_table = {"src-tpl": "dest-tpl"}  # WHY: the mapping the import built.
+        obj: dict[str, Any] = {"gateway_template_id": "src-tpl"}  # WHY: one reference.
+        manager._remap_device_profile_refs(obj)  # WHY: drive the swap.
+        assert obj["gateway_template_id"] == "dest-tpl"
+
+    def test_an_unmapped_device_profile_identifier_is_left_alone(self, manager: OrgConfigMigrationManager) -> None:
+        """Blanking an unmapped reference would detach the profile from its template."""
+        manager._remap_table = {}  # WHY: no mapping exists for this reference.
+        obj: dict[str, Any] = {"gateway_template_id": "src-tpl"}  # WHY: one reference.
+        manager._remap_device_profile_refs(obj)  # WHY: drive the guard.
+        assert obj["gateway_template_id"] == "src-tpl"  # WHY: the original must survive.
+
+    def test_a_device_profile_without_a_template_is_untouched(self, manager: OrgConfigMigrationManager) -> None:
+        """A standalone profile has no template reference to repair."""
+        obj: dict[str, Any] = {"name": "Branch-GW"}  # WHY: no template reference.
+        manager._remap_device_profile_refs(obj)  # WHY: the call must return, not raise.
+        assert obj == {"name": "Branch-GW"}  # WHY: the guard must not add a key.
+
+    def test_a_service_policy_identifier_is_swapped(self, manager: OrgConfigMigrationManager) -> None:
+        """A service policy references services by identifier in a list."""
+        manager._remap_table = {"src-svc": "dest-svc"}  # WHY: the mapping the import built.
+        obj: dict[str, Any] = {"services": [{"id": "src-svc"}]}  # WHY: one reference.
+        manager._remap_service_policy_refs(obj)  # WHY: drive the swap.
+        assert obj["services"][0]["id"] == "dest-svc"
+
+    def test_every_service_policy_entry_is_visited(self, manager: OrgConfigMigrationManager) -> None:
+        """Stopping at the first entry would leave a later reference stale."""
+        manager._remap_table = {"a": "dest-a", "c": "dest-c"}  # WHY: the first and the third map.
+        # WHY: the middle entry has no mapping, so it proves the loop does not stop there.
+        obj: dict[str, Any] = {"services": [{"id": "a"}, {"id": "b"}, {"id": "c"}]}
+        manager._remap_service_policy_refs(obj)  # WHY: drive the whole loop.
+        assert [entry["id"] for entry in obj["services"]] == ["dest-a", "b", "dest-c"]
+
+    def test_a_malformed_service_policy_value_is_ignored(self, manager: OrgConfigMigrationManager) -> None:
+        """A dictionary where a list belongs must not crash the whole import."""
+        obj: dict[str, Any] = {"services": {"not": "a-list"}}  # WHY: reproduce the bad shape.
+        manager._remap_service_policy_refs(obj)  # WHY: the call must return, not raise.
+        assert obj["services"] == {"not": "a-list"}  # WHY: the guard must not rewrite the value.
+
+    def test_the_dispatcher_routes_each_type_to_its_repair(self, manager: OrgConfigMigrationManager) -> None:
+        """A wrong route would leave every reference of that type stale."""
+        manager._remap_table = {"src": "dest"}  # WHY: one mapping serves every case below.
+        # WHY: each pair holds the type key and the object shape that type uses.
+        cases = [
+            ("vpns", {"networks": {"n": {"id": "src"}}}),
+            ("gateway_templates", {"networks": {"n": {"id": "src"}}}),
+            ("service_policies", {"services": [{"id": "src"}]}),
+        ]
+        for type_key, obj in cases:  # WHY: one loop keeps the three routes in one assertion.
+            manager._remap_object_references(obj, type_key)  # WHY: drive the dispatcher.
+        assert cases[0][1]["networks"]["n"]["id"] == "dest"  # WHY: the VPN route must fire.
+        assert cases[1][1]["networks"]["n"]["id"] == "dest"  # WHY: the template route must fire.
+        assert cases[2][1]["services"][0]["id"] == "dest"  # WHY: the policy route must fire.
+
+    def test_the_dispatcher_returns_a_type_it_does_not_repair(self, manager: OrgConfigMigrationManager) -> None:
+        """A network holds no outward reference, so it passes through unchanged."""
+        obj: dict[str, Any] = {"name": "Corp-LAN", "subnet": "10.0.1.0/24"}  # WHY: no reference.
+        assert manager._remap_object_references(obj, "networks") is obj
+
+
+class TestResolveApiFn:
+    """Cover the dotted-path walker that turns a config entry into a callable."""
+
+    def test_a_dotted_path_resolves_to_the_endpoint(self, manager: OrgConfigMigrationManager) -> None:
+        """A wrong walk would call the wrong Mist endpoint against a live org."""
+        # WHY: the real SDK path proves the walk works against the shipped package.
+        resolved = manager._resolve_api_fn("mistapi.api.v1.orgs.networks.listOrgNetworks")
+        assert callable(resolved)  # WHY: the caller invokes the result directly.
+
+    def test_every_configured_list_path_resolves(self, manager: OrgConfigMigrationManager) -> None:
+        """A typo in one path breaks that type at run time, not at import time."""
+        for config_type in OrgConfigMigrationManager.CONFIG_TYPES:  # WHY: check all six types.
+            # WHY: a broken path raises AttributeError here rather than in a live import.
+            assert callable(manager._resolve_api_fn(str(config_type["list_fn"])))
+
+    def test_every_configured_create_path_resolves(self, manager: OrgConfigMigrationManager) -> None:
+        """A broken create path fails only after the operator confirms the import."""
+        for config_type in OrgConfigMigrationManager.CONFIG_TYPES:  # WHY: check all six types.
+            assert callable(manager._resolve_api_fn(str(config_type["create_fn"])))
+
+    def test_an_unknown_segment_raises(self, manager: OrgConfigMigrationManager) -> None:
+        """A silent None would fail later with a confusing not-callable error."""
+        with pytest.raises(AttributeError):  # WHY: fail fast at the resolve step.
+            manager._resolve_api_fn("mistapi.api.v1.orgs.networks.noSuchEndpoint")
+
+
+class TestExtractCreatedId:
+    """Cover the response reader that feeds the remap table."""
+
+    def test_an_identifier_is_read_from_the_data_dictionary(self, manager: OrgConfigMigrationManager) -> None:
+        """Without the new identifier every later reference stays stale."""
+        response = MagicMock()  # WHY: stand in for the SDK response wrapper.
+        response.data = {"id": "dest-1", "name": "Corp-LAN"}  # WHY: the documented shape.
+        assert manager._extract_created_id(response) == "dest-1"
+
+    def test_a_missing_identifier_returns_an_empty_string(self, manager: OrgConfigMigrationManager) -> None:
+        """A partial response must not raise inside the create loop."""
+        response = MagicMock()  # WHY: stand in for the SDK response wrapper.
+        response.data = {"name": "Corp-LAN"}  # WHY: the identifier is absent.
+        assert manager._extract_created_id(response) == ""
+
+    def test_a_list_payload_returns_an_empty_string(self, manager: OrgConfigMigrationManager) -> None:
+        """A list payload is the wrong shape, and indexing it would raise."""
+        response = MagicMock()  # WHY: stand in for the SDK response wrapper.
+        response.data = [{"id": "dest-1"}]  # WHY: reproduce the wrong shape.
+        assert manager._extract_created_id(response) == ""
+
+
+class TestExtractResponseData:
+    """Cover the payload reader that both the export and the conflict cache use."""
+
+    def test_a_list_payload_is_returned_directly(self, manager: OrgConfigMigrationManager) -> None:
+        """A direct list needs no paging call, which saves a round trip."""
+        response = MagicMock()  # WHY: stand in for the SDK response wrapper.
+        response.data = [{"id": "a"}, {"id": "b"}]  # WHY: the single-page shape.
+        assert manager._extract_response_data(response) == [{"id": "a"}, {"id": "b"}]
+
+    def test_a_paged_payload_goes_through_the_sdk_helper(self, manager: OrgConfigMigrationManager) -> None:
+        """A truncated first page would silently shrink the conflict cache."""
+        response = MagicMock()  # WHY: stand in for the SDK response wrapper.
+        response.data = {"results": []}  # WHY: a dictionary means the reply is paged.
+        with patch.object(ocm.mistapi, "get_all", return_value=[{"id": "a"}]) as paging_spy:
+            assert manager._extract_response_data(response) == [{"id": "a"}]
+        paging_spy.assert_called_once()  # WHY: the helper must follow the remaining pages.
+
+    def test_a_none_paging_result_becomes_an_empty_list(self, manager: OrgConfigMigrationManager) -> None:
+        """The SDK returns None for an empty reply, which callers must not index."""
+        response = MagicMock()  # WHY: stand in for the SDK response wrapper.
+        response.data = {"results": []}  # WHY: a dictionary means the reply is paged.
+        with patch.object(ocm.mistapi, "get_all", return_value=None):
+            assert manager._extract_response_data(response) == []
+
+
+class TestFetchConfigType:
+    """Cover the fetch that both the export and the conflict cache depend on."""
+
+    def test_the_call_carries_the_page_limit(self, manager: OrgConfigMigrationManager) -> None:
+        """A default page size would truncate a large org and hide a conflict."""
+        endpoint = MagicMock()  # WHY: stand in for the resolved SDK endpoint.
+        with (
+            patch.object(manager, "_resolve_api_fn", return_value=endpoint),
+            patch.object(manager, "_extract_response_data", return_value=[]),
+        ):
+            manager._fetch_config_type(dict(OrgConfigMigrationManager.CONFIG_TYPES[0]))
+        _, kwargs = endpoint.call_args  # WHY: read the endpoint keywords.
+        assert kwargs["limit"] == 1000  # WHY: the large page keeps the fetch to one round trip.
+
+    def test_the_configured_filter_reaches_the_call(self, manager: OrgConfigMigrationManager) -> None:
+        """Device profiles must be filtered to gateways, or the import pulls access points."""
+        endpoint = MagicMock()  # WHY: stand in for the resolved SDK endpoint.
+        # WHY: the device profile entry is the only one that declares extra keywords.
+        profile_type = next(ct for ct in OrgConfigMigrationManager.CONFIG_TYPES if ct["key"] == "device_profiles")
+        with (
+            patch.object(manager, "_resolve_api_fn", return_value=endpoint),
+            patch.object(manager, "_extract_response_data", return_value=[]),
+        ):
+            manager._fetch_config_type(dict(profile_type))
+        _, kwargs = endpoint.call_args  # WHY: read the endpoint keywords.
+        assert kwargs["type"] == "gateway"  # WHY: an unfiltered call returns the wrong profiles.
+
+    def test_a_failure_returns_an_empty_list(self, manager: OrgConfigMigrationManager, caplog: Any) -> None:
+        """One dead endpoint must not abandon the other five config types."""
+        caplog.set_level("ERROR")  # WHY: the handler reports the failure at ERROR level.
+        with patch.object(manager, "_resolve_api_fn", side_effect=RuntimeError("api down")):
+            assert manager._fetch_config_type(dict(OrgConfigMigrationManager.CONFIG_TYPES[0])) == []
+        assert "api down" in caplog.text  # WHY: the operator needs the cause to triage.
+
+
+class TestExecuteImport:
+    """Cover the import driver, which must respect the dependency order."""
+
+    def test_the_types_are_imported_in_dependency_order(self, manager: OrgConfigMigrationManager) -> None:
+        """A VPN created before its networks references an object that does not exist."""
+        # WHY: the bundle lists the dependent types first, so insertion order cannot win.
+        bundle = {
+            "device_profiles": [{"name": "P"}],  # WHY: import order 2.
+            "vpns": [{"name": "V"}],  # WHY: import order 1.
+            "networks": [{"name": "N"}],  # WHY: import order 0.
+        }
+        seen: list[str] = []  # WHY: record the order the batches actually ran in.
+        with patch.object(
+            manager,
+            "_import_type_batch",
+            side_effect=lambda ct, *_args: seen.append(str(ct["key"])),
+        ):
+            manager._execute_import(bundle, dry_run=True)
+        assert seen == ["networks", "vpns", "device_profiles"]  # WHY: order must follow the rank.
+
+    def test_an_empty_type_is_skipped(self, manager: OrgConfigMigrationManager) -> None:
+        """A batch call for zero objects prints a misleading empty heading."""
+        bundle = {"networks": [], "vpns": [{"name": "V"}]}  # WHY: one empty and one populated.
+        seen: list[str] = []  # WHY: record which batches actually ran.
+        with patch.object(
+            manager,
+            "_import_type_batch",
+            side_effect=lambda ct, *_args: seen.append(str(ct["key"])),
+        ):
+            manager._execute_import(bundle, dry_run=True)
+        assert seen == ["vpns"]  # WHY: the empty type must not produce a batch.
+
+    def test_an_empty_bundle_returns_no_results(self, manager: OrgConfigMigrationManager) -> None:
+        """A bundle with only metadata must return cleanly, not raise."""
+        assert manager._execute_import({"metadata": {}}, dry_run=True) == []
+
+
+class TestProcessImportObject:
+    """Cover the per-object decision, which is the last guard before a write."""
+
+    @staticmethod
+    def _network_type() -> dict[str, Any]:
+        """Return the networks config entry, which every test in this class uses.
+
+        Why:
+            Networks are the simplest type, because they hold no outward
+            reference that the remapping would rewrite.
+        """
+        # WHY: a copy keeps a test from mutating the shared class constant.
+        return dict(OrgConfigMigrationManager.CONFIG_TYPES[0])
+
+    def test_a_conflict_blocks_the_create_call(self, manager: OrgConfigMigrationManager) -> None:
+        """The conflict guard exists to stop a duplicate reaching the live org."""
+        manager._existing = {"networks": [{"name": "Corp", "id": "dest-1"}]}  # WHY: a duplicate.
+        results: list[dict[str, Any]] = []  # WHY: the accumulator the report reads.
+        with patch.object(manager, "_create_and_record") as create_spy:
+            manager._process_import_object(self._network_type(), {"name": "Corp", "id": "src-1"}, False, results)
+        create_spy.assert_not_called()  # WHY: a blocked object must never reach the API.
+        assert results[0]["status"] == "skipped"  # WHY: the report must show the skip.
+
+    def test_a_dry_run_never_calls_the_api(self, manager: OrgConfigMigrationManager) -> None:
+        """A preview that writes would defeat the whole purpose of the dry run."""
+        manager._existing = {"networks": []}  # WHY: no conflict blocks this object.
+        results: list[dict[str, Any]] = []  # WHY: the accumulator the report reads.
+        with patch.object(manager, "_create_and_record") as create_spy:
+            manager._process_import_object(self._network_type(), {"name": "Corp", "id": "src-1"}, True, results)
+        create_spy.assert_not_called()  # WHY: a dry run must make no write call.
+        assert results[0]["status"] == "would_import"  # WHY: the preview label must differ.
+
+    def test_a_clean_object_reaches_the_create_call(self, manager: OrgConfigMigrationManager) -> None:
+        """A clean object is the whole point of the import, so it must not be blocked."""
+        manager._existing = {"networks": []}  # WHY: no conflict blocks this object.
+        results: list[dict[str, Any]] = []  # WHY: the accumulator the report reads.
+        with patch.object(manager, "_create_and_record") as create_spy:
+            manager._process_import_object(self._network_type(), {"name": "Corp", "id": "src-1"}, False, results)
+        create_spy.assert_called_once()  # WHY: the object must reach the API.
+
+    def test_the_source_fields_are_stripped_before_the_create_call(self, manager: OrgConfigMigrationManager) -> None:
+        """A source identifier in the body makes the create call fail on the server."""
+        manager._existing = {"networks": []}  # WHY: no conflict blocks this object.
+        results: list[dict[str, Any]] = []  # WHY: the accumulator the report reads.
+        obj = {"name": "Corp", "id": "src-1", "org_id": "src-org"}  # WHY: two source fields.
+        with patch.object(manager, "_create_and_record") as create_spy:
+            manager._process_import_object(self._network_type(), obj, False, results)
+        cleaned = create_spy.call_args[0][1]  # WHY: read the body the create call received.
+        assert "id" not in cleaned  # WHY: the source identifier must not reach the server.
+        assert "org_id" not in cleaned  # WHY: the source org must not reach the server.
+
+    def test_an_unnamed_object_is_reported_under_a_placeholder(self, manager: OrgConfigMigrationManager) -> None:
+        """A blank line in the report tells the operator nothing."""
+        manager._existing = {"networks": []}  # WHY: no conflict blocks this object.
+        results: list[dict[str, Any]] = []  # WHY: the accumulator the report reads.
+        with patch.object(manager, "_create_and_record"):
+            manager._process_import_object(self._network_type(), {"id": "src-1"}, True, results)
+        assert results[0]["name"] == "unnamed"  # WHY: the placeholder keeps the row readable.
+
+
+class TestRecordConflict:
+    """Cover the skip record, which also seeds the remap table."""
+
+    def test_the_skip_is_recorded_with_its_reason(self, manager: OrgConfigMigrationManager) -> None:
+        """A skip without a reason leaves the operator unable to act on the report."""
+        results: list[dict[str, Any]] = []  # WHY: the accumulator the report reads.
+        conflict = {"detail": "already exists", "existing_id": "dest-1"}  # WHY: a name match.
+        manager._record_conflict("networks", "Corp", "src-1", conflict, results)
+        assert results[0]["status"] == "skipped"  # WHY: the report groups by status.
+        assert results[0]["reason"] == "already exists"  # WHY: the reason drives the fix.
+
+    def test_a_skipped_object_still_maps_to_the_existing_one(self, manager: OrgConfigMigrationManager) -> None:
+        """A later VPN must point at the object that is already in the destination.
+
+        Why:
+            Without this entry the VPN keeps the source identifier and breaks.
+        """
+        results: list[dict[str, Any]] = []  # WHY: the accumulator the report reads.
+        conflict = {"detail": "already exists", "existing_id": "dest-1"}  # WHY: a name match.
+        manager._record_conflict("networks", "Corp", "src-1", conflict, results)
+        assert manager._remap_table["src-1"] == "dest-1"  # WHY: the reference must be repairable.
+
+    def test_a_subnet_conflict_adds_no_mapping(self, manager: OrgConfigMigrationManager) -> None:
+        """A subnet overlap names no single existing object to map onto."""
+        results: list[dict[str, Any]] = []  # WHY: the accumulator the report reads.
+        conflict = {"detail": "10.0.1.0/24 overlaps"}  # WHY: no existing identifier is given.
+        manager._record_conflict("networks", "Corp", "src-1", conflict, results)
+        assert manager._remap_table == {}  # WHY: a guessed mapping would corrupt the import.
+
+
+class TestCreateAndRecord:
+    """Cover the single write call and the failure path that keeps the import alive."""
+
+    @staticmethod
+    def _network_type() -> dict[str, Any]:
+        """Return the networks config entry used by every test in this class."""
+        # WHY: a copy keeps a test from mutating the shared class constant.
+        return dict(OrgConfigMigrationManager.CONFIG_TYPES[0])
+
+    def test_the_body_is_sent_to_the_resolved_endpoint(self, manager: OrgConfigMigrationManager) -> None:
+        """A body sent positionally would land in the org identifier slot."""
+        endpoint = MagicMock()  # WHY: stand in for the resolved SDK endpoint.
+        endpoint.return_value.data = {"id": "dest-1"}  # WHY: the documented reply shape.
+        manager.org_id = "org-9"  # WHY: the destination org the write targets.
+        results: list[dict[str, Any]] = []  # WHY: the accumulator the report reads.
+        with patch.object(manager, "_resolve_api_fn", return_value=endpoint):
+            manager._create_and_record(self._network_type(), {"name": "Corp"}, "Corp", "src-1", results)
+        args, kwargs = endpoint.call_args  # WHY: read the call the endpoint received.
+        assert args[1] == "org-9"  # WHY: the destination org must be the second argument.
+        assert kwargs["body"] == {"name": "Corp"}  # WHY: the body must go by keyword.
+
+    def test_a_success_records_the_new_mapping(self, manager: OrgConfigMigrationManager) -> None:
+        """A later object references this one, so the new identifier must be stored."""
+        endpoint = MagicMock()  # WHY: stand in for the resolved SDK endpoint.
+        endpoint.return_value.data = {"id": "dest-1"}  # WHY: the documented reply shape.
+        results: list[dict[str, Any]] = []  # WHY: the accumulator the report reads.
+        with patch.object(manager, "_resolve_api_fn", return_value=endpoint):
+            manager._create_and_record(self._network_type(), {"name": "Corp"}, "Corp", "src-1", results)
+        assert manager._remap_table["src-1"] == "dest-1"  # WHY: the reference must be repairable.
+        assert results[0]["status"] == "imported"  # WHY: the report must show the success.
+
+    def test_a_response_without_an_identifier_adds_no_mapping(self, manager: OrgConfigMigrationManager) -> None:
+        """An empty mapping is safer than one that points at nothing."""
+        endpoint = MagicMock()  # WHY: stand in for the resolved SDK endpoint.
+        endpoint.return_value.data = {"name": "Corp"}  # WHY: the identifier is absent.
+        results: list[dict[str, Any]] = []  # WHY: the accumulator the report reads.
+        with patch.object(manager, "_resolve_api_fn", return_value=endpoint):
+            manager._create_and_record(self._network_type(), {"name": "Corp"}, "Corp", "src-1", results)
+        assert manager._remap_table == {}  # WHY: an empty target would blank a later reference.
+
+    def test_a_failure_is_recorded_and_not_raised(self, manager: OrgConfigMigrationManager, caplog: Any) -> None:
+        """One rejected object must not abandon the rest of the import batch."""
+        caplog.set_level("ERROR")  # WHY: the handler reports the failure at ERROR level.
+        results: list[dict[str, Any]] = []  # WHY: the accumulator the report reads.
+        with patch.object(manager, "_resolve_api_fn", side_effect=RuntimeError("400 bad body")):
+            manager._create_and_record(self._network_type(), {"name": "Corp"}, "Corp", "src-1", results)
+        assert results[0]["status"] == "failed"  # WHY: the report must show the failure.
+        assert results[0]["reason"] == "400 bad body"  # WHY: the reason drives the fix.
+        assert "400 bad body" in caplog.text  # WHY: the operator needs the cause to triage.
+
+    def test_a_failure_adds_no_mapping(self, manager: OrgConfigMigrationManager) -> None:
+        """A mapping to an object that was never created would corrupt every reference."""
+        endpoint = MagicMock()  # WHY: stand in for the resolved SDK endpoint.
+        endpoint.side_effect = RuntimeError("409 conflict")  # WHY: the server rejects the write.
+        results: list[dict[str, Any]] = []  # WHY: the accumulator the report reads.
+        with patch.object(manager, "_resolve_api_fn", return_value=endpoint):
+            manager._create_and_record(self._network_type(), {"name": "Corp"}, "Corp", "src-1", results)
+        assert manager._remap_table == {}  # WHY: no object exists, so no mapping may exist.
+
+
+class TestImportTypeBatch:
+    """Cover the batch loop, which must visit every object in the type."""
+
+    def test_every_object_is_processed(self, manager: OrgConfigMigrationManager) -> None:
+        """A dropped object would silently miss part of the migration."""
+        config_type = dict(OrgConfigMigrationManager.CONFIG_TYPES[0])  # WHY: the networks entry.
+        objects = [{"name": "A"}, {"name": "B"}, {"name": "C"}]  # WHY: three objects to import.
+        results: list[dict[str, Any]] = []  # WHY: the accumulator the report reads.
+        with patch.object(manager, "_process_import_object") as process_spy:
+            manager._import_type_batch(config_type, objects, True, results)
+        assert process_spy.call_count == 3  # WHY: the loop must reach every object.
+
+    def test_an_empty_batch_processes_nothing(self, manager: OrgConfigMigrationManager) -> None:
+        """An empty list must return cleanly rather than raise on the loop."""
+        config_type = dict(OrgConfigMigrationManager.CONFIG_TYPES[0])  # WHY: the networks entry.
+        results: list[dict[str, Any]] = []  # WHY: the accumulator the report reads.
+        with patch.object(manager, "_process_import_object") as process_spy:
+            manager._import_type_batch(config_type, [], True, results)
+        process_spy.assert_not_called()  # WHY: no object means no call.
+
+
+class TestPartitionImportResults:
+    """Cover the report grouping that the operator reads after an import."""
+
+    def test_each_status_lands_in_its_own_bucket(self, manager: OrgConfigMigrationManager) -> None:
+        """A mixed bucket would hide a failure among the successes."""
+        # WHY: one row of each status proves the grouping separates all four.
+        results = [
+            {"type": "networks", "name": "A", "status": "imported"},
+            {"type": "networks", "name": "B", "status": "skipped", "reason": "dup"},
+            {"type": "networks", "name": "C", "status": "failed", "reason": "400"},
+            {"type": "networks", "name": "D", "status": "would_import"},
+        ]
+        buckets = manager._partition_import_results(results)  # WHY: drive the grouping.
+        # WHY: each bucket must hold exactly the one row that carries its status.
+        assert len(buckets["imported"]) == 1
+        assert len(buckets["skipped"]) == 1
+        assert len(buckets["failed"]) == 1
+        assert len(buckets["would_import"]) == 1
+
+    def test_an_empty_result_list_yields_empty_buckets(self, manager: OrgConfigMigrationManager) -> None:
+        """A dry run over an empty bundle must not raise on the report."""
+        buckets = manager._partition_import_results([])  # WHY: drive the empty path.
+        # WHY: every bucket must exist so the printer can read it without a guard.
+        assert all(not rows for rows in buckets.values())

--- a/tests/unit/ssh/test_cli_shell_manager.py
+++ b/tests/unit/ssh/test_cli_shell_manager.py
@@ -63,10 +63,25 @@ class TestModuleLevelPyteImport:
     """Cover the module-level ``try/except ImportError`` around pyte."""
 
     def test_has_pyte_flag_reflects_import_state(self):
-        """The ``_has_pyte`` flag mirrors whether the ``pyte`` import succeeded."""
-        # Under the normal test environment pyte is installed and _has_pyte is True.
-        assert csm_module._has_pyte is True
-        assert csm_module.pyte is not None
+        """The ``_has_pyte`` flag mirrors whether the ``pyte`` import succeeded.
+
+        Why:
+            The ``pyte`` package is an optional dependency. The module wraps the
+            import in ``try/except ImportError`` and degrades to a warning. A
+            fixed ``assert _has_pyte is True`` asserts the machine, not the code,
+            so it fails on any checkout without the package. This asserts the
+            invariant between the flag and the real import state instead.
+        """
+        try:  # WHY: reproduce the exact import the module performs at load time.
+            import pyte as real_pyte  # noqa: F401  # WHY: presence is the fact under test.
+
+            pyte_is_importable = True  # WHY: the import succeeded, so the flag must be True.
+        except ImportError:  # WHY: the optional package is absent on this machine.
+            pyte_is_importable = False  # WHY: the flag must be False and the alias must be None.
+        # WHY: the flag must agree with the real import state in both directions.
+        assert csm_module._has_pyte is pyte_is_importable
+        # WHY: the module sets the alias to None only on the ImportError path.
+        assert (csm_module.pyte is not None) is pyte_is_importable
 
     def test_import_falls_back_when_pyte_missing(self, monkeypatch):
         """Load the module into an isolated namespace with ``pyte`` blocked to exercise the ImportError branch."""

--- a/tests/unit/utils/test_zscaler_probe_transport.py
+++ b/tests/unit/utils/test_zscaler_probe_transport.py
@@ -1,0 +1,631 @@
+"""Tests for the Zscaler probe transport helpers and the parallel probe runner.
+
+Why:
+    ``src/utils/zscaler_probe.py`` opens sockets, runs a subprocess, wraps a
+    TLS session, and fans probes out across a thread pool. Every one of those
+    paths owns a resource that must close on both the success path and the
+    failure path. A leak here strands a socket or a worker thread for the whole
+    session. This module covers those transport helpers and the runner. Every
+    socket, every TLS context, and every subprocess is mocked, so no test
+    reaches the network.
+"""
+
+from __future__ import annotations
+
+import socket
+import ssl
+import subprocess
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.utils import zscaler_probe as zp
+from src.utils.zscaler_probe import ProbeResult
+
+
+def _make_result(**overrides: Any) -> ProbeResult:
+    """Return a ProbeResult with the required fields filled in.
+
+    Why:
+        The dataclass has five required fields. Repeating them in every test
+        would hide the one field each test actually cares about.
+    """
+    # WHY: the defaults describe a plain non-critical host with no declared ports.
+    base: dict[str, Any] = {
+        "fqdn": "gateway.zscaler.net",
+        "role": "zen",
+        "role_description": "Zscaler enforcement node",
+        "declared_ports": [],
+        "critical": False,
+    }
+    base.update(overrides)  # WHY: let each test override only the field under test.
+    return ProbeResult(**base)
+
+
+class TestResolve:
+    """Cover DNS resolution, which must report a failure rather than raise."""
+
+    def test_a_successful_lookup_returns_the_address(self) -> None:
+        """A caller needs the address to decide whether any probe can run."""
+        with patch.object(socket, "gethostbyname", return_value="10.0.0.1"):
+            assert zp._resolve("gateway.zscaler.net") == ("10.0.0.1", None)
+
+    def test_a_failed_lookup_returns_the_reason(self) -> None:
+        """The report separates a dead name from a live but unreachable host."""
+        # WHY: gaierror is the exact type the resolver raises for an unknown name.
+        with patch.object(socket, "gethostbyname", side_effect=socket.gaierror("no such host")):
+            ip, error = zp._resolve("nope.invalid")
+        assert ip is None  # WHY: no address means no downstream probe can run.
+        assert error is not None  # WHY: the reason must survive for the summary.
+        assert "gaierror" in error  # WHY: the class name tells the operator it was DNS.
+
+    def test_a_failure_does_not_raise(self) -> None:
+        """A raised error inside a worker thread would abort the whole fan-out."""
+        with patch.object(socket, "gethostbyname", side_effect=OSError("network down")):
+            zp._resolve("gateway.zscaler.net")  # WHY: the call must return, not raise.
+
+
+class TestIcmpPing:
+    """Cover the ping subprocess, including the platform flag switch."""
+
+    def test_windows_uses_millisecond_timeout_flags(self) -> None:
+        """The Windows ping binary reads the timeout in milliseconds, not seconds."""
+        completed = MagicMock(returncode=0)  # WHY: a zero exit means the host answered.
+        with (
+            patch.object(zp.platform, "system", return_value="Windows"),
+            patch.object(subprocess, "run", return_value=completed) as run_spy,
+        ):
+            assert zp._icmp_ping("10.0.0.1", 3.0) is True
+        cmd = run_spy.call_args[0][0]  # WHY: read the argument vector that was built.
+        assert cmd[1] == "-n"  # WHY: Windows spells the count flag "-n".
+        assert cmd[3] == "-w"  # WHY: Windows spells the timeout flag "-w".
+        assert cmd[4] == "3000"  # WHY: three seconds must become three thousand milliseconds.
+
+    def test_posix_uses_second_timeout_flags(self) -> None:
+        """The POSIX ping binary reads the timeout in whole seconds."""
+        completed = MagicMock(returncode=0)  # WHY: a zero exit means the host answered.
+        with (
+            patch.object(zp.platform, "system", return_value="Linux"),
+            patch.object(subprocess, "run", return_value=completed) as run_spy,
+        ):
+            zp._icmp_ping("10.0.0.1", 3.0)  # WHY: drive the POSIX branch.
+        cmd = run_spy.call_args[0][0]  # WHY: read the argument vector that was built.
+        assert cmd[1] == "-c"  # WHY: POSIX spells the count flag "-c".
+        assert cmd[3] == "-W"  # WHY: POSIX spells the timeout flag with a capital "W".
+        assert cmd[4] == "3"  # WHY: three seconds must stay three, not become three thousand.
+
+    def test_the_shell_is_never_used(self) -> None:
+        """A shell would let a hostname from the catalogue start a program."""
+        completed = MagicMock(returncode=0)  # WHY: the exit code is not under test here.
+        with (
+            patch.object(zp.platform, "system", return_value="Linux"),
+            patch.object(subprocess, "run", return_value=completed) as run_spy,
+        ):
+            zp._icmp_ping("10.0.0.1", 3.0)  # WHY: drive the subprocess call.
+        _, kwargs = run_spy.call_args  # WHY: read the subprocess keywords.
+        # WHY: the absence of shell=True keeps the host as one argv element.
+        assert kwargs.get("shell", False) is False
+
+    def test_the_subprocess_timeout_exceeds_the_probe_timeout(self) -> None:
+        """A subprocess killed before ping finishes would report a false negative."""
+        completed = MagicMock(returncode=0)  # WHY: the exit code is not under test here.
+        with (
+            patch.object(zp.platform, "system", return_value="Linux"),
+            patch.object(subprocess, "run", return_value=completed) as run_spy,
+        ):
+            zp._icmp_ping("10.0.0.1", 3.0)  # WHY: drive the subprocess call.
+        _, kwargs = run_spy.call_args  # WHY: read the subprocess keywords.
+        assert kwargs["timeout"] == 5.0  # WHY: the two-second margin lets ping exit on its own.
+
+    def test_a_non_zero_exit_reports_no_answer(self) -> None:
+        """A non-zero exit means the host did not answer the echo request."""
+        completed = MagicMock(returncode=1)  # WHY: ping exits non-zero on packet loss.
+        with (
+            patch.object(zp.platform, "system", return_value="Linux"),
+            patch.object(subprocess, "run", return_value=completed),
+        ):
+            assert zp._icmp_ping("10.0.0.1", 3.0) is False
+
+    def test_a_hung_ping_reports_no_answer(self) -> None:
+        """A hung subprocess must not propagate out of a probe worker."""
+        # WHY: TimeoutExpired is what subprocess raises when it kills the child.
+        with (
+            patch.object(zp.platform, "system", return_value="Linux"),
+            patch.object(subprocess, "run", side_effect=subprocess.TimeoutExpired("ping", 5.0)),
+        ):
+            assert zp._icmp_ping("10.0.0.1", 3.0) is False
+
+    def test_a_missing_ping_binary_reports_no_answer(self) -> None:
+        """A container without a ping binary must degrade, not crash the scan."""
+        # WHY: a stripped image raises FileNotFoundError, a subclass of OSError.
+        with (
+            patch.object(zp.platform, "system", return_value="Linux"),
+            patch.object(subprocess, "run", side_effect=FileNotFoundError("ping")),
+        ):
+            assert zp._icmp_ping("10.0.0.1", 3.0) is False
+
+
+class TestTcpCheck:
+    """Cover the TCP handshake, which must always release its socket."""
+
+    def test_a_successful_connect_reports_open(self) -> None:
+        """An open port is the signal that a later HTTP probe is worth running."""
+        with patch.object(socket, "create_connection", return_value=MagicMock()):
+            assert zp._tcp_check("gateway.zscaler.net", 443, 3.0) == "open"
+
+    def test_the_socket_closes_on_the_success_path(self) -> None:
+        """A leaked socket would exhaust the file handle budget across a fleet scan."""
+        sock = MagicMock()  # WHY: stand in for the connected socket object.
+        with patch.object(socket, "create_connection", return_value=sock):
+            zp._tcp_check("gateway.zscaler.net", 443, 3.0)  # WHY: drive the context manager.
+        # WHY: the with block calls __exit__, which is the close hook on a socket.
+        sock.__exit__.assert_called_once()
+
+    def test_a_timeout_reports_closed(self) -> None:
+        """A silent drop by a firewall reads as closed, not as an error."""
+        with patch.object(socket, "create_connection", side_effect=TimeoutError("timed out")):
+            assert zp._tcp_check("gateway.zscaler.net", 443, 3.0) == "closed"
+
+    def test_a_refusal_reports_closed(self) -> None:
+        """An explicit refusal also reads as closed, so the report stays simple."""
+        with patch.object(socket, "create_connection", side_effect=ConnectionRefusedError()):
+            assert zp._tcp_check("gateway.zscaler.net", 443, 3.0) == "closed"
+
+    def test_another_socket_fault_reports_the_class_name(self) -> None:
+        """A routing fault differs from a refusal, so the report must say which."""
+        # WHY: an unreachable network is a transport fault, not a closed port.
+        with patch.object(socket, "create_connection", side_effect=OSError("unreachable")):
+            assert zp._tcp_check("gateway.zscaler.net", 443, 3.0) == "error:OSError"
+
+    def test_the_timeout_reaches_the_socket_layer(self) -> None:
+        """A connect without a timeout can hang a worker thread forever."""
+        with patch.object(socket, "create_connection", return_value=MagicMock()) as connect_spy:
+            zp._tcp_check("gateway.zscaler.net", 443, 7.5)  # WHY: drive the connect call.
+        _, kwargs = connect_spy.call_args  # WHY: read the connect keywords.
+        assert kwargs["timeout"] == 7.5  # WHY: the caller timeout must not be dropped.
+
+
+class TestOpenProbeConnection:
+    """Cover the connection factory, which the 405 retry reuses."""
+
+    def test_a_tls_request_builds_an_https_connection(self) -> None:
+        """A plain connection on port 443 would fail the handshake."""
+        with (
+            patch.object(zp, "HTTPSConnection") as https_cls,
+            patch.object(ssl, "create_default_context", return_value=MagicMock()),
+        ):
+            zp._open_probe_connection("gateway.zscaler.net", 443, 3.0, tls=True)
+        https_cls.assert_called_once()  # WHY: TLS must route to the HTTPS class.
+
+    def test_a_tls_request_uses_the_system_trust_store(self) -> None:
+        """A permissive context would hide a certificate substitution."""
+        context = MagicMock()  # WHY: stand in for the default SSL context.
+        with (
+            patch.object(zp, "HTTPSConnection") as https_cls,
+            patch.object(ssl, "create_default_context", return_value=context),
+        ):
+            zp._open_probe_connection("gateway.zscaler.net", 443, 3.0, tls=True)
+        _, kwargs = https_cls.call_args  # WHY: read the connection keywords.
+        assert kwargs["context"] is context  # WHY: the verified context must reach the connection.
+
+    def test_a_plain_request_builds_an_http_connection(self) -> None:
+        """Port 80 has no TLS layer, so the plain class is correct."""
+        with patch.object(zp, "HTTPConnection") as http_cls:
+            zp._open_probe_connection("gateway.zscaler.net", 80, 3.0, tls=False)
+        http_cls.assert_called_once_with("gateway.zscaler.net", 80, timeout=3.0)
+
+
+class TestCloseQuietly:
+    """Cover the cleanup helper, which must never mask a probe result."""
+
+    def test_a_healthy_connection_closes(self) -> None:
+        """The socket must release as soon as the response headers are read."""
+        conn = MagicMock()  # WHY: stand in for the HTTP connection object.
+        zp._close_quietly(conn)  # WHY: drive the normal cleanup path.
+        conn.close.assert_called_once()  # WHY: a skipped close leaks the socket.
+
+    def test_a_failing_close_is_swallowed(self) -> None:
+        """A cleanup error must not replace the probe result the caller earned."""
+        conn = MagicMock()  # WHY: stand in for the HTTP connection object.
+        conn.close.side_effect = OSError("already closed")  # WHY: reproduce a double close.
+        zp._close_quietly(conn)  # WHY: the call must return, not raise.
+
+
+class TestRequestHeadOrGet:
+    """Cover the HEAD probe and the 405 retry, which needs a second connection."""
+
+    def test_a_normal_response_returns_without_a_retry(self) -> None:
+        """A second request would double the load on every healthy endpoint."""
+        conn = MagicMock()  # WHY: stand in for the HTTP connection object.
+        conn.getresponse.return_value = MagicMock(status=200)  # WHY: a plain success.
+        with patch.object(zp, "_open_probe_connection", return_value=conn) as open_spy:
+            response = zp._request_head_or_get("gateway.zscaler.net", 443, 3.0, tls=True)
+        assert response.status == 200  # WHY: the first response must reach the caller.
+        assert open_spy.call_count == 1  # WHY: exactly one connection for a healthy endpoint.
+
+    def test_a_405_response_retries_with_get_on_a_new_connection(self) -> None:
+        """The first connection is consumed, so the retry needs a fresh one."""
+        first = MagicMock()  # WHY: the connection that answers 405.
+        first.getresponse.return_value = MagicMock(status=405)  # WHY: HEAD is refused.
+        second = MagicMock()  # WHY: the connection that carries the GET retry.
+        second.getresponse.return_value = MagicMock(status=200)  # WHY: GET succeeds.
+        with patch.object(zp, "_open_probe_connection", side_effect=[first, second]) as open_spy:
+            response = zp._request_head_or_get("pac.zscaler.net", 443, 3.0, tls=True)
+        assert response.status == 200  # WHY: the retry result must reach the caller.
+        assert open_spy.call_count == 2  # WHY: a reused connection would raise on request.
+        assert second.request.call_args[0][0] == "GET"  # WHY: the retry must change the method.
+
+    def test_the_consumed_connection_closes_before_the_retry(self) -> None:
+        """Leaving the 405 connection open would leak one socket for every PAC host."""
+        first = MagicMock()  # WHY: the connection that answers 405.
+        first.getresponse.return_value = MagicMock(status=405)  # WHY: HEAD is refused.
+        second = MagicMock()  # WHY: the connection that carries the GET retry.
+        second.getresponse.return_value = MagicMock(status=200)  # WHY: GET succeeds.
+        with patch.object(zp, "_open_probe_connection", side_effect=[first, second]):
+            zp._request_head_or_get("pac.zscaler.net", 443, 3.0, tls=True)
+        first.close.assert_called_once()  # WHY: the consumed connection must release.
+
+    def test_the_last_connection_closes_on_the_success_path(self) -> None:
+        """The finally block is the only release point for the returned response."""
+        conn = MagicMock()  # WHY: stand in for the HTTP connection object.
+        conn.getresponse.return_value = MagicMock(status=200)  # WHY: a plain success.
+        with patch.object(zp, "_open_probe_connection", return_value=conn):
+            zp._request_head_or_get("gateway.zscaler.net", 443, 3.0, tls=True)
+        conn.close.assert_called_once()  # WHY: the finally block must run on success too.
+
+    def test_the_connection_closes_when_the_request_fails(self) -> None:
+        """A raised error must still release the socket, or the pool leaks.
+
+        Why:
+            This is the resource-cleanup case that a success-only test misses.
+        """
+        conn = MagicMock()  # WHY: stand in for the HTTP connection object.
+        conn.request.side_effect = OSError("reset by peer")  # WHY: fail before the response.
+        with patch.object(zp, "_open_probe_connection", return_value=conn):
+            with pytest.raises(OSError):  # WHY: the caller catches this one level up.
+                zp._request_head_or_get("gateway.zscaler.net", 443, 3.0, tls=True)
+        conn.close.assert_called_once()  # WHY: the finally block must run on the error path.
+
+
+class TestDoHttp:
+    """Cover the error translation that keeps the probe report readable."""
+
+    def test_a_success_returns_the_response_and_no_error(self) -> None:
+        """The caller reads status and headers off the returned response."""
+        response = MagicMock(status=200)  # WHY: stand in for the HTTP response object.
+        with patch.object(zp, "_request_head_or_get", return_value=response):
+            assert zp._do_http("gateway.zscaler.net", 443, 3.0, tls=True) == (response, None)
+
+    def test_a_timeout_is_labeled_as_a_timeout(self) -> None:
+        """A stalled edge reads differently from a refused one in the report."""
+        with patch.object(zp, "_request_head_or_get", side_effect=TimeoutError("no reply")):
+            response, error = zp._do_http("gateway.zscaler.net", 443, 3.0, tls=True)
+        assert response is None  # WHY: no response means no status to record.
+        assert error is not None and error.startswith("timeout:")  # WHY: the label drives triage.
+
+    def test_a_tls_failure_is_labeled_as_ssl(self) -> None:
+        """A certificate rotation must not hide behind a generic transport error."""
+        with patch.object(zp, "_request_head_or_get", side_effect=ssl.SSLError("bad cert")):
+            _, error = zp._do_http("gateway.zscaler.net", 443, 3.0, tls=True)
+        assert error is not None and error.startswith("ssl:")  # WHY: the label names the layer.
+
+    def test_a_transport_failure_reports_the_class_name(self) -> None:
+        """The class name tells the operator which layer refused the probe."""
+        with patch.object(zp, "_request_head_or_get", side_effect=ConnectionRefusedError("no")):
+            _, error = zp._do_http("gateway.zscaler.net", 443, 3.0, tls=True)
+        assert error is not None  # WHY: the reason must survive for the summary.
+        assert "ConnectionRefusedError" in error  # WHY: the class name is the triage signal.
+
+
+class TestTlsPeer:
+    """Cover the certificate read, which owns both a socket and a TLS session."""
+
+    @staticmethod
+    def _wire_handshake(cert: dict[str, Any]) -> tuple[MagicMock, MagicMock, MagicMock]:
+        """Return mocks that emulate a successful handshake returning ``cert``.
+
+        Why:
+            Both the raw socket and the wrapped socket are context managers, so
+            each test would otherwise repeat six lines of mock plumbing.
+        """
+        raw = MagicMock()  # WHY: stand in for the plain TCP socket.
+        raw.__enter__.return_value = raw  # WHY: the with block binds the same object.
+        tls = MagicMock()  # WHY: stand in for the wrapped TLS socket.
+        tls.__enter__.return_value = tls  # WHY: the with block binds the same object.
+        tls.getpeercert.return_value = cert  # WHY: supply the certificate under test.
+        context = MagicMock()  # WHY: stand in for the default SSL context.
+        context.wrap_socket.return_value = tls  # WHY: the handshake yields the TLS socket.
+        return raw, tls, context
+
+    def test_the_subject_and_the_issuer_are_returned(self) -> None:
+        """The issuer common name is the cheapest signal for classifying a host."""
+        cert = {
+            "subject": ((("commonName", "*.zscaler.net"),),),  # WHY: the served identity.
+            "issuer": ((("commonName", "Zscaler Root CA"),),),  # WHY: the signing authority.
+        }
+        raw, _, context = self._wire_handshake(cert)  # WHY: build the handshake mocks.
+        with (
+            patch.object(socket, "create_connection", return_value=raw),
+            patch.object(ssl, "create_default_context", return_value=context),
+        ):
+            subject, issuer, error = zp._tls_peer("gateway.zscaler.net", 443, 3.0)
+        assert subject == "*.zscaler.net"  # WHY: the subject drives the CloudFront rule.
+        assert issuer == "Zscaler Root CA"  # WHY: the issuer drives the Zscaler rule.
+        assert error is None  # WHY: a clean handshake reports no error.
+
+    def test_the_hostname_is_sent_as_the_sni_value(self) -> None:
+        """Without SNI a shared edge serves the wrong certificate."""
+        raw, _, context = self._wire_handshake({})  # WHY: the certificate is not under test.
+        with (
+            patch.object(socket, "create_connection", return_value=raw),
+            patch.object(ssl, "create_default_context", return_value=context),
+        ):
+            zp._tls_peer("gateway.zscaler.net", 443, 3.0)  # WHY: drive the handshake.
+        _, kwargs = context.wrap_socket.call_args  # WHY: read the handshake keywords.
+        assert kwargs["server_hostname"] == "gateway.zscaler.net"  # WHY: SNI must match the host.
+
+    def test_both_sockets_close_after_the_handshake(self) -> None:
+        """A leaked TLS session holds a socket and a buffer for the whole run."""
+        raw, tls, context = self._wire_handshake({})  # WHY: build the handshake mocks.
+        with (
+            patch.object(socket, "create_connection", return_value=raw),
+            patch.object(ssl, "create_default_context", return_value=context),
+        ):
+            zp._tls_peer("gateway.zscaler.net", 443, 3.0)  # WHY: drive both context managers.
+        raw.__exit__.assert_called_once()  # WHY: the plain socket must release.
+        tls.__exit__.assert_called_once()  # WHY: the TLS session must release.
+
+    def test_a_missing_certificate_yields_two_none_values(self) -> None:
+        """A session without a peer cert must not raise on the dictionary read."""
+        raw, tls, context = self._wire_handshake({})  # WHY: build the handshake mocks.
+        tls.getpeercert.return_value = None  # WHY: reproduce a session with no peer cert.
+        with (
+            patch.object(socket, "create_connection", return_value=raw),
+            patch.object(ssl, "create_default_context", return_value=context),
+        ):
+            assert zp._tls_peer("gateway.zscaler.net", 443, 3.0) == (None, None, None)
+
+    def test_a_handshake_timeout_is_labeled(self) -> None:
+        """A stalled handshake reads differently from a rejected certificate."""
+        with patch.object(socket, "create_connection", side_effect=TimeoutError("slow")):
+            _, _, error = zp._tls_peer("gateway.zscaler.net", 443, 3.0)
+        assert error is not None and error.startswith("timeout:")  # WHY: the label drives triage.
+
+    def test_a_certificate_rejection_is_labeled_as_ssl(self) -> None:
+        """An inspection proxy shows up here as a verification failure."""
+        with patch.object(socket, "create_connection", return_value=MagicMock()):
+            with patch.object(ssl, "create_default_context", side_effect=ssl.SSLError("bad")):
+                _, _, error = zp._tls_peer("gateway.zscaler.net", 443, 3.0)
+        assert error is not None and error.startswith("ssl:")  # WHY: the label names the layer.
+
+    def test_a_transport_failure_reports_the_class_name(self) -> None:
+        """A refused connection must abort the read, not raise into the worker."""
+        with patch.object(socket, "create_connection", side_effect=ConnectionRefusedError("no")):
+            _, _, error = zp._tls_peer("gateway.zscaler.net", 443, 3.0)
+        assert error is not None  # WHY: the reason must survive for the summary.
+        assert "ConnectionRefusedError" in error  # WHY: the class name is the triage signal.
+
+
+class TestPickCn:
+    """Cover the distinguished-name reader, which tolerates a sparse certificate."""
+
+    def test_a_common_name_is_preferred(self) -> None:
+        """The common name is the field the classification rules compare against."""
+        rdns = ((("commonName", "*.zscaler.net"),),)  # WHY: a plain single-field name.
+        assert zp._pick_cn(rdns) == "*.zscaler.net"
+
+    def test_an_organization_name_is_the_fallback(self) -> None:
+        """A handful of Zscaler certificate authorities omit the common name."""
+        rdns = ((("organizationName", "Zscaler Inc."),),)  # WHY: reproduce the sparse case.
+        assert zp._pick_cn(rdns) == "Zscaler Inc."
+
+    def test_an_unrelated_field_is_skipped(self) -> None:
+        """A country field must not be mistaken for an identity."""
+        # WHY: the country comes first, so a naive reader would return it.
+        rdns = ((("countryName", "US"),), (("commonName", "*.zscaler.net"),))
+        assert zp._pick_cn(rdns) == "*.zscaler.net"
+
+    def test_an_empty_sequence_returns_nothing(self) -> None:
+        """A certificate with no matching field must not raise on the loop."""
+        assert zp._pick_cn(()) is None  # WHY: the caller treats None as unknown.
+
+    def test_a_none_sequence_returns_nothing(self) -> None:
+        """A missing key in the certificate dictionary reaches this helper as None."""
+        assert zp._pick_cn(None) is None  # WHY: the guard must accept None, not raise.
+
+    def test_the_value_is_coerced_to_a_string(self) -> None:
+        """A non-string value would break the later substring comparisons."""
+        rdns = ((("commonName", 12345),),)  # WHY: mimic an unusual encoder output.
+        assert zp._pick_cn(rdns) == "12345"
+
+
+class TestProbeHttpStack:
+    """Cover the HTTP, HTTPS, and proxy blocks that read from the TCP scan."""
+
+    def test_a_closed_port_80_skips_the_http_probe(self) -> None:
+        """Probing a closed port wastes a full timeout on every host."""
+        result = _make_result()  # WHY: a fresh result with no ports open.
+        result.tcp = {80: "closed", 443: "closed"}  # WHY: nothing is open to probe.
+        with patch.object(zp, "_do_http") as http_spy:
+            zp._probe_http_stack("gateway.zscaler.net", 3.0, [], result)
+        http_spy.assert_not_called()  # WHY: the guard must prevent the request.
+
+    def test_an_http_success_records_the_status_and_the_headers(self) -> None:
+        """The server header is a classification input, so it must be captured."""
+        result = _make_result()  # WHY: a fresh result to populate.
+        result.tcp = {80: "open"}  # WHY: only port 80 is open.
+        response = MagicMock(status=302)  # WHY: a redirect is the common ZEN answer.
+        # WHY: the helper reads two named headers off the response.
+        response.getheader.side_effect = lambda name: {
+            "Server": "Zscaler",
+            "Location": "https://gateway.zscaler.net/",
+        }.get(name)
+        with patch.object(zp, "_do_http", return_value=(response, None)):
+            zp._probe_http_stack("gateway.zscaler.net", 3.0, [], result)
+        assert result.http_status == 302  # WHY: the status drives the report row.
+        assert result.http_server == "Zscaler"  # WHY: the server header drives classification.
+        assert result.http_location == "https://gateway.zscaler.net/"  # WHY: shows the redirect.
+        assert "HTTP" in result.responding_protocols  # WHY: the summary lists live protocols.
+
+    def test_an_http_failure_records_a_note(self) -> None:
+        """A silent failure would leave the operator with an unexplained gap."""
+        result = _make_result()  # WHY: a fresh result to populate.
+        result.tcp = {80: "open"}  # WHY: only port 80 is open.
+        with patch.object(zp, "_do_http", return_value=(None, "timeout: no reply")):
+            zp._probe_http_stack("gateway.zscaler.net", 3.0, [], result)
+        assert result.http_status is None  # WHY: a failure leaves no status to record.
+        assert any("HTTP :80 error" in note for note in result.notes)  # WHY: the note explains.
+
+    def test_an_https_success_records_the_certificate_and_the_status(self) -> None:
+        """The certificate and the status are read in one pass over port 443."""
+        result = _make_result()  # WHY: a fresh result to populate.
+        result.tcp = {443: "open"}  # WHY: only port 443 is open.
+        response = MagicMock(status=200)  # WHY: a plain success on the TLS port.
+        response.getheader.return_value = "Zscaler"  # WHY: both headers read the same value.
+        with (
+            patch.object(zp, "_tls_peer", return_value=("*.zscaler.net", "Zscaler CA", None)),
+            patch.object(zp, "_do_http", return_value=(response, None)),
+        ):
+            zp._probe_http_stack("gateway.zscaler.net", 3.0, [], result)
+        assert result.tls_issuer == "Zscaler CA"  # WHY: the issuer drives the Zscaler rule.
+        assert result.https_status == 200  # WHY: the status drives the report row.
+        assert "HTTPS" in result.responding_protocols  # WHY: the summary lists live protocols.
+
+    def test_an_https_failure_records_a_note(self) -> None:
+        """A TLS port that accepts TCP but refuses HTTP must still be explained."""
+        result = _make_result()  # WHY: a fresh result to populate.
+        result.tcp = {443: "open"}  # WHY: only port 443 is open.
+        with (
+            patch.object(zp, "_tls_peer", return_value=(None, None, "ssl:bad cert")),
+            patch.object(zp, "_do_http", return_value=(None, "ssl:bad cert")),
+        ):
+            zp._probe_http_stack("gateway.zscaler.net", 3.0, [], result)
+        assert result.tls_error == "ssl:bad cert"  # WHY: the handshake error must survive.
+        assert any("HTTPS :443 error" in note for note in result.notes)  # WHY: the note explains.
+
+    def test_an_open_declared_proxy_port_is_recorded(self) -> None:
+        """The TCP handshake alone proves a ZEN proxy port is live."""
+        result = _make_result(declared_ports=[8080])  # WHY: the role declares the proxy port.
+        result.tcp = {8080: "open"}  # WHY: the proxy port answered the handshake.
+        zp._probe_http_stack("gateway.zscaler.net", 3.0, [8080], result)  # WHY: drive the branch.
+        # WHY: the label distinguishes a proxy port from a plain web port in the report.
+        assert "TCP/8080 (proxy)" in result.responding_protocols
+
+    def test_an_undeclared_proxy_port_is_not_recorded(self) -> None:
+        """An off-doc open port must not be reported as a working proxy."""
+        result = _make_result()  # WHY: the role declares no proxy port.
+        result.tcp = {8080: "open"}  # WHY: the port answered, but the role did not declare it.
+        zp._probe_http_stack("gateway.zscaler.net", 3.0, [], result)  # WHY: drive the guard.
+        assert "TCP/8080 (proxy)" not in result.responding_protocols
+
+
+class TestProbeFqdn:
+    """Cover the per-host orchestration, including the DNS short circuit."""
+
+    def test_a_dns_failure_skips_every_later_probe(self) -> None:
+        """A name that does not resolve has no address to probe."""
+        with (
+            patch.object(zp, "_resolve", return_value=(None, "gaierror: unknown")),
+            patch.object(zp, "_icmp_ping") as ping_spy,
+            patch.object(zp, "_tcp_check") as tcp_spy,
+        ):
+            result = zp._probe_fqdn("nope.invalid", {"role": "zen"}, 3.0)
+        assert result.dns_error is not None  # WHY: the reason reaches the report.
+        ping_spy.assert_not_called()  # WHY: an unresolved name wastes a full ping timeout.
+        tcp_spy.assert_not_called()  # WHY: an unresolved name wastes three connect timeouts.
+
+    def test_a_successful_ping_is_listed_as_a_protocol(self) -> None:
+        """ICMP is the first evidence that a path to the host exists."""
+        with (
+            patch.object(zp, "_resolve", return_value=("10.0.0.1", None)),
+            patch.object(zp, "_icmp_ping", return_value=True),
+            patch.object(zp, "_tcp_check", return_value="closed"),
+            patch.object(zp, "_probe_http_stack"),
+            patch.object(zp, "_probe_udp_ike_if_needed"),
+            patch.object(zp, "_classify", return_value="unknown"),
+        ):
+            result = zp._probe_fqdn("gateway.zscaler.net", {"role": "zen"}, 3.0)
+        assert result.icmp_ok is True  # WHY: the flag drives the report column.
+        assert "ICMP" in result.responding_protocols  # WHY: the summary lists live protocols.
+
+    def test_the_declared_ports_join_the_common_ports(self) -> None:
+        """An off-doc port must be scanned so the report can spot a drift."""
+        role = {"role": "zen", "ports": [9443]}  # WHY: a port outside the common tuple.
+        with (
+            patch.object(zp, "_resolve", return_value=("10.0.0.1", None)),
+            patch.object(zp, "_icmp_ping", return_value=False),
+            patch.object(zp, "_tcp_check", return_value="closed") as tcp_spy,
+            patch.object(zp, "_probe_http_stack"),
+            patch.object(zp, "_probe_udp_ike_if_needed"),
+            patch.object(zp, "_classify", return_value="unknown"),
+        ):
+            zp._probe_fqdn("gateway.zscaler.net", role, 3.0)  # WHY: drive the port union.
+        scanned = sorted(call[0][1] for call in tcp_spy.call_args_list)  # WHY: read the ports.
+        assert scanned == [80, 443, 8080, 9443]  # WHY: the union must be sorted and complete.
+
+    def test_an_open_port_is_listed_as_a_protocol(self) -> None:
+        """Each open port earns a line in the responding-protocol summary."""
+        with (
+            patch.object(zp, "_resolve", return_value=("10.0.0.1", None)),
+            patch.object(zp, "_icmp_ping", return_value=False),
+            patch.object(zp, "_tcp_check", return_value="open"),
+            patch.object(zp, "_probe_http_stack"),
+            patch.object(zp, "_probe_udp_ike_if_needed"),
+            patch.object(zp, "_classify", return_value="zscaler"),
+        ):
+            result = zp._probe_fqdn("gateway.zscaler.net", {"role": "zen"}, 3.0)
+        assert "TCP/443" in result.responding_protocols  # WHY: the port label must appear.
+        assert result.server_class == "zscaler"  # WHY: the classifier result must be stored.
+
+
+class TestRunProbes:
+    """Cover the thread pool, which must join every worker and sort the output."""
+
+    def test_every_entry_produces_a_result(self) -> None:
+        """A dropped result would silently shrink the report."""
+        # WHY: three entries prove the fan-out collects more than one future.
+        entries = [
+            ("a.zscaler.net", {"role": "zen"}),
+            ("b.zscaler.net", {"role": "zen"}),
+            ("c.zscaler.net", {"role": "zen"}),
+        ]
+        with patch.object(zp, "_probe_fqdn", side_effect=lambda f, r, t: _make_result(fqdn=f)):
+            results = zp._run_probes(entries, 3.0, workers=2)
+        assert len(results) == 3  # WHY: one result for each submitted entry.
+
+    def test_the_output_is_sorted_by_role_and_then_by_name(self) -> None:
+        """An unsorted report changes order between runs and hides a real diff."""
+        entries = [
+            ("z.zscaler.net", {"role": "zen"}),  # WHY: last by both keys.
+            ("a.zscaler.net", {"role": "pac"}),  # WHY: first by role.
+            ("b.zscaler.net", {"role": "zen"}),  # WHY: same role as the first entry.
+        ]
+
+        def _fake(fqdn: str, role: dict[str, Any], _timeout: float) -> ProbeResult:
+            """Return a result carrying the role, so the sort key is real."""
+            # WHY: the sort reads role first and fqdn second, so both must be set.
+            return _make_result(fqdn=fqdn, role=str(role["role"]))
+
+        with patch.object(zp, "_probe_fqdn", side_effect=_fake):
+            results = zp._run_probes(entries, 3.0, workers=3)
+        # WHY: pac ranks before zen, then the two zen rows sort by name.
+        assert [r.fqdn for r in results] == ["a.zscaler.net", "b.zscaler.net", "z.zscaler.net"]
+
+    def test_the_worker_count_reaches_the_pool(self) -> None:
+        """An unbounded pool would open one socket for every catalogue host."""
+        entries = [("a.zscaler.net", {"role": "zen"})]  # WHY: one entry is enough.
+        with (
+            patch.object(zp, "_probe_fqdn", return_value=_make_result()),
+            patch.object(zp.concurrent.futures, "ThreadPoolExecutor") as pool_cls,
+        ):
+            # WHY: an empty iterator keeps the loop body out of this assertion.
+            pool_cls.return_value.__enter__.return_value.submit.return_value = MagicMock()
+            with patch.object(zp.concurrent.futures, "as_completed", return_value=[]):
+                zp._run_probes(entries, 3.0, workers=7)
+        _, kwargs = pool_cls.call_args  # WHY: read the pool keywords.
+        assert kwargs["max_workers"] == 7  # WHY: the caller bound must not be dropped.
+
+    def test_an_empty_entry_list_returns_no_results(self) -> None:
+        """An empty catalogue must return cleanly, not hang on the pool."""
+        assert zp._run_probes([], 3.0, workers=4) == []  # WHY: the pool must still close.


### PR DESCRIPTION
## Summary

This branch raises the test coverage on high-risk code. It also fixes one test
defect that the baseline run found.

The priority order was the Mist API business logic, the error handling paths,
the retry logic, the resource cleanup, and the boundary conditions.

## Results

| Measure | Before | After |
| - | - | - |
| Tests that pass | 9721 | 10377 |
| Tests that fail | 1 | 0 |
| Total coverage | 92.33 percent | 93 percent |

## New test files

| File | Tests | Module coverage |
| - | - | - |
| `tests/unit/export/test_count_exporter_workflows.py` | 17 | 56 -> 98 percent |
| `tests/unit/export/test_site_webhook_deliveries_exporter.py` | 20 | 24 -> 100 percent |
| `tests/unit/export/test_wan_client_events_exporter_paths.py` | 25 | 41 -> 100 percent |
| `tests/unit/capture/test_client_pcap_downloader_network_paths.py` | 37 | 59 -> 99 percent |
| `tests/unit/utils/test_zscaler_probe_transport.py` | 58 | 70 -> 99 percent |
| `tests/unit/org/test_org_config_migration_conflicts.py` | 86 | 16 -> 63 percent |
| `tests/unit/refactors/test_wlanradius_timer_manager_paths.py` | 168 | 13 -> 100 percent |

The total is 411 new tests.

## The defect that the baseline found

Closes #1940.

`tests/unit/ssh/test_cli_shell_manager.py` asserted that `_has_pyte` is
`True`. The `pyte` package is optional. The module catches the
`ImportError` and sets the flag to `False`. The test therefore asserted a
fact about the machine, not a fact about the code. It failed on any machine
without the optional package.

The test now derives the expected value from a real import attempt. It then
asserts that the flag agrees with that attempt. The test proves the invariant
in both states.

Only the test file changed. The production code was correct.

## The connection release alignment

The main branch changed `_download_one` to wrap the request in a `with`
block. That change returns the socket to the pool after a failure. The first
version of the capture tests mocked the response as a plain object, so the
`with` block bound a different mock.

The branch is rebased on main. The response mock now binds `__enter__` to
itself. Two tests were added. They prove that a failed transfer and a clean
transfer both release the connection.

## What the new tests cover

- The pagination loops and the empty result guards in the three exporters.
- The socket, TLS, and thread pool paths in the Zscaler probe.
- The connection release, the chunked write, and the mid-stream reset in the
  PCAP downloader.
- The conflict guards and the identifier remapping in the org config migration.
- The WLAN RADIUS timer manager for menu 148. This module writes authentication
  timers to one of three Mist API endpoints. It had 13 percent coverage, so
  most error branches ran unguarded. The tests now cover the template
  assignment rules, the RADIUS detection rules, both edges of the timeout and
  the retry ranges, the picker boundaries, every API error branch, and the
  blast-radius warnings that tell the operator a change reaches every site that
  uses a shared template.

## Conformance

- Every external call is mocked. No test reaches the live Mist API.
- `MistHelper.py` is unchanged.
- No production file under `src/` changed.
- `ruff check tests` reports no finding.
- `black --check tests` reports no change.
- All 18 quality gates pass.