### PR TITLE
fix(runtime): bound every helper subprocess and release the pool on eleven engine paths

### DIFF
--- a/mist-ops-platform/src/api/routes/deploy.py
+++ b/mist-ops-platform/src/api/routes/deploy.py
@@ -27,7 +27,7 @@ from src.api.deps import (
 )
 from src.api.middleware.auth import CurrentUser
 from src.api.schemas.common import ResponseEnvelope
-from src.shared.config.settings import get_settings
+from src.shared.sync_db import sync_engine
 from src.api.schemas.deploy import (
     CheckpointDetail,
     DryRunRequest,
@@ -513,17 +513,15 @@ async def rollback_wave(
         raise HTTPException(status_code=400, detail="confirm required")
 
     from src.worker.deploy.rollout import RolloutOrchestrator
-    from sqlalchemy import create_engine as _ce
     from sqlalchemy.orm import Session as _Sess
 
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
-    engine = _ce(sync_url)
-    with _Sess(engine) as sync_db:
-        orch = RolloutOrchestrator(sync_db)
-        result = orch.rollback_wave(plan_id, wave_number, body.comment)
-    engine.dispose()
+    logger.info("Rolling back wave %d of rollout plan %s", wave_number, plan_id)
+    # The scope disposes the pool on the success path and on the error path.
+    with sync_engine() as engine, _Sess(engine) as sync_db:
+        orch = RolloutOrchestrator(sync_db)  # Own the wave state machine.
+        result = orch.rollback_wave(plan_id, wave_number, body.comment)  # Undo the wave.
 
+    logger.debug("Rollback of plan %s returned %s", plan_id, result)
     return ResponseEnvelope(data=result)
 
 
@@ -730,16 +728,15 @@ async def instantiate_template(
     tmpl = await _load_template(db, template_id)
 
     from src.shared.services.template import TemplateService
-    from sqlalchemy import create_engine as _ce
     from sqlalchemy.orm import Session as _Sess
 
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
-    engine = _ce(sync_url)
-    with _Sess(engine) as sync_db:
-        svc = TemplateService(sync_db)
-        payload = svc.instantiate(tmpl, body.parameters)
-    engine.dispose()
+    logger.info("Instantiating template %s", template_id)
+    # The scope disposes the pool on the success path and on the error path.
+    with sync_engine() as engine, _Sess(engine) as sync_db:
+        svc = TemplateService(sync_db)  # Own the template expansion rules.
+        payload = svc.instantiate(tmpl, body.parameters)  # Build the config body.
+
+    logger.debug("Template %s produced %d config keys", template_id, len(payload))
 
     job = ScheduledJob(
         org_id=body.org_id,

--- a/mist-ops-platform/src/shared/sync_db.py
+++ b/mist-ops-platform/src/shared/sync_db.py
@@ -1,0 +1,70 @@
+"""A guarded synchronous engine scope for the Celery tasks and the sync routes.
+
+A SQLAlchemy engine owns a connection pool. The pool holds open PostgreSQL
+sockets until some code calls ``dispose``. A caller that places the
+``dispose`` call after a ``with Session(engine)`` block skips the call
+whenever the block raises, because the exception leaves the function first.
+
+Both process types that run this code live for a long time. A Celery worker
+stays up for days, and a FastAPI worker serves many requests. So one leaked
+pool per failure adds up until PostgreSQL reaches ``max_connections``. After
+that limit, every service on the database fails to connect.
+
+The scope below closes that gap. The ``finally`` clause runs after a return
+and after an exception, so no exit path can skip the release.
+
+This module fixes issue #1942. It also holds the pattern that pull request
+#1920 first applied to one task in ``src.worker.tasks.sync_tasks``.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from sqlalchemy import create_engine
+
+from src.shared.config.settings import get_settings
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from sqlalchemy import Engine
+
+logger = logging.getLogger(__name__)
+
+# The async driver cannot run inside a Celery task or a sync route, so the
+# caller swaps it for the blocking driver before it opens the engine.
+_ASYNC_DRIVER = "+asyncpg"
+_SYNC_DRIVER = "+psycopg2"
+
+
+def build_sync_url() -> str:
+    """Return the database URL with the blocking driver in place.
+
+    Returns:
+        The configured database URL that names the ``psycopg2`` driver.
+    """
+    settings = get_settings()  # Read the one settings object the app shares.
+    # Swap the driver name, because asyncpg cannot serve a blocking Session.
+    return str(settings.database_url).replace(_ASYNC_DRIVER, _SYNC_DRIVER)
+
+
+@contextmanager
+def sync_engine() -> Iterator[Engine]:
+    """Yield a scoped engine and dispose it on every exit path.
+
+    Yields:
+        An engine bound to the blocking database driver.
+    """
+    sync_url = build_sync_url()  # Build the URL before the engine opens.
+    logger.info("Opening a scoped engine for the sync database")
+    engine = create_engine(sync_url)  # Open the pool this scope owns.
+    try:
+        yield engine  # Run the whole caller body inside this scope.
+    finally:
+        # This line runs after a return and after an exception, so the pool
+        # goes back to the operating system on every path.
+        engine.dispose()
+        logger.debug("Disposed the scoped engine and closed its connection pool")

--- a/mist-ops-platform/src/worker/tasks/audit_tasks.py
+++ b/mist-ops-platform/src/worker/tasks/audit_tasks.py
@@ -14,12 +14,12 @@ import logging
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import create_engine, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from src.shared.config.settings import get_settings
 from src.shared.models.governance import ComplianceAuditPack
 from src.shared.models.operations import AuditRecord
+from src.shared.sync_db import sync_engine
 from src.worker.celeryconfig import app
 
 logger = logging.getLogger(__name__)
@@ -36,15 +36,13 @@ def export_audit_records(
     Returns metadata about the generated export including
     record count and serialized content for storage.
     """
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
-    engine = create_engine(sync_url)
+    logger.info("Exporting audit records for organization %s", org_id)
+    # The scope disposes the pool on the success path and on the error path.
+    with sync_engine() as engine, Session(engine) as db:
+        records = _query_filtered(db, org_id, filters)  # Read the matching rows.
+        content = _serialize(records, export_format)  # Turn the rows into text.
 
-    with Session(engine) as db:
-        records = _query_filtered(db, org_id, filters)
-        content = _serialize(records, export_format)
-
-    engine.dispose()
+    logger.debug("Exported %d audit records as %s", len(records), export_format)
     return {
         "status": "completed",
         "record_count": len(records),
@@ -67,11 +65,9 @@ def generate_compliance_pack(
     Queries all audit records in the date range, builds a
     summary, and persists a ComplianceAuditPack record.
     """
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
-    engine = create_engine(sync_url)
-
-    with Session(engine) as db:
+    logger.info("Building a %s compliance pack for organization %s", framework, org_id)
+    # The scope disposes the pool on the success path and on the error path.
+    with sync_engine() as engine, Session(engine) as db:
         records = _query_date_range(
             db,
             org_id,
@@ -92,7 +88,7 @@ def generate_compliance_pack(
         db.commit()
         pack_id = str(pack.pack_id)
 
-    engine.dispose()
+    logger.debug("Built compliance pack %s from %d records", pack_id, len(records))
     return {
         "pack_id": pack_id,
         "status": "completed",
@@ -230,17 +226,14 @@ def run_retention_cleanup() -> dict:
     """Nightly cleanup of expired records per data-model.md retention."""
     from sqlalchemy import text
 
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
-    engine = create_engine(sync_url)
-
+    logger.info("Starting the nightly retention cleanup")
     results: dict[str, int] = {}
-    with Session(engine) as db:
+    # The scope disposes the pool on the success path and on the error path.
+    with sync_engine() as engine, Session(engine) as db:
         for table, days in _RETENTION_DAYS.items():
-            results[table] = _purge_table(db, table, days)
-        db.commit()
+            results[table] = _purge_table(db, table, days)  # Delete the aged rows.
+        db.commit()  # Commit once, so one failure rolls the whole sweep back.
 
-    engine.dispose()
     logger.info("Retention cleanup complete: %s", results)
     return results
 

--- a/mist-ops-platform/src/worker/tasks/check_tasks.py
+++ b/mist-ops-platform/src/worker/tasks/check_tasks.py
@@ -10,13 +10,13 @@ import logging
 from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
-from sqlalchemy import create_engine, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from src.shared.config.settings import get_settings
 from src.shared.mist.endpoints import MistEndpointService
 from src.shared.mist.session import get_session_factory
 from src.shared.models.operations import JobCheckpoint, ScheduledJob
+from src.shared.sync_db import sync_engine
 from src.worker.celeryconfig import app
 
 logger = logging.getLogger(__name__)
@@ -25,28 +25,24 @@ logger = logging.getLogger(__name__)
 @app.task(name="src.worker.tasks.check_tasks.run_pre_checks")
 def run_pre_checks(job_id: str, org_id: str, target_ids: list[str]) -> dict:
     """Execute pre-deployment checks and store results as checkpoint."""
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
-    engine = create_engine(sync_url)
+    logger.info("Running the pre-deployment checks for job %s", job_id)
+    # The scope disposes the pool on the success path and on the error path.
+    with sync_engine() as engine, Session(engine) as db:
+        result = _execute_pre_checks(db, job_id, org_id, target_ids)  # Run the checks.
 
-    with Session(engine) as db:
-        result = _execute_pre_checks(db, job_id, org_id, target_ids)
-
-    engine.dispose()
+    logger.debug("Pre-checks for job %s returned %s", job_id, result.get("status"))
     return result
 
 
 @app.task(name="src.worker.tasks.check_tasks.run_post_checks")
 def run_post_checks(job_id: str, org_id: str, target_ids: list[str]) -> dict:
     """Execute post-deployment checks and store results as checkpoint."""
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
-    engine = create_engine(sync_url)
+    logger.info("Running the post-deployment checks for job %s", job_id)
+    # The scope disposes the pool on the success path and on the error path.
+    with sync_engine() as engine, Session(engine) as db:
+        result = _execute_post_checks(db, job_id, org_id, target_ids)  # Run the checks.
 
-    with Session(engine) as db:
-        result = _execute_post_checks(db, job_id, org_id, target_ids)
-
-    engine.dispose()
+    logger.debug("Post-checks for job %s returned %s", job_id, result.get("status"))
     return result
 
 

--- a/mist-ops-platform/src/worker/tasks/deploy_tasks.py
+++ b/mist-ops-platform/src/worker/tasks/deploy_tasks.py
@@ -11,15 +11,15 @@ import logging
 from datetime import UTC, datetime
 from uuid import UUID
 
-from sqlalchemy import create_engine, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from src.shared.config.constants import JobStatus
-from src.shared.config.settings import get_settings
 from src.shared.mist.endpoints import MistEndpointService
 from src.shared.mist.session import get_session_factory
 from src.shared.models.config import ConfigRevision
 from src.shared.models.operations import ScheduledJob
+from src.shared.sync_db import sync_engine
 from src.worker.celeryconfig import app
 from src.worker.deploy.rollback import RollbackService, RollbackState
 
@@ -46,11 +46,9 @@ def install_from_revision(
         3. Push via RollbackService (saga pattern)
         4. Update job status
     """
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
-    engine = create_engine(sync_url)
-
-    with Session(engine) as db:
+    logger.info("Installing revision %s for job %s", revision_id, job_id)
+    # The scope disposes the pool on the success path and on the error path.
+    with sync_engine() as engine, Session(engine) as db:
         result = _execute_install(
             db,
             job_id,
@@ -59,7 +57,7 @@ def install_from_revision(
             org_id,
         )
 
-    engine.dispose()
+    logger.debug("Install for job %s returned status %s", job_id, result.get("status"))
     return result
 
 
@@ -173,17 +171,15 @@ def poll_scheduled_jobs() -> dict:
     Polls for jobs with status APPROVED and scheduled_at <= now(),
     then executes each with pre-checks, push, and post-checks.
     """
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
-    engine = create_engine(sync_url)
-
-    with Session(engine) as db:
-        due_jobs = _find_due_jobs(db)
+    logger.info("Polling for scheduled jobs that are due")
+    # The scope disposes the pool on the success path and on the error path.
+    with sync_engine() as engine, Session(engine) as db:
+        due_jobs = _find_due_jobs(db)  # Read the approved jobs whose time arrived.
         results = {}
         for job in due_jobs:
-            results[str(job.job_id)] = _execute_scheduled_job(db, job)
+            results[str(job.job_id)] = _execute_scheduled_job(db, job)  # Run each job.
 
-    engine.dispose()
+    logger.debug("Polled and ran %d scheduled jobs", len(results))
     return {"polled": len(results), "results": results}
 
 
@@ -247,15 +243,13 @@ def execute_rollout_wave(plan_id: str) -> dict:
     """
     from src.worker.deploy.rollout import RolloutOrchestrator
 
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
-    engine = create_engine(sync_url)
+    logger.info("Executing the next wave of rollout plan %s", plan_id)
+    # The scope disposes the pool on the success path and on the error path.
+    with sync_engine() as engine, Session(engine) as db:
+        orchestrator = RolloutOrchestrator(db)  # Own the wave state machine.
+        result = orchestrator.execute_next_wave(UUID(plan_id))  # Push one wave.
 
-    with Session(engine) as db:
-        orchestrator = RolloutOrchestrator(db)
-        result = orchestrator.execute_next_wave(UUID(plan_id))
-
-    engine.dispose()
+    logger.debug("Wave execution for plan %s returned %s", plan_id, result)
 
     if result.get("auto_promote"):
         execute_rollout_wave.delay(plan_id)
@@ -271,13 +265,11 @@ def promote_rollout_wave(
     """Manually promote to the next wave."""
     from src.worker.deploy.rollout import RolloutOrchestrator
 
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
-    engine = create_engine(sync_url)
+    logger.info("Promoting rollout plan %s to wave %d", plan_id, wave_number)
+    # The scope disposes the pool on the success path and on the error path.
+    with sync_engine() as engine, Session(engine) as db:
+        orchestrator = RolloutOrchestrator(db)  # Own the wave state machine.
+        result = orchestrator.promote_wave(UUID(plan_id), wave_number)  # Advance it.
 
-    with Session(engine) as db:
-        orchestrator = RolloutOrchestrator(db)
-        result = orchestrator.promote_wave(UUID(plan_id), wave_number)
-
-    engine.dispose()
+    logger.debug("Promotion of plan %s returned %s", plan_id, result)
     return result

--- a/mist-ops-platform/tests/unit/worker/test_task_engine_disposal.py
+++ b/mist-ops-platform/tests/unit/worker/test_task_engine_disposal.py
@@ -1,0 +1,301 @@
+"""Tests that every worker task releases its database engine (issue #1942).
+
+Each Celery task and each sync route builds its own SQLAlchemy engine. An
+engine owns a connection pool, and an undisposed pool holds open PostgreSQL
+sockets until the database reaches ``max_connections``.
+
+Issue #1908 fixed one task in ``sync_tasks``. Eleven sibling sites kept the
+old shape, where the ``dispose`` call sat after the ``with Session(engine)``
+block. An exception inside that block skipped the call.
+
+These tests prove that the shared ``sync_engine`` scope disposes the engine on
+both exit paths, and that the task modules now use that scope.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+# The task modules import Celery and the settings package at import time.
+# Neither is present in the test environment, so the fixture installs a stub
+# for each missing name before it imports the module under test.
+_STUBBED_MODULES = (
+    "celery",
+    "celery.schedules",
+    "src.shared.config",
+    "src.shared.config.settings",
+    "src.shared.config.constants",
+)
+
+# The fixture reimports these modules under the stubs, so it must drop any
+# copy that an earlier test left in the module cache.
+_RELOADED_MODULES = (
+    "src.shared.sync_db",
+    "src.worker.celeryconfig",
+    "src.worker.tasks.check_tasks",
+    "src.worker.tasks.audit_tasks",
+)
+
+_ASYNC_DATABASE_URL = "postgresql+asyncpg://user@localhost:5432/mistops"
+
+
+class _StubCelery:
+    """Celery stand-in whose task decorator returns the plain function."""
+
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        # The celeryconfig module assigns include and beat_schedule on conf.
+        self.conf = MagicMock(name="celery_conf")
+
+    def config_from_object(self, *_args: Any, **_kwargs: Any) -> None:
+        """Accept the broker settings and keep no state."""
+
+    def task(self, *_args: Any, **_kwargs: Any) -> Callable[[Any], Any]:
+        """Return a decorator that leaves the wrapped function callable."""
+
+        def _decorate(func: Any) -> Any:
+            # The test calls the task body directly, so no Celery wrapper may
+            # hide it behind a delay or an apply_async call.
+            return func
+
+        return _decorate
+
+
+class _StubSettings:
+    """Settings stand-in that carries the one field the scope reads."""
+
+    database_url = _ASYNC_DATABASE_URL
+    redis_url = "redis://localhost:6379/0"
+    sync_interval_seconds = 300
+    vault_addr = ""
+    vault_token = ""  # nosec B105 - The empty string means "not configured".
+
+
+def _build_stub_modules() -> dict[str, types.ModuleType]:
+    """Return the stub module for every missing import.
+
+    Returns:
+        A map of module name to the stub module that stands in for it.
+    """
+    celery_module = types.ModuleType("celery")
+    celery_module.Celery = _StubCelery  # type: ignore[attr-defined]
+    schedules_module = types.ModuleType("celery.schedules")
+    # The celeryconfig module calls crontab() to build the Beat schedule.
+    schedules_module.crontab = lambda **kwargs: kwargs  # type: ignore[attr-defined]
+
+    config_package = types.ModuleType("src.shared.config")
+    config_package.__path__ = []  # type: ignore[attr-defined]
+    settings_module = types.ModuleType("src.shared.config.settings")
+    settings_module.AppSettings = _StubSettings  # type: ignore[attr-defined]
+    settings_module.get_settings = _StubSettings  # type: ignore[attr-defined]
+    constants_module = types.ModuleType("src.shared.config.constants")
+    # The sync services read EntityType members at import time.
+    constants_module.EntityType = MagicMock(name="EntityType")  # type: ignore[attr-defined]
+    constants_module.JobStatus = MagicMock(name="JobStatus")  # type: ignore[attr-defined]
+
+    return {
+        "celery": celery_module,
+        "celery.schedules": schedules_module,
+        "src.shared.config": config_package,
+        "src.shared.config.settings": settings_module,
+        "src.shared.config.constants": constants_module,
+    }
+
+
+@pytest.fixture
+def ops_modules() -> Iterator[dict[str, types.ModuleType]]:
+    """Import the scope and the task modules under the stubs.
+
+    Yields:
+        A map that holds the shared scope module and each task module.
+    """
+    tracked = _STUBBED_MODULES + _RELOADED_MODULES
+    saved = {name: sys.modules.get(name) for name in tracked}
+    sys.modules.update(_build_stub_modules())
+    for name in _RELOADED_MODULES:
+        # A cached copy would hold the real settings import and would fail.
+        sys.modules.pop(name, None)
+    try:
+        import src.shared.sync_db as sync_db
+        import src.worker.tasks.audit_tasks as audit_tasks
+        import src.worker.tasks.check_tasks as check_tasks
+
+        yield {
+            "sync_db": sync_db,
+            "audit_tasks": audit_tasks,
+            "check_tasks": check_tasks,
+        }
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def _patch_engine(
+    sync_db: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> MagicMock:
+    """Replace the engine factory with a test double.
+
+    Returns:
+        The engine double, so the caller can assert on ``dispose``.
+    """
+    engine = MagicMock(name="engine")
+    # The real create_engine would open a PostgreSQL connection pool.
+    monkeypatch.setattr(sync_db, "create_engine", lambda _url: engine)
+    return engine
+
+
+def _patch_session(
+    module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replace the ORM session so no test reaches a real database."""
+    # A real Session would issue SQL against a server the test cannot reach.
+    monkeypatch.setattr(module, "Session", MagicMock(name="Session"))
+
+
+def _raise_runtime_error(*_args: Any, **_kwargs: Any) -> None:
+    """Fail the way a broken query or a lost network link fails."""
+    raise RuntimeError("stage failed")
+
+
+class TestSyncEngineScope:
+    """The shared scope must dispose the engine on both exit paths."""
+
+    def test_disposes_the_engine_after_success(
+        self,
+        ops_modules: dict[str, types.ModuleType],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        sync_db = ops_modules["sync_db"]
+        engine = _patch_engine(sync_db, monkeypatch)
+
+        with sync_db.sync_engine() as scoped:
+            assert scoped is engine
+
+        engine.dispose.assert_called_once_with()
+
+    def test_disposes_the_engine_after_failure(
+        self,
+        ops_modules: dict[str, types.ModuleType],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        sync_db = ops_modules["sync_db"]
+        engine = _patch_engine(sync_db, monkeypatch)
+
+        with pytest.raises(RuntimeError), sync_db.sync_engine():
+            _raise_runtime_error()
+
+        engine.dispose.assert_called_once_with()
+
+    def test_swaps_the_async_driver_for_the_blocking_driver(
+        self,
+        ops_modules: dict[str, types.ModuleType],
+    ) -> None:
+        sync_db = ops_modules["sync_db"]
+
+        url = sync_db.build_sync_url()
+
+        # The blocking Session cannot drive an asyncpg connection.
+        assert "+asyncpg" not in url
+        assert "+psycopg2" in url
+
+
+class TestCheckTasksDisposeEngine:
+    """Both check tasks must release the pool when the check stage fails."""
+
+    def test_pre_checks_dispose_the_engine_after_failure(
+        self,
+        ops_modules: dict[str, types.ModuleType],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        check_tasks = ops_modules["check_tasks"]
+        engine = _patch_engine(ops_modules["sync_db"], monkeypatch)
+        _patch_session(check_tasks, monkeypatch)
+        monkeypatch.setattr(check_tasks, "_execute_pre_checks", _raise_runtime_error)
+
+        with pytest.raises(RuntimeError):
+            check_tasks.run_pre_checks("job-1", "org-1", ["dev-1"])
+
+        engine.dispose.assert_called_once_with()
+
+    def test_post_checks_dispose_the_engine_after_failure(
+        self,
+        ops_modules: dict[str, types.ModuleType],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        check_tasks = ops_modules["check_tasks"]
+        engine = _patch_engine(ops_modules["sync_db"], monkeypatch)
+        _patch_session(check_tasks, monkeypatch)
+        monkeypatch.setattr(check_tasks, "_execute_post_checks", _raise_runtime_error)
+
+        with pytest.raises(RuntimeError):
+            check_tasks.run_post_checks("job-1", "org-1", ["dev-1"])
+
+        engine.dispose.assert_called_once_with()
+
+
+class TestAuditTasksDisposeEngine:
+    """Every audit task must release the pool when a query fails."""
+
+    def test_export_disposes_the_engine_after_failure(
+        self,
+        ops_modules: dict[str, types.ModuleType],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        audit_tasks = ops_modules["audit_tasks"]
+        engine = _patch_engine(ops_modules["sync_db"], monkeypatch)
+        _patch_session(audit_tasks, monkeypatch)
+        monkeypatch.setattr(audit_tasks, "_query_filtered", _raise_runtime_error)
+
+        with pytest.raises(RuntimeError):
+            audit_tasks.export_audit_records("org-1", "csv", {})
+
+        engine.dispose.assert_called_once_with()
+
+    def test_compliance_pack_disposes_the_engine_after_failure(
+        self,
+        ops_modules: dict[str, types.ModuleType],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        audit_tasks = ops_modules["audit_tasks"]
+        engine = _patch_engine(ops_modules["sync_db"], monkeypatch)
+        _patch_session(audit_tasks, monkeypatch)
+        monkeypatch.setattr(audit_tasks, "_query_date_range", _raise_runtime_error)
+
+        with pytest.raises(RuntimeError):
+            audit_tasks.generate_compliance_pack(
+                "org-1",
+                "SOC2",
+                "2026-01-01T00:00:00",
+                "2026-02-01T00:00:00",
+                "json",
+                "operator",
+            )
+
+        engine.dispose.assert_called_once_with()
+
+    def test_retention_cleanup_disposes_the_engine_after_failure(
+        self,
+        ops_modules: dict[str, types.ModuleType],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        audit_tasks = ops_modules["audit_tasks"]
+        engine = _patch_engine(ops_modules["sync_db"], monkeypatch)
+        _patch_session(audit_tasks, monkeypatch)
+        monkeypatch.setattr(audit_tasks, "_purge_table", _raise_runtime_error)
+
+        with pytest.raises(RuntimeError):
+            audit_tasks.run_retention_cleanup()
+
+        engine.dispose.assert_called_once_with()

--- a/scripts/check_top5_complexity.py
+++ b/scripts/check_top5_complexity.py
@@ -7,6 +7,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+# A wedged radon run holds the gate with no bound of its own. This cap turns
+# that stall into a clear message instead of a six-hour CI job.
+_RADON_TIMEOUT_SECONDS = 300
+
 TARGETS = {
     "MistHelper.py": [
         "_early_dependency_check",
@@ -21,7 +25,12 @@ TARGETS = {
 def _run_radon(path: str) -> list[dict[str, object]]:
     """Run radon CC in JSON mode and return function records."""
     command = [sys.executable, "-m", "radon", "cc", path, "-j"]
-    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    try:
+        # The bound stops a wedged radon run from hanging the whole gate.
+        result = subprocess.run(command, capture_output=True, text=True, check=False, timeout=_RADON_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        # Name the bound, so the operator can tell a stall from a crash.
+        raise RuntimeError(f"radon passed the {_RADON_TIMEOUT_SECONDS}s bound for {path}") from None
     if result.returncode != 0:
         raise RuntimeError(f"radon failed for {path}: {result.stderr.strip()}")
     payload = json.loads(result.stdout or "{}")

--- a/scripts/codeql_verdict_register.py
+++ b/scripts/codeql_verdict_register.py
@@ -36,6 +36,10 @@ DEFAULT_REGISTER_PATH = Path("documentation") / "security" / "codeql-verdict-reg
 # The number of days between a dismissal and the review that the register forces.
 REVIEW_INTERVAL_DAYS = 180
 
+# The gh call reaches the GitHub API over the network. A stalled read has no
+# bound of its own, so this cap stops it from hanging the whole gate.
+_GH_TIMEOUT_SECONDS = 120
+
 # The map from an API dismissal reason to a register verdict. The API accepts
 # three reasons, so the register holds one verdict for each reason.
 API_REASON_TO_VERDICT = {
@@ -126,12 +130,19 @@ class AlertSource:
         path = f"repos/{self.repository}/code-scanning/alerts?state=dismissed&per_page=100"
         logger.info("Reading dismissed CodeQL alerts for rule %s", self.rule_id)
         # Call the GitHub CLI, because it carries the credentials the user holds.
-        raw = subprocess.run(
-            ["gh", "api", "--paginate", path],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout
+        try:
+            raw = subprocess.run(
+                ["gh", "api", "--paginate", path],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=_GH_TIMEOUT_SECONDS,  # A stalled network read must not hang the gate.
+            ).stdout
+        except subprocess.TimeoutExpired:
+            # Name the bound, so the operator can tell a stall from a crash.
+            logger.error("The gh api call passed the %ds bound and was stopped", _GH_TIMEOUT_SECONDS)
+            msg = f"The GitHub API read passed the {_GH_TIMEOUT_SECONDS}s bound"
+            raise RuntimeError(msg) from None  # Fail loudly instead of returning an empty register.
         # Parse the response into Python objects.
         alerts = json.loads(raw)
         # Keep only the alerts that the register governs.

--- a/tests/unit/prod_readiness/test_subprocess_timeouts.py
+++ b/tests/unit/prod_readiness/test_subprocess_timeouts.py
@@ -1,0 +1,146 @@
+"""Tests that every helper subprocess call carries a timeout (issue #1943).
+
+A child process that never exits holds its parent forever. Four helper
+modules called ``subprocess.run`` with no ``timeout=`` argument. Three of the
+four run inside a CI quality gate, so a stalled git call or a stalled network
+read held the gate until the six-hour job limit ended it.
+
+These tests read the real call keywords through a recording double. They fail
+whenever a caller drops the bound again.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class _RecordingRun:
+    """Stand in for ``subprocess.run`` and keep the keywords it received."""
+
+    def __init__(self, returncode: int = 0, stdout: Any = "") -> None:
+        # The caller reads returncode and stdout, so the double carries both.
+        self.returncode = returncode
+        self.stdout = stdout
+        # The test asserts on this map after the call under test returns.
+        self.captured: dict[str, Any] = {}
+
+    def __call__(self, *args: Any, **kwargs: Any) -> _RecordingRun:
+        """Record the keywords and return this object as the result."""
+        self.captured = dict(kwargs)  # Copy, so a later call cannot mutate it.
+        return self  # The caller reads .returncode and .stdout off the result.
+
+
+class _TimeoutRun:
+    """Stand in for ``subprocess.run`` and always raise the timeout error."""
+
+    def __call__(self, *_args: Any, **_kwargs: Any) -> Any:
+        """Fail the way a wedged child process fails."""
+        raise subprocess.TimeoutExpired(cmd="stub", timeout=1)
+
+
+@pytest.fixture
+def repository_root() -> Iterator[Path]:
+    """Yield the repository root, because two calls read files below it."""
+    yield Path(__file__).resolve().parents[2]
+
+
+class TestSymbolDiffTimeout:
+    """The symbol comparator must bound its git call."""
+
+    def test_git_show_passes_a_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from tools.symbol_diff import comparator
+
+        recorder = _RecordingRun(returncode=0, stdout="x = 1\n")
+        monkeypatch.setattr(comparator.subprocess, "run", recorder)
+
+        comparator.SymbolTableComparator().read_revision("HEAD", Path("a.py"))
+
+        assert recorder.captured["timeout"] == comparator._GIT_TIMEOUT_SECONDS
+
+    def test_a_stalled_git_show_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from tools.symbol_diff import comparator
+
+        monkeypatch.setattr(comparator.subprocess, "run", _TimeoutRun())
+
+        result = comparator.SymbolTableComparator().read_revision("HEAD", Path("a.py"))
+
+        # The caller must skip the file, not crash the whole gate.
+        assert result is None
+
+
+class TestComplianceAnalyzerTimeout:
+    """The compliance analyzer must bound its git call."""
+
+    def test_check_ignore_passes_a_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from tools.compliance_analyzer import engine
+
+        recorder = _RecordingRun(returncode=0, stdout=b"")
+        monkeypatch.setattr(engine.subprocess, "run", recorder)
+        monkeypatch.setattr(engine.ComplianceAnalyzer, "_resolve_git_executable", staticmethod(lambda: "git"))
+
+        engine.ComplianceAnalyzer._filter_git_ignored([Path("a.py")])
+
+        assert recorder.captured["timeout"] == engine._GIT_TIMEOUT_SECONDS
+
+    def test_a_stalled_check_ignore_keeps_every_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from tools.compliance_analyzer import engine
+
+        monkeypatch.setattr(engine.subprocess, "run", _TimeoutRun())
+        monkeypatch.setattr(engine.ComplianceAnalyzer, "_resolve_git_executable", staticmethod(lambda: "git"))
+        files = [Path("a.py"), Path("b.py")]
+
+        result = engine.ComplianceAnalyzer._filter_git_ignored(files)
+
+        # The analyzer fails open, so it must never hide a file after a stall.
+        assert result == files
+
+
+class TestComplexityCheckTimeout:
+    """The complexity check must bound its radon call."""
+
+    def test_radon_passes_a_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from scripts import check_top5_complexity
+
+        recorder = _RecordingRun(returncode=0, stdout="{}")
+        monkeypatch.setattr(check_top5_complexity.subprocess, "run", recorder)
+
+        check_top5_complexity._run_radon("MistHelper.py")
+
+        assert recorder.captured["timeout"] == check_top5_complexity._RADON_TIMEOUT_SECONDS
+
+    def test_a_stalled_radon_raises_a_named_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from scripts import check_top5_complexity
+
+        monkeypatch.setattr(check_top5_complexity.subprocess, "run", _TimeoutRun())
+
+        with pytest.raises(RuntimeError, match="bound"):
+            check_top5_complexity._run_radon("MistHelper.py")
+
+
+class TestVerdictRegisterTimeout:
+    """The CodeQL verdict register must bound its network call."""
+
+    def test_gh_api_passes_a_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from scripts import codeql_verdict_register as register
+
+        recorder = _RecordingRun(returncode=0, stdout="[]")
+        monkeypatch.setattr(register.subprocess, "run", recorder)
+
+        register.AlertSource("owner/repo", "py/rule").fetch()
+
+        assert recorder.captured["timeout"] == register._GH_TIMEOUT_SECONDS
+
+    def test_a_stalled_gh_api_raises_a_named_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from scripts import codeql_verdict_register as register
+
+        monkeypatch.setattr(register.subprocess, "run", _TimeoutRun())
+
+        with pytest.raises(RuntimeError, match="bound"):
+            register.AlertSource("owner/repo", "py/rule").fetch()

--- a/tools/compliance_analyzer/engine.py
+++ b/tools/compliance_analyzer/engine.py
@@ -17,6 +17,10 @@ from .scoring import ComplianceScorer
 
 logger = logging.getLogger(__name__)  # Module-scoped logger for action logging.
 
+# A held git index lock or a credential prompt blocks a git call with no bound.
+# This cap turns that stall into a clear message instead of a six-hour CI job.
+_GIT_TIMEOUT_SECONDS = 30
+
 
 class _LogicalLineTracker:
     """Map a Python token stream to per-logical-line inline-comment coverage.
@@ -243,7 +247,12 @@ class ComplianceAnalyzer:
                 input=payload,  # Feed the collected file list as raw bytes.
                 capture_output=True,  # Capture the ignored-path bytes from stdout.
                 check=False,  # Exit 1 (none ignored) is normal, not an error.
+                timeout=_GIT_TIMEOUT_SECONDS,  # A held index lock must not stall the gate forever.
             )
+        except subprocess.TimeoutExpired:  # git held the pipe past the bound.
+            # Name the bound, so the operator can tell a stall from a crash.
+            print(f"compliance_analyzer: git check-ignore passed {_GIT_TIMEOUT_SECONDS}s and was stopped")
+            return files  # Fail open: never hide files when git cannot be consulted.
         except (OSError, ValueError):  # git binary missing or stdin write failure.
             return files  # Fail open: never hide files when git cannot be consulted.
         if completed.returncode not in (0, 1):  # 128 => not a git repo; other codes => unknown failure.

--- a/tools/symbol_diff/comparator.py
+++ b/tools/symbol_diff/comparator.py
@@ -25,6 +25,10 @@ _DEFINITION_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
 # step can then run the tool from any working directory and read the same files.
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 
+# A held git index lock or a credential prompt blocks a git call with no bound.
+# This cap turns that stall into a clear message instead of a six-hour CI job.
+_GIT_TIMEOUT_SECONDS = 30
+
 
 @dataclass(frozen=True)
 class SymbolDelta:
@@ -61,13 +65,20 @@ class SymbolTableComparator:
             print("symbol_diff: PATH holds no git executable")  # Tell the operator what is missing.
             return None  # The caller skips this file.
         logging.info("Reading %s from git", target)  # Log before the read.
-        completed = subprocess.run(  # nosec B603 - shutil.which resolved the path and the rest are literals.
-            [git_path, "show", target],  # A fixed argument list, so no shell parses the target.
-            capture_output=True,  # Capture the file text from stdout.
-            text=True,  # Decode to str, because ast.parse reads text.
-            check=False,  # An unknown path returns 128, which this method reports itself.
-            cwd=_REPOSITORY_ROOT,  # Read the repository, not the caller working directory.
-        )
+        try:
+            completed = subprocess.run(  # nosec B603 - shutil.which resolved the path and the rest are literals.
+                [git_path, "show", target],  # A fixed argument list, so no shell parses the target.
+                capture_output=True,  # Capture the file text from stdout.
+                text=True,  # Decode to str, because ast.parse reads text.
+                check=False,  # An unknown path returns 128, which this method reports itself.
+                cwd=_REPOSITORY_ROOT,  # Read the repository, not the caller working directory.
+                timeout=_GIT_TIMEOUT_SECONDS,  # A credential prompt must not stall the gate forever.
+            )
+        except subprocess.TimeoutExpired:  # git held the pipe past the bound.
+            # Name the bound, so the operator can tell a stall from a crash.
+            print(f"symbol_diff: git show passed {_GIT_TIMEOUT_SECONDS}s and was stopped")
+            logging.warning("The git show command passed the %ds bound", _GIT_TIMEOUT_SECONDS)
+            return None  # The caller skips this file.
         if completed.returncode != 0:  # git could not resolve the revision or the path.
             print(f"symbol_diff: cannot read {target}")  # Name the unreadable target.
             logging.warning("The git show command failed for %s", target)  # Log after the failure.


### PR DESCRIPTION
Closes #1942
Closes #1943

## Problem

Two defect classes reached production code.

The first is a leaked database connection pool. Eleven code paths in the ops
platform built a SQLAlchemy engine, used it inside a `with Session(engine)`
block, and then called `engine.dispose()` on the line after the block. The
`with` block guarded the session. Nothing guarded the engine. An exception
inside the block left the function through the exception path and skipped the
`dispose()` line.

Issue #1908 reported the same defect in `run_daily_backup`. Pull request #1920
fixed that one task. These eleven sites were not part of that fix.

The second is a subprocess call with no bound. Four helper modules called
`subprocess.run` with no `timeout=` argument. A child process that never exits
holds its parent forever.

## Impact

An engine owns a `QueuePool`. The default pool holds up to 5 live PostgreSQL
sockets plus 10 overflow sockets. A leaked pool keeps those sockets open for
the life of the process, and both process types that run this code live for a
long time. PostgreSQL ships with `max_connections = 100`, so about twenty
failed calls exhaust that limit. After the limit, every service on that
database fails to connect.

Two of the eleven sites are HTTP routes that an authenticated user can call at
will. A bad plan identifier raises inside the block, so a repeat caller could
take the database down.

A stalled `git`, `gh`, or `radon` call held a CI gate until the GitHub Actions
six-hour job limit ended it. The gate then reported no result, so the pull
request could not merge.

## Change

1. Add `mist-ops-platform/src/shared/sync_db.py`. It holds a `sync_engine`
   scope that disposes the engine from a `finally` block, so no exit path can
   skip the release. It also holds `build_sync_url`, which swaps the async
   driver for the blocking driver in one place.
2. Route all eleven sites through that scope. The sites live in
   `check_tasks.py`, `audit_tasks.py`, `deploy_tasks.py`, and
   `api/routes/deploy.py`.
3. Add a named timeout constant and an explicit `timeout=` argument to the
   four `subprocess.run` calls in `tools/compliance_analyzer/engine.py`,
   `tools/symbol_diff/comparator.py`, `scripts/codeql_verdict_register.py`,
   and `scripts/check_top5_complexity.py`.
4. Catch `subprocess.TimeoutExpired` at each call. The two analyzers fail open
   and keep every file, because a stall must never hide a file. The two
   scripts raise a clear error that names the bound.

## Tests

16 new tests. All 16 fail on the base revision and pass after the change.

`mist-ops-platform/tests/unit/worker/test_task_engine_disposal.py` holds 8
tests. Three prove the scope itself, and five prove that a task releases the
pool when its work stage raises. On the base revision the five task tests fail,
because the task modules built their engine directly and never entered a
guarded scope.

`tests/unit/prod_readiness/test_subprocess_timeouts.py` holds 8 tests. Four
read the real call keywords through a recording double and assert the bound.
Four replace the call with a stub that raises `TimeoutExpired` and assert the
caller behavior.

## Verification

| Gate | Result |
| - | - |
| `python -m ruff check .` | All checks passed |
| `python -m black` on every changed file | 11 files unchanged |
| `pytest tests/unit/prod_readiness tests/unit/tools` | 34 passed |
| `pytest mist-ops-platform/tests/unit/worker` | 26 passed |
| `pytest tests -k "compliance or complexity or codeql or symbol"` | 76 passed |
| `python -m py_compile` on every changed source file | No output |

The 26 ops platform tests include the 18 that pull request #1920 added, so the
earlier fix still holds.

`MistHelper.py` is untouched.

## Notes for the reviewer

The two test suites cannot run in one pytest process. The repository root and
the ops platform both own a package named `src`, so a combined run raises a
collection error. That constraint predates this change, and the sibling test
from #1920 has it too.
