### PR TITLE
ci: run the quality gates on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,14 @@
 name: Quality Gates
 
 on:
+  # No branch filter here. A pull request against any base runs every gate.
+  # A filter that named main alone let a stacked pull request merge with zero
+  # checks, which a reviewer reads as clean rather than unmeasured. Issue #1952
+  # records that gap.
   pull_request:
-    branches: [main]
   push:
+    # The push trigger stays pinned to main. A push run on every branch would
+    # repeat the pull request run and add cost with no added signal.
     branches: [main]
   workflow_dispatch:
   workflow_call:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Run the quality gates on every pull request (issue #1952)
+
+- **Defect (Fixed)**: `.github/workflows/ci.yml` started on a pull request that
+  targeted `main` only. A pull request against any other base ran no gate. Ruff,
+  Black, mypy, pytest, the coverage gate, Bandit, pip-audit, Pylint, Radon,
+  Vulture, and both docstring gates all stayed silent.
+- **Evidence (Measured)**: pull request #1890 targets
+  `feat/1823-upgrade-capture-portal`. It reported 0 successful checks and 0
+  failed checks, while every pull request against `main` reported 17 to 19. The
+  pull request was closed and reopened to force a new run. The count stayed at
+  zero, which rules out a missed event.
+- **Reader risk (Explained)**: the pull request also reported a `CLEAN` merge
+  state. `CLEAN` means no required check is failing. A reviewer reads an empty
+  check list as safe, and the correct reading is unmeasured.
+- **Trigger (Changed)**: the `pull_request` trigger now carries no branch
+  filter, so a pull request against any base runs every gate.
+- **Cost control (Kept)**: the `push` trigger stays pinned to `main`. A push run
+  on every branch would repeat the pull request run and add no signal.
+- **Tests (Added)**: `tests/guardrails/test_ci_gate_triggers.py` holds 5 tests.
+  They pin the absent branch filter and the narrow push trigger. The tests were
+  verified red first. They report 2 failures against the old workflow and 5
+  passes against the new one.
+
 ### Stop the ZTP password from reaching a stored stream (issue #1735)
 
 - **Defect (Fixed)**: `src/device/_utility_commands_action.py` printed the live

--- a/tests/guardrails/test_ci_gate_triggers.py
+++ b/tests/guardrails/test_ci_gate_triggers.py
@@ -1,0 +1,99 @@
+"""Guardrails for the events that start the quality gate workflow.
+
+Issue #1952 recorded that `.github/workflows/ci.yml` started on a pull request
+that targeted `main` only. A pull request against any other base ran no gate at
+all. It reported zero checks and a `CLEAN` merge state, which a reviewer reads
+as safe rather than unmeasured.
+
+Pull request #1890 showed the behavior. It reported 0 successful checks and 0
+failed checks, while every pull request against `main` reported 17 to 19.
+
+The repair removes the branch filter from the `pull_request` trigger. These
+tests hold the repair in place. A change that restores the filter fails a test.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+# The workflow sits three directories above this test file.
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Name the workflow once, because every test below reads the same file.
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+# PyYAML turns the bare `on` key into the boolean True, so name that key once.
+TRIGGER_KEY = True
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    """Parse the quality gate workflow and return the mapping."""
+    # Read with an explicit encoding, because the Windows default differs.
+    text = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    # Parse with the safe loader, because the file is untrusted configuration.
+    parsed = yaml.safe_load(text)
+
+    # Fail early with a clear message, because a non-mapping breaks each test.
+    assert isinstance(parsed, dict), "The quality gate workflow must be a mapping."
+
+    return parsed
+
+
+class TestPullRequestTrigger:
+    """Check the pull request event that starts the quality gates."""
+
+    def test_workflow_file_exists(self) -> None:
+        """The workflow file must exist, because every other test reads it."""
+        # A missing file means the gates are gone, so state that plainly.
+        assert CI_WORKFLOW.is_file(), f"Missing workflow: {CI_WORKFLOW}"
+
+    def test_pull_request_trigger_is_present(self, workflow: dict[str, Any]) -> None:
+        """A pull request must start the quality gates."""
+        # Without this trigger no pull request is measured at all.
+        assert "pull_request" in workflow[TRIGGER_KEY], "A pull request must run CI."
+
+    def test_pull_request_has_no_branch_filter(self, workflow: dict[str, Any]) -> None:
+        """Every pull request must run the gates, whatever its base branch."""
+        # Read the trigger. A bare key parses to None, which means every branch.
+        trigger = workflow[TRIGGER_KEY]["pull_request"]
+
+        # A None trigger is the repaired shape, so accept it and stop here.
+        if trigger is None:
+            return
+
+        # A mapping with a branch filter is the exact defect that #1952 records.
+        assert "branches" not in trigger, (
+            "The pull_request trigger must carry no branch filter. "
+            "A filter lets a stacked pull request merge with zero checks."
+        )
+
+    def test_stacked_base_branch_is_not_excluded(self, workflow: dict[str, Any]) -> None:
+        """A pull request against a feature branch must not be filtered out."""
+        # Read the trigger, because the check below inspects any surviving filter.
+        trigger = workflow[TRIGGER_KEY]["pull_request"]
+
+        # The repaired shape parses to None, so no branch can be excluded.
+        if trigger is None:
+            return
+
+        # If a filter survives, it must at least admit a feature branch pattern.
+        branches = trigger.get("branches", [])
+
+        # A filter of main alone reproduces the defect, so reject that exact case.
+        assert branches != ["main"], "A filter of main alone reproduces issue #1952."
+
+
+class TestPushTrigger:
+    """Check the push event, which must stay narrow."""
+
+    def test_push_stays_pinned_to_main(self, workflow: dict[str, Any]) -> None:
+        """The push trigger must stay on main, so no branch runs twice."""
+        # Read the push trigger, because a wide filter doubles every run.
+        push = workflow[TRIGGER_KEY]["push"]
+
+        # A push run on every branch repeats the pull request run and adds cost.
+        assert push["branches"] == ["main"], "The push trigger must stay on main."


### PR DESCRIPTION
Closes #1952

## Problem

`.github/workflows/ci.yml` started on a pull request that targeted `main` only:

```
on:
  pull_request:
    branches: [main]
```

A pull request against any other base started no quality gate. Ruff, Black, mypy, pytest, the coverage gate, Bandit, pip-audit, Pylint, Radon, Vulture, and both docstring gates all stayed silent.

The pull request reported no check at all, rather than a failing check. A reviewer reads an empty check list as safe. The correct reading is unmeasured.

## Evidence

Pull request #1890 is open now and shows the behavior.

| Field | Value |
| - | - |
| Head | `fix/1827-upgrade-lock-store` |
| Base | `feat/1823-upgrade-capture-portal` |
| Successful checks | 0 |
| Failed checks | 0 |
| `mergeStateStatus` | `CLEAN` |

`CLEAN` means no required check is failing. No check ran.

The state is not stale. The pull request was closed and reopened during this cycle to force a new run. The count stayed at zero, which rules out a missed event and confirms the branch filter as the cause.

Every pull request that targeted `main` this cycle reported 17 to 19 successful checks.

## Impact

Work reaches `main` without ever passing a gate on its own. A stacked pull request merges into a feature branch with no gates, and the feature branch later merges into `main`. The gates then run once, on the combined result. A defect that a gate would have caught on the small change is mixed into a large one, where attribution is much harder.

This also reduces the value of the other gate repairs in flight. Issues #1895, #1948, #1763, and #1795 each add or repair a gate. A gate that never starts cannot help.

## Solution

Remove the branch filter from the `pull_request` trigger. A pull request against any base now runs every gate.

The `push` trigger stays pinned to `main`. A push run on every branch would repeat the pull request run and add cost with no added signal.

## Test evidence

`tests/guardrails/test_ci_gate_triggers.py` adds 5 tests. They pin the absent branch filter and the narrow push trigger.

The tests were verified red first:

```
Against the old workflow: 3 passed, 2 failed
Against the new workflow: 5 passed
```

The full guardrail suite reports 78 passed.

Ruff and Black pass on the new test file. The mypy scope is `src/ MistHelper.py wsgi.py`, so a file under `tests/` stays out of that gate.

## Expected effect on this repository

Open pull requests that target a feature branch will start reporting checks. Pull request #1890 is the clearest example, and it may report its first real gate result after this lands. A red result there is new information, not a new defect.

## Conformance

- [x] Linked to the originating issue
- [x] A failing test proved the defect before the fix
- [x] The test passes after the fix
- [x] Ruff passes
- [x] Black passes
- [x] CHANGELOG.md updated
- [x] No secret is added
- [x] Simplified Technical English used in all text and comments

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
