### PR TITLE
security(web-portal): refuse a remote client when no allowlist is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,49 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   eslint peer range below the installed eslint 10.7.0, and both are the newest
   published releases. The workflow comment records the measurement.
 
+### Warning: the web portal now refuses a remote client by default (issue #1933)
+
+- **Warning: read this before you upgrade.** This entry changes a shipped
+  default. A running portal can stop answering a remote browser after the
+  upgrade. Set `PORTAL_ALLOWED_IPS` before you upgrade, and no operator loses
+  access. The startup log names the setting and gives an example value.
+- **Defect (Fixed)**: the web portal has no user authentication. The address
+  allowlist is the only access control it has. `PORTAL_ALLOWED_IPS` shipped
+  empty, and `SecurityMiddleware._register_ip_allowlist` read an empty value as
+  "accept every source address". A portal that reached a network therefore
+  served every page, every data browser table, and every operation to any
+  caller who reached the port. No credential was needed.
+- **Fallback (Added)**: an empty `PORTAL_ALLOWED_IPS` value no longer opens the
+  portal. `SecurityMiddleware._build_fallback_allowlist` picks a closed set of
+  networks that fits the run mode. Outside a container the portal serves the
+  loopback ranges `127.0.0.0/8` and `::1/128` only. The operator who starts the
+  portal keeps access.
+- **Container case (Added)**: inside a container the portal serves the private
+  ranges only. These are the two loopback ranges, `10.0.0.0/8`,
+  `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `fe80::/10`, and
+  `fc00::/7`. A container must bind every interface to answer a published port,
+  so a loopback rule would make every container unreachable. This fallback
+  blocks a direct path from the public internet. It does not replace a real
+  allowlist. Set `PORTAL_ALLOWED_IPS` on a container that faces a shared
+  network.
+- **Opt-out (Added)**: `PORTAL_ALLOW_PUBLIC_ACCESS` restores the old open
+  behavior. The portal accepts `1`, `true`, `yes`, and `on`. Every other value
+  keeps the portal shut, so a typing slip cannot open it. The portal writes a
+  warning to the log at every startup while the setting is true, so an audit
+  finds the choice.
+- **Startup message (Added)**: each fallback writes one warning. The message
+  names the served scope, names `PORTAL_ALLOWED_IPS`, gives the example value
+  `10.20.30.0/24,192.168.1.5`, and names the opt-out setting. The message is
+  ASCII only.
+- **Precedence (Unchanged)**: a configured `PORTAL_ALLOWED_IPS` value still
+  wins. The fallback ranges never widen an explicit allowlist.
+- **Tests (Added)**: `tests/unit/web_portal/test_portal_access_control_default.py`
+  adds 24 tests. Twelve of them failed before the fix. The proof case sends a
+  request from the public address `203.0.113.10` to a portal with no allowlist
+  and expects 403.
+- **Documentation (Changed)**: `deploy/.env.example` states the fallback, the
+  container ranges, and the opt-out.
+
 ### Stop the ZTP password from reaching a stored stream (issue #1735)
 
 - **Defect (Fixed)**: `src/device/_utility_commands_action.py` printed the live

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -96,10 +96,29 @@ MIST_ORG_ID=your_org_id_here
 # ============================================================
 
 # Comma-separated allowlist of source addresses for the web portal.
-# Each entry is a plain address or a CIDR range. An empty value allows
-# every source address. The portal compares the allowlist against the
-# socket peer address, which a caller cannot forge.
+# Each entry is a plain address or a CIDR range. The portal compares the
+# allowlist against the socket peer address, which a caller cannot forge.
+#
+# Warning: The portal has no user authentication. This allowlist is the only
+# access control. Set it before you expose the portal to a network.
+#
+# If this value stays empty, the portal falls back to a closed set of networks:
+#   - Outside a container, the portal serves the loopback address only.
+#   - Inside a container, the portal serves the private ranges only. These are
+#     127.0.0.0/8, ::1/128, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16,
+#     169.254.0.0/16, fe80::/10, and fc00::/7. A published port needs them.
+# The portal prints a warning at startup when a fallback runs.
 # PORTAL_ALLOWED_IPS=10.0.0.0/24,192.168.1.5
+
+# Set this value to true to serve every source address on purpose.
+# The default is empty, which keeps the fallback above in place.
+#
+# Warning: This setting removes the only access control the portal has. Any
+# caller who reaches the port then gets every page and every operation. Use
+# this setting only when another control, such as a reverse proxy that
+# authenticates a user, sits in front of the portal.
+# The portal writes a warning to the log at every startup while this is true.
+# PORTAL_ALLOW_PUBLIC_ACCESS=true
 
 # Comma-separated list of reverse proxy addresses that the portal trusts.
 # Each entry is a plain address or a CIDR range. The default is empty.

--- a/tests/unit/web_portal/test_portal_access_control_default.py
+++ b/tests/unit/web_portal/test_portal_access_control_default.py
@@ -1,0 +1,247 @@
+"""Prove that the portal refuses a remote client when no allowlist is set.
+
+The portal has no user authentication. `PORTAL_ALLOWED_IPS` defaults to an
+empty value, and the old code read an empty allowlist as "accept every source
+address". The portal therefore served every route to any caller who reached the
+port. See issue #1933.
+
+These tests hold the contract for the fix.
+
+- Without an allowlist, a workstation serves the loopback address only.
+- Without an allowlist, a container serves the private ranges only, because a
+  container that serves loopback only is unreachable through a published port.
+- An operator opts out on purpose with `PORTAL_ALLOW_PUBLIC_ACCESS`.
+- An explicit `PORTAL_ALLOWED_IPS` value still wins over every fallback.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from flask import Flask
+
+from src.utils.environment_utils import EnvironmentUtils
+from web_portal.services.config import PortalConfigLoader, SecurityMiddleware
+
+# A routable public address. No fallback may ever allow this address.
+PUBLIC_CLIENT = "203.0.113.10"
+
+# A private address that a container reaches through the bridge gateway.
+CONTAINER_GATEWAY = "172.17.0.1"
+
+# A private address on a normal office network.
+LAN_CLIENT = "192.168.1.50"
+
+# The loopback address that a workstation browser uses.
+LOOPBACK_CLIENT = "127.0.0.1"
+
+# The name of the deliberate opt-out setting.
+OPT_OUT_NAME = "PORTAL_ALLOW_PUBLIC_ACCESS"
+
+
+def _build_app(allowed_ips: list, trusted_proxies: list | None = None) -> Flask:
+    """Build a small Flask app that carries the security middleware."""
+    logging.info("Building a test portal with %d configured networks", len(allowed_ips))
+    app = Flask(__name__)
+    # The CSRF extension needs a secret key even when the check is off.
+    app.config["SECRET_KEY"] = "test-secret-key"
+    # Turn the CSRF check off, because these tests judge the address check only.
+    app.config["WTF_CSRF_ENABLED"] = False
+
+    @app.route("/")
+    def index():
+        return "portal home"
+
+    middleware = SecurityMiddleware()
+    middleware.apply(app, allowed_ips, trusted_proxies)
+    logging.debug("Built a test portal that serves one route")
+    return app
+
+
+def _get(app: Flask, client_ip: str):
+    """Send one request from a chosen source address."""
+    # `environ_base` sets the socket peer address that the middleware reads.
+    return app.test_client().get("/", environ_base={"REMOTE_ADDR": client_ip})
+
+
+@pytest.fixture
+def workstation(monkeypatch):
+    """Report that the process runs outside a container."""
+    logging.info("Forcing the container probe to report a workstation")
+    monkeypatch.setattr(EnvironmentUtils, "is_running_in_container", staticmethod(lambda: False))
+    # Clear the opt-out so that a leaked value from the shell cannot pass a test.
+    monkeypatch.delenv(OPT_OUT_NAME, raising=False)
+
+
+@pytest.fixture
+def container(monkeypatch):
+    """Report that the process runs inside a container."""
+    logging.info("Forcing the container probe to report a container")
+    monkeypatch.setattr(EnvironmentUtils, "is_running_in_container", staticmethod(lambda: True))
+    # Clear the opt-out so that the container fallback is the rule under test.
+    monkeypatch.delenv(OPT_OUT_NAME, raising=False)
+
+
+class TestWorkstationDefaultRefusesRemoteClients:
+    """Without an allowlist a workstation must serve the loopback address only."""
+
+    def test_a_public_client_is_refused(self, workstation) -> None:
+        """A public address never reaches a portal that has no allowlist."""
+        logging.info("Sending a request from a public address with no allowlist")
+        # An empty list is the shipped default, so this is the upgrade path.
+        response = _get(_build_app([]), PUBLIC_CLIENT)
+        assert response.status_code == 403, (
+            "A portal with no allowlist served a public address. "
+            "The portal has no authentication, so every route was open."
+        )
+        logging.debug("The public address received %d", response.status_code)
+
+    def test_a_lan_client_is_refused(self, workstation) -> None:
+        """A neighbour on the office network cannot reach a workstation portal."""
+        logging.info("Sending a request from a LAN address with no allowlist")
+        # A workstation run needs the loopback address only, so the LAN is out.
+        response = _get(_build_app([]), LAN_CLIENT)
+        assert response.status_code == 403, "A workstation portal served a LAN address."
+        logging.debug("The LAN address received %d", response.status_code)
+
+    def test_the_loopback_client_still_works(self, workstation) -> None:
+        """The operator who runs the portal still reaches it."""
+        logging.info("Sending a request from the loopback address with no allowlist")
+        # This case must keep working, because the fallback must not lock the
+        # operator out of a portal that runs on the same machine.
+        response = _get(_build_app([]), LOOPBACK_CLIENT)
+        assert response.status_code == 200, "The fallback locked the operator out of a local portal."
+        logging.debug("The loopback address received %d", response.status_code)
+
+
+class TestContainerDefaultRefusesPublicClients:
+    """Without an allowlist a container must serve the private ranges only."""
+
+    def test_a_public_client_is_refused(self, container) -> None:
+        """A public address never reaches a container portal that has no allowlist."""
+        logging.info("Sending a request from a public address inside a container")
+        # A container binds every interface, so the address check is the only
+        # control that remains. Read pull request #1877.
+        response = _get(_build_app([]), PUBLIC_CLIENT)
+        assert response.status_code == 403, "A container portal served a public address."
+        logging.debug("The public address received %d", response.status_code)
+
+    def test_the_bridge_gateway_still_works(self, container) -> None:
+        """A published port still reaches the portal from the host."""
+        logging.info("Sending a request from the container bridge gateway")
+        # A request through a published port arrives from the bridge gateway.
+        # A loopback only rule would make the container unreachable.
+        response = _get(_build_app([]), CONTAINER_GATEWAY)
+        assert response.status_code == 200, (
+            "The container fallback blocked the bridge gateway. "
+            "A published port would stop working after an upgrade."
+        )
+        logging.debug("The bridge gateway received %d", response.status_code)
+
+    def test_a_lan_client_still_works(self, container) -> None:
+        """An operator on the office network still reaches a container portal."""
+        logging.info("Sending a request from a LAN address inside a container")
+        # A NOC engineer browses from a desk, so the LAN must keep working.
+        response = _get(_build_app([]), LAN_CLIENT)
+        assert response.status_code == 200, "The container fallback blocked the office network."
+        logging.debug("The LAN address received %d", response.status_code)
+
+    def test_the_loopback_client_still_works(self, container) -> None:
+        """A health probe inside the container still reaches the portal."""
+        logging.info("Sending a request from the loopback address inside a container")
+        # The container health check calls the portal on the loopback address.
+        response = _get(_build_app([]), LOOPBACK_CLIENT)
+        assert response.status_code == 200, "The container fallback blocked the health probe."
+        logging.debug("The loopback address received %d", response.status_code)
+
+
+class TestTheOperatorCanOptOut:
+    """An operator who wants an open portal must say so on purpose."""
+
+    @pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes", "on"])
+    def test_the_opt_out_serves_a_public_client(self, workstation, monkeypatch, value) -> None:
+        """A deliberate opt-out restores the old open behavior."""
+        logging.info("Setting the opt-out to %s and sending a public request", value)
+        # The operator sets the value on purpose, so the portal obeys.
+        monkeypatch.setenv(OPT_OUT_NAME, value)
+        response = _get(_build_app([]), PUBLIC_CLIENT)
+        assert response.status_code == 200, f"The opt-out value {value!r} did not open the portal."
+        logging.debug("The opt-out value %s produced %d", value, response.status_code)
+
+    @pytest.mark.parametrize("value", ["false", "no", "0", "off", "", "maybe"])
+    def test_a_value_that_is_not_true_keeps_the_portal_closed(self, workstation, monkeypatch, value) -> None:
+        """Only a clear yes opens the portal."""
+        logging.info("Setting the opt-out to %s and sending a public request", value)
+        # A typing slip must never open the portal, so the parser fails closed.
+        monkeypatch.setenv(OPT_OUT_NAME, value)
+        response = _get(_build_app([]), PUBLIC_CLIENT)
+        assert response.status_code == 403, f"The value {value!r} opened the portal by accident."
+        logging.debug("The value %s produced %d", value, response.status_code)
+
+    def test_the_opt_out_records_a_warning(self, workstation, monkeypatch, caplog) -> None:
+        """The open choice appears in the log, so an audit finds it."""
+        logging.info("Checking that the opt-out writes a warning to the log")
+        monkeypatch.setenv(OPT_OUT_NAME, "true")
+        # Capture at warning level, because the message must be loud.
+        with caplog.at_level(logging.WARNING):
+            _build_app([])
+        # The message must name the setting so that a reader can undo the choice.
+        assert OPT_OUT_NAME in caplog.text, "The opt-out warning does not name the setting."
+        logging.debug("The opt-out wrote %d characters to the log", len(caplog.text))
+
+
+class TestAnExplicitAllowlistStillWins:
+    """A configured allowlist must override every fallback."""
+
+    def test_the_configured_network_is_served(self, workstation) -> None:
+        """An address inside the configured range reaches the portal."""
+        logging.info("Applying an explicit allowlist and sending a matching request")
+        # The operator named this range, so the portal serves it.
+        allowed = PortalConfigLoader.parse_networks("203.0.113.0/24", "PORTAL_ALLOWED_IPS")
+        response = _get(_build_app(allowed), PUBLIC_CLIENT)
+        assert response.status_code == 200, "An explicit allowlist did not serve its own range."
+        logging.debug("The configured address received %d", response.status_code)
+
+    def test_an_address_outside_the_configured_network_is_refused(self, workstation) -> None:
+        """The fallback ranges do not widen a configured allowlist."""
+        logging.info("Applying an explicit allowlist and sending a loopback request")
+        # The loopback address sits in the fallback, so this test proves that
+        # the fallback does not leak into an explicit configuration.
+        allowed = PortalConfigLoader.parse_networks("203.0.113.0/24", "PORTAL_ALLOWED_IPS")
+        response = _get(_build_app(allowed), LOOPBACK_CLIENT)
+        assert response.status_code == 403, "The fallback widened an explicit allowlist."
+        logging.debug("The loopback address received %d", response.status_code)
+
+
+class TestTheFallbackTellsTheOperatorWhatToDo:
+    """The startup message must name the setting and give an example."""
+
+    def test_the_workstation_fallback_writes_one_warning(self, workstation, caplog) -> None:
+        """The message names the setting that turns the fallback off."""
+        logging.info("Checking the workstation fallback startup message")
+        with caplog.at_level(logging.WARNING):
+            _build_app([])
+        # A reader must learn the exact setting name from the message.
+        assert "PORTAL_ALLOWED_IPS" in caplog.text, "The warning does not name PORTAL_ALLOWED_IPS."
+        # A reader must also learn the opt-out, so the message covers both paths.
+        assert OPT_OUT_NAME in caplog.text, "The warning does not name the opt-out setting."
+        logging.debug("The workstation fallback wrote a warning")
+
+    def test_the_message_holds_an_example_value(self, workstation, caplog) -> None:
+        """The message shows a CIDR range that an operator can copy."""
+        logging.info("Checking that the startup message holds an example")
+        with caplog.at_level(logging.WARNING):
+            _build_app([])
+        # A junior engineer needs a value to copy, not only a setting name.
+        assert "/" in caplog.text, "The warning holds no CIDR example."
+        logging.debug("The startup message holds an example")
+
+    def test_the_message_is_ascii(self, workstation, caplog) -> None:
+        """The log holds no character above the ASCII range."""
+        logging.info("Checking that the startup message is ASCII")
+        with caplog.at_level(logging.WARNING):
+            _build_app([])
+        # The project forbids a Unicode character in a log line.
+        assert caplog.text.isascii(), "The startup message holds a character above ASCII."
+        logging.debug("The startup message is ASCII")

--- a/web_portal/services/config.py
+++ b/web_portal/services/config.py
@@ -8,6 +8,13 @@ The IP allowlist judges the socket peer address from `request.remote_addr`.
 The portal reads the `X-Forwarded-For` header only when the peer address
 matches an entry in `PORTAL_TRUSTED_PROXIES`. That setting is empty by
 default, so a client-supplied header never changes the decision.
+
+The portal has no user authentication. The address allowlist is therefore the
+only access control. `PORTAL_ALLOWED_IPS` is empty by default, so the portal
+falls back to a closed set of networks. A workstation serves the loopback
+address only. A container serves the private ranges only, because a container
+that serves loopback only cannot answer a published port. An operator opens the
+portal to every address with `PORTAL_ALLOW_PUBLIC_ACCESS`. See issue #1933.
 """
 
 import ipaddress
@@ -17,6 +24,36 @@ import re
 import uuid
 
 from flask import Flask, abort, request
+
+from src.utils.environment_utils import EnvironmentUtils
+
+# The networks that a workstation serves when the operator sets no allowlist.
+# A browser on the same machine uses one of these two addresses.
+LOOPBACK_FALLBACK_NETWORKS = ("127.0.0.0/8", "::1/128")
+
+# The networks that a container serves when the operator sets no allowlist.
+# The list holds the loopback ranges for the health probe, the three RFC 1918
+# ranges for an office network, the link-local ranges, and the IPv6 private
+# range. A container reaches a published port through a private address.
+PRIVATE_FALLBACK_NETWORKS = (
+    "127.0.0.0/8",
+    "::1/128",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+    "169.254.0.0/16",
+    "fe80::/10",
+    "fc00::/7",
+)
+
+# The setting that an operator sets to serve every source address on purpose.
+PUBLIC_ACCESS_SETTING = "PORTAL_ALLOW_PUBLIC_ACCESS"
+
+# The values that count as a clear yes. Every other value keeps the portal shut.
+AFFIRMATIVE_VALUES = frozenset({"1", "true", "yes", "on"})
+
+# An example value for the startup message. A junior engineer copies this shape.
+ALLOWLIST_EXAMPLE = "10.20.30.0/24,192.168.1.5"
 
 
 class PortalConfigLoader:
@@ -34,6 +71,7 @@ class PortalConfigLoader:
         "WEB_PORT": "8055",
         "PORTAL_ALLOWED_IPS": "",
         "PORTAL_TRUSTED_PROXIES": "",
+        PUBLIC_ACCESS_SETTING: "",
     }
 
     def load_config(self) -> dict:
@@ -131,14 +169,64 @@ class SecurityMiddleware:
         logging.info("Applying the portal security controls to the Flask application")
         # Resolve the trusted proxies first, because the allowlist hook reads them.
         self._trusted_proxies = self._resolve_trusted_proxies(trusted_proxies)
+        # Resolve the allowlist next, because an empty setting needs a safe fallback.
+        effective_ips = self._resolve_effective_allowlist(allowed_ips)
         self._register_csp_headers(app)
-        self._register_ip_allowlist(app, allowed_ips)
+        self._register_ip_allowlist(app, effective_ips)
         self._configure_csrf(app)
         logging.debug(
             "Applied the portal security controls with %d allowed networks and %d trusted proxies",
-            len(allowed_ips),
+            len(effective_ips),
             len(self._trusted_proxies),
         )
+
+    def _resolve_effective_allowlist(self, allowed_ips: list) -> list:
+        """Return the networks that the portal serves after the fallback runs."""
+        if allowed_ips:
+            # The operator named the networks, so the portal obeys the setting.
+            logging.debug("Using the %d networks that the operator configured", len(allowed_ips))
+            return allowed_ips
+        if self._public_access_is_allowed():
+            # The operator chose an open portal, so the log records the choice.
+            logging.warning(
+                "Warning: the portal serves every source address, because %s is set. "
+                "The portal has no user authentication. Any caller who reaches the port "
+                "gets every page. Set PORTAL_ALLOWED_IPS instead, for example %s.",
+                PUBLIC_ACCESS_SETTING,
+                ALLOWLIST_EXAMPLE,
+            )
+            return []  # An empty list turns the address check off on purpose.
+        return self._build_fallback_allowlist()
+
+    @staticmethod
+    def _public_access_is_allowed() -> bool:
+        """Return True when the operator opts out of the address check."""
+        # An unset value reads as an empty string, which is not a clear yes.
+        raw = os.environ.get(PUBLIC_ACCESS_SETTING, "").strip().lower()
+        # Only a value from the affirmative set opens the portal, so a typing
+        # slip such as "maybe" leaves the portal shut.
+        return raw in AFFIRMATIVE_VALUES
+
+    def _build_fallback_allowlist(self) -> list:
+        """Return the closed network set that fits the current run mode."""
+        in_container = EnvironmentUtils.is_running_in_container()
+        # A container answers a published port from a private address, so a
+        # loopback only rule would make every existing deployment unreachable.
+        sources = PRIVATE_FALLBACK_NETWORKS if in_container else LOOPBACK_FALLBACK_NETWORKS
+        scope = "the private network ranges" if in_container else "the loopback address"
+        logging.warning(
+            "Warning: the portal has no user authentication and no configured allowlist. "
+            "The portal now serves %s only. Set PORTAL_ALLOWED_IPS to the networks that "
+            "need access, for example %s. To serve every source address on purpose, set "
+            "%s to true.",
+            scope,
+            ALLOWLIST_EXAMPLE,
+            PUBLIC_ACCESS_SETTING,
+        )
+        # Every entry is a fixed constant, so the parser cannot raise an error.
+        networks = [ipaddress.ip_network(entry) for entry in sources]
+        logging.debug("Built a fallback allowlist of %d networks", len(networks))
+        return networks
 
     def _resolve_trusted_proxies(self, trusted_proxies: list | None) -> list:
         """Return the proxy networks that may set the forwarded header."""
@@ -163,7 +251,9 @@ class SecurityMiddleware:
     def _register_ip_allowlist(self, app: Flask, allowed_ips: list) -> None:
         """Block requests from IPs not in the allowlist."""
         if not allowed_ips:
-            return  # An empty allowlist means the operator accepts every source address.
+            # The caller reaches this line only after a deliberate opt-out.
+            # `_resolve_effective_allowlist` already logged that choice.
+            return
 
         logging.info("Registering the portal IP allowlist with %d networks", len(allowed_ips))
 


### PR DESCRIPTION
Fixes #1933.

## Warning: read this before you merge

This pull request changes a shipped default. A running portal can stop
answering a remote browser after the upgrade. Do not add the `auto-merge`
label. A human must judge the rollout.

**What an operator must do before the upgrade:** set `PORTAL_ALLOWED_IPS` to
the networks that need access. For example, `PORTAL_ALLOWED_IPS=10.20.30.0/24`.
An operator who does this loses no access at all.

## Problem

The web portal has no user authentication. The address allowlist is the only
access control it has. `PORTAL_ALLOWED_IPS` shipped empty, and
`_register_ip_allowlist` read an empty value as "accept every source address":

```python
if not allowed_ips:
    return  # An empty allowlist means the operator accepts every source address.
```

A portal that reached a network therefore served every page, every data
browser table, and every operation to any caller who reached the port. No
credential was needed. Every other defect this fleet found in the portal is
reachable without authentication.

## The fix

The gate is fail-closed, and it has a clear escape hatch.

| Condition | Result |
| - | - |
| `PORTAL_ALLOWED_IPS` is set | Use it. No change at all. |
| `PORTAL_ALLOW_PUBLIC_ACCESS` is true | Serve everyone. Log a warning at every startup. |
| Empty allowlist, no container | Serve the loopback ranges only. |
| Empty allowlist, in a container | Serve the private ranges only. |

Each fallback writes one loud startup warning. The message names the served
scope, names `PORTAL_ALLOWED_IPS`, gives the example value
`10.20.30.0/24,192.168.1.5`, and names the opt-out setting. The message is
ASCII only.

The opt-out accepts `1`, `true`, `yes`, and `on`. Every other value keeps the
portal shut, so a typing slip cannot open it.

## Why a container gets a wider set

A container must bind every interface to answer a published port. A container
that serves the loopback address only is unreachable through
`podman run -p 8055:8055`. A request through a published port arrives from the
bridge gateway, which is a private address.

A loopback rule inside a container is therefore a hard lockout for every
existing deployment. The private ranges keep a normal deployment working and
still block a direct path from the public internet.

**State the tradeoff plainly.** The container fallback is a mitigation, not a
full control. A container on a shared corporate network still serves that whole
network. An operator must set `PORTAL_ALLOWED_IPS` on any container that faces a
shared network. The startup warning says so.

## Coordination with pull request #1877

Pull request #1877 sets the bind address in `MistHelper.py`. It binds loopback
outside a container and `0.0.0.0` inside a container. The lanes do not overlap.

- #1877 owns the bind address in `MistHelper.py`. This branch does not touch
  that file.
- This branch owns the access control inside `web_portal/`.

The two changes agree. Outside a container both layers pick loopback. Inside a
container #1877 must bind every interface, so this allowlist is the only
control that remains there. The changes reinforce each other. They do not
fight.

## Evidence

`web_portal/services/config.py:163-166` on `main` holds the early return shown
above.

## Tests

`tests/unit/web_portal/test_portal_access_control_default.py` adds 24 tests.
**Twelve of them failed before the fix.** The proof case sends a request from
the public address `203.0.113.10` to a portal with no allowlist and expects
403. On `main` that request returns 200.

The tests cover every branch:

- A public client and a LAN client are refused on a workstation.
- The loopback client still works, so a local operator is not locked out.
- A container refuses a public client.
- A container still serves the bridge gateway, the office network, and the
  health probe.
- The opt-out serves a public client and records a warning.
- Six values that are not a clear yes keep the portal shut.
- An explicit allowlist still wins, and the fallback never widens it.
- The startup message names both settings, holds a CIDR example, and is ASCII.

## Verification

- `python -m pytest tests/unit/web_portal/ -q` reports 147 passed. The 15
  existing allowlist tests from #1857 still pass.
- `python -m pytest tests/unit -q` reports 3935 passed. The one failure,
  `test_has_pyte_flag_reflects_import_state`, also fails on `main` on this
  workstation, because `pyte` is not installed here.
- `python -m ruff check` and `python -m black --check` pass on both changed
  Python files.
- `python -c "import web_portal.app"` still works, so the new import adds no
  cycle.

## Rollout guidance

1. Set `PORTAL_ALLOWED_IPS` in `.env` on every deployment first.
2. Upgrade.
3. Read the startup log. A warning means the fallback ran and a setting is
   missing.
4. Use `PORTAL_ALLOW_PUBLIC_ACCESS=true` only when another control, such as a
   reverse proxy that authenticates a user, sits in front of the portal.

## Remaining work

This change limits **who** reaches the portal. It does not add user
authentication. The portal still has no login, so every caller inside an
allowed range holds full rights. Issue #1933 should stay open for that larger
piece of work, or a new issue should carry it.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
