### PR TITLE
fix(ops-platform): repair 10 deselected tests and shrink the gate deselect list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,13 +70,15 @@ env:
   INTERROGATE_PATHS: 'src/ MistHelper.py wsgi.py starlink_dashboard.py web_portal tools'
   COVERAGE_THRESHOLD: ${{ inputs.coverage-threshold || '80' }}
   # Issue #1895: the ops platform suite keeps its own denominator and its own
-  # floor, so it can never move the root percentage. The suite collects 302
-  # tests and measures 53.9 percent. The floor sits under that number, so a
-  # coverage drop fails the gate. Issue #1897 raises the floor toward 80.
-  OPS_PLATFORM_COVERAGE_THRESHOLD: '50'
-  # The count floor proves the gate ran the tests. A broken import path drops
-  # the collected count, and this floor turns that drop into a red gate.
-  OPS_PLATFORM_MIN_TESTS: '280'
+  # floor, so it can never move the root percentage. The suite measures 53.91
+  # percent. The floor sits just under that number, so a coverage drop fails the
+  # gate. Issue #1883 unblocks the last 2 tests and raises the floor further.
+  OPS_PLATFORM_COVERAGE_THRESHOLD: '53'
+  # The count floor proves the gate ran the tests. A broken import path drops a
+  # whole module from collection, and this floor turns that drop into a red gate.
+  # The suite collects 334 tests. If you delete a test on purpose, lower this
+  # number in the same commit.
+  OPS_PLATFORM_MIN_TESTS: '330'
   PYLINT_THRESHOLD: ${{ inputs.pylint-threshold || '9.5' }}
   INTERROGATE_THRESHOLD: ${{ inputs.interrogate-threshold || '90' }}
   # Vulture reports 0 findings at 90, at 80, and at 70. The cliff sits at 60, which
@@ -564,7 +566,7 @@ jobs:
     # every event rather than behind a path filter, because a skipped result is
     # ambiguous to a reviewer and to a branch protection rule.
     #
-    # The gate blocks. It runs 290 tests and it fails on a red test, on a
+    # The gate blocks. It runs 300 tests and it fails on a red test, on a
     # coverage drop, and on a drop in the collected count.
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -600,26 +602,18 @@ jobs:
         # measures mist-ops-platform/src only, so neither percentage moves the
         # other.
         #
-        # The 12 deselected tests fail on main today. They assert behavior that
-        # the source does not have, so they are product defects and not gate
-        # defects. Issue #1883 covers the six schema mismatches. Issue #1897
-        # tracks the removal of this list. Do not add a test to this list to
-        # make a new failure go away. Fix the code instead.
+        # The 2 deselected tests fail on main today. They assert the table names
+        # that migration 0001 creates, and the ORM models declare different names
+        # and different columns. Issue #1883 covers that divergence. The repair is
+        # a schema migration and not a test edit, so the pair stays deselected.
+        # Issue #1897 tracks the removal of this list.
+        # Do not add a test to this list to make a new failure go away. Fix the
+        # code instead.
         run: |
           pytest --cov=src \
             --cov-fail-under=${{ env.OPS_PLATFORM_COVERAGE_THRESHOLD }} \
-            --deselect tests/contract/test_api_contracts.py::TestSyncContracts::test_sync_status_response_fields \
-            --deselect tests/contract/test_api_contracts.py::TestConfigContracts::test_revision_response_fields \
-            --deselect tests/contract/test_api_contracts.py::TestConfigContracts::test_diff_request_requires_two_revisions \
-            --deselect tests/contract/test_api_contracts.py::TestDeployContracts::test_job_create_payload \
-            --deselect tests/contract/test_api_contracts.py::TestDeployContracts::test_rollout_create_has_waves \
-            --deselect tests/contract/test_api_contracts.py::TestAuditContracts::test_audit_record_response \
-            --deselect tests/integration/test_drift.py::TestDriftDetectionIntegration::test_drift_change_paths_are_descriptive \
-            --deselect tests/integration/test_e2e_smoke.py::TestE2ESmokeComponents::test_celery_app_importable \
-            --deselect tests/integration/test_e2e_smoke.py::TestE2ESmokeComponents::test_all_routes_registered \
             --deselect tests/unit/shared/test_models_inventory.py::TestOrganization::test_tablename \
-            --deselect tests/unit/shared/test_models_inventory.py::TestSyncLedgerEntry::test_tablename \
-            --deselect tests/unit/shared/test_models_inventory.py::TestSyncLedgerEntry::test_primary_key
+            --deselect tests/unit/shared/test_models_inventory.py::TestSyncLedgerEntry::test_tablename
 
   # ──────────────────────────────────────────────────────────────
   # FAILURE → GITHUB ISSUES (auto-create issues for each failure)

--- a/mist-ops-platform/src/shared/services/diff.py
+++ b/mist-ops-platform/src/shared/services/diff.py
@@ -14,6 +14,22 @@ from deepdiff import DeepDiff
 
 logger = logging.getLogger(__name__)
 
+# The four labels below are the whole public vocabulary of DiffChange.change_type.
+# A drift alert, a config diff response, and the ops portal all read this field,
+# so the value must stay stable. deepdiff uses its own longer key names, such as
+# "dictionary_item_added". _collect_additions and its siblings map those keys onto
+# this set, which keeps the deepdiff vocabulary out of the API.
+# ScheduledJob.change_type is a String(20) column, so every label must fit in 20
+# characters. The longest label here is "value_changed" at 13 characters.
+DIFF_CHANGE_TYPES: frozenset[str] = frozenset(
+    {
+        "value_changed",
+        "item_added",
+        "item_removed",
+        "type_changed",
+    }
+)
+
 
 class DiffChange:
     """Single field-level change record."""

--- a/mist-ops-platform/tests/contract/test_api_contracts.py
+++ b/mist-ops-platform/tests/contract/test_api_contracts.py
@@ -66,41 +66,50 @@ class TestSyncContracts:
         assert req.org_id is not None
 
     def test_sync_status_response_fields(self) -> None:
+        # This test sent org_id, status, last_sync_at, and next_sync_at. The schema
+        # names its fields orgId, state, lastSyncAt, and nextPollAt, and it sets no
+        # alias, so every one of those four names was wrong.
         resp = SyncStatusResponse(
-            org_id=str(uuid.uuid4()),
-            status="idle",
-            last_sync_at=datetime.now(tz=UTC),
-            next_sync_at=None,
+            orgId=uuid.uuid4(),
+            state="idle",
+            lastSyncAt=datetime.now(tz=UTC),
+            nextPollAt=None,
         )
         data = resp.model_dump()
-        assert "org_id" in data
-        assert "status" in data
+        assert "orgId" in data
+        assert "state" in data
 
 
 class TestConfigContracts:
     """Verify config endpoint schemas."""
 
     def test_revision_response_fields(self) -> None:
+        # This test sent org_id, config_blob, and config_hash. The schema carries
+        # none of those three names. It requires content_hash, and it exposes
+        # revision_id under the alias revision_number. The schema sets no
+        # populate_by_name, so a caller must use the alias.
         resp = RevisionResponse(
-            revision_id=str(uuid.uuid4()),
+            revision_number=1,
             entity_type="device",
-            entity_id=str(uuid.uuid4()),
-            org_id=str(uuid.uuid4()),
-            config_blob={"radio": {"power": 10}},
-            config_hash="abc123",
+            entity_id=uuid.uuid4(),
+            content_hash="abc123",
             captured_at=datetime.now(tz=UTC),
             source="sync",
         )
         data = resp.model_dump()
         assert "revision_id" in data
-        assert "config_blob" in data
+        assert "content_hash" in data
 
     def test_diff_request_requires_two_revisions(self) -> None:
+        # This test sent revision_a and revision_b. The schema requires org_id,
+        # old_revision_id, and new_revision_id, and the revision keys are integers
+        # rather than UUID strings.
         req = DiffRequest(
-            revision_a=str(uuid.uuid4()),
-            revision_b=str(uuid.uuid4()),
+            org_id=uuid.uuid4(),
+            old_revision_id=1,
+            new_revision_id=2,
         )
-        assert req.revision_a != req.revision_b
+        assert req.old_revision_id != req.new_revision_id
 
     def test_time_travel_request(self) -> None:
         req = TimeTravelRequest(
@@ -116,9 +125,13 @@ class TestDeployContracts:
     """Verify deploy endpoint schemas."""
 
     def test_job_create_payload(self) -> None:
+        # This test omitted scheduled_at. JobCreate requires it, because the deploy
+        # route writes it straight to ScheduledJob.scheduled_at. JobUpdate is the
+        # schema that makes the field optional, so the requirement is deliberate.
         job = JobCreate(
-            org_id=str(uuid.uuid4()),
+            org_id=uuid.uuid4(),
             change_payload={"radio": {"power": 12}},
+            scheduled_at=datetime.now(tz=UTC),
             target_entities=[
                 {"entity_type": "device", "entity_id": str(uuid.uuid4())},
             ],
@@ -138,12 +151,18 @@ class TestDeployContracts:
         assert req.change_payload is not None
 
     def test_rollout_create_has_waves(self) -> None:
+        # This test sent name and device_ids to WaveCreate. The schema requires
+        # wave_number and target_entities. device_ids does not exist, and a wave
+        # targets an entity pair rather than a bare device identifier.
         wave = WaveCreate(
+            wave_number=1,
             name="Wave 1",
-            device_ids=[str(uuid.uuid4())],
+            target_entities=[
+                {"entity_type": "device", "entity_id": str(uuid.uuid4())},
+            ],
         )
         rollout = RolloutCreate(
-            org_id=str(uuid.uuid4()),
+            org_id=uuid.uuid4(),
             name="Firmware v1.2",
             waves=[wave],
         )
@@ -161,16 +180,18 @@ class TestAuditContracts:
         assert req.format in ("csv", "json")
 
     def test_audit_record_response(self) -> None:
+        # This test sent record_id as a UUID string and added org_id, action, and
+        # details. record_id is an integer, because the audit_records table uses an
+        # autoincrement key. The schema names the verb change_type, not action, and
+        # it carries no org_id or details field.
         resp = AuditRecordResponse(
-            record_id=str(uuid.uuid4()),
-            org_id=str(uuid.uuid4()),
+            record_id=1,
             entity_type="device",
-            entity_id=str(uuid.uuid4()),
-            action="config_push",
+            entity_id=uuid.uuid4(),
+            change_type="config_push",
             actor="system",
             timestamp=datetime.now(tz=UTC),
-            details={},
         )
         data = resp.model_dump()
         assert "record_id" in data
-        assert "action" in data
+        assert "change_type" in data

--- a/mist-ops-platform/tests/integration/test_drift.py
+++ b/mist-ops-platform/tests/integration/test_drift.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 import pytest
 
 from src.shared.config.constants import AlertSeverity, AlertType
-from src.shared.services.diff import DiffService
+from src.shared.services.diff import DIFF_CHANGE_TYPES, DiffService
 
 
 class TestDriftDetectionIntegration:
@@ -62,7 +62,12 @@ class TestDriftDetectionIntegration:
         result = svc.compute_diff(baseline_config, drifted_config)
         for change in result.changes:
             assert len(change.path) > 0
-            assert change.change_type in ("changed", "added", "removed")
+            # This test asserted ("changed", "added", "removed"). DiffService never
+            # emitted those three labels, so the test always failed. The narrower
+            # set also loses the split between a value change and a type change.
+            # The assertion now reads the exported vocabulary, so a new label must
+            # join DIFF_CHANGE_TYPES before it can reach a drift alert.
+            assert change.change_type in DIFF_CHANGE_TYPES
 
     def test_drift_summary_counts(
         self,

--- a/mist-ops-platform/tests/integration/test_e2e_smoke.py
+++ b/mist-ops-platform/tests/integration/test_e2e_smoke.py
@@ -35,7 +35,15 @@ class TestE2ESmokeComponents:
         from src.api.main import create_app
 
         app = create_app()
-        paths = [route.path for route in app.routes]
+        # FastAPI 0.141 defers an included router into an _IncludedRouter marker,
+        # so app.routes holds markers rather than the mounted paths. The old list
+        # comprehension read route.path on those markers and raised AttributeError,
+        # so this test never checked a single route. The OpenAPI schema resolves
+        # every included router, and it is the same surface a client reads.
+        paths = list(app.openapi().get("paths", {}))
+        # An empty mapping would satisfy the any() check below by accident, so this
+        # floor proves the routers mounted. create_app publishes 48 paths today.
+        assert len(paths) >= 40, f"create_app published only {len(paths)} paths"
         # Core endpoints exist
         assert any("/healthz" in p for p in paths)
 

--- a/mist-ops-platform/tests/unit/shared/test_models_inventory.py
+++ b/mist-ops-platform/tests/unit/shared/test_models_inventory.py
@@ -98,7 +98,10 @@ class TestSyncLedgerEntry:
 
     def test_primary_key(self) -> None:
         cols = {c.name for c in SyncLedgerEntry.__table__.primary_key.columns}
-        assert cols == {"ledger_id"}
+        # This test asserted "ledger_id". No such column exists. The ORM names the
+        # key "id", and migration 0001 creates sync_ledger_entries with a BigInteger
+        # column named "id" as well. Both sides agree, so the expectation was wrong.
+        assert cols == {"id"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Repairs 10 of the 12 tests that the new ops platform gate deselected, and shrinks the deselect list in the same commit.

Refs #1897. Leaves #1883 open with a precise plan.

## What the gate reports now

| Measure | Before | After |
| - | - | - |
| Tests run | 290 | 300 |
| Deselected | 12 | 2 |
| Coverage floor | 50 percent | 53 percent |
| Collected count floor | 280 | 330 |

Measured coverage is 53.91 percent. The floor stays under the measured number.

## One product change

`DiffChange.change_type` had no declared vocabulary. Four string literals sat in `diff.py`, and nothing stopped a fifth from reaching a drift alert. This pull request exports `DIFF_CHANGE_TYPES` and the test asserts against it. A new label must now join the set on purpose.

## Nine tests encoded a wrong expectation

Instruction 5 of the task applies to these. The product is correct, so the test changed. Each case:

1. `test_sync_status_response_fields` sent `org_id`, `status`, `last_sync_at`, and `next_sync_at`. `SyncStatusResponse` names its fields `orgId`, `state`, `lastSyncAt`, and `nextPollAt`, and it sets no alias.
2. `test_revision_response_fields` sent `org_id`, `config_blob`, and `config_hash`. The schema carries none of those three. It requires `content_hash`, and it exposes `revision_id` under the alias `revision_number`.
3. `test_diff_request_requires_two_revisions` sent `revision_a` and `revision_b`. The schema requires `org_id`, `old_revision_id`, and `new_revision_id`, and the revision keys are integers.
4. `test_job_create_payload` omitted `scheduled_at`. `JobCreate` requires it, because the deploy route writes it to `ScheduledJob.scheduled_at`. `JobUpdate` is the schema that makes the field optional, so the requirement is deliberate.
5. `test_rollout_create_has_waves` sent `device_ids` to `WaveCreate`. The schema requires `wave_number` and `target_entities`.
6. `test_audit_record_response` sent `record_id` as a UUID string and added `org_id`, `action`, and `details`. `record_id` is an integer, and the schema names the verb `change_type`.
7. `test_drift_change_paths_are_descriptive` expected `changed`, `added`, or `removed`. `DiffService` never emitted those labels. The narrower set also loses the split between a value change and a type change.
8. `test_all_routes_registered` read `route.path` for every entry in `app.routes`. FastAPI 0.141 defers an included router into an `_IncludedRouter` marker that has no `path`, so the test raised `AttributeError` and checked nothing. It now reads the OpenAPI schema, which resolves all 48 paths, and it asserts a floor of 40 so a dropped router fails the test.
9. `test_primary_key` expected `ledger_id`. No such column exists. The ORM names the key `id`, and migration 0001 creates `sync_ledger_entries` with a BigInteger column named `id`. Both sides already agreed.

## Two tests stay deselected, and issue #1883 is deeper than a rename

I checked whether the 2 remaining failures were a table rename. They are not. Migration 0001 and the ORM build different tables.

| Model | Migration 0001 | ORM |
| - | - | - |
| Organization | table `organizations`, key `id` | table `orgs`, key `org_id` |
| SyncLedgerEntry | table `sync_ledger_entries` | table `sync_ledger` |

The columns differ as well. The migration gives `organizations` the columns `id`, `name`, `mist_org_id`, and `metadata_`. The ORM gives `orgs` the columns `org_id`, `msp_id`, `name`, `api_host`, `last_sync_at`, `sync_enabled`, and `created_at`. `sync_ledger_entries` and `sync_ledger` diverge the same way.

Three more ORM tables have no migration at all: `audit_records`, `config_revisions`, and `device_status_snapshots`.

Seventeen `ForeignKey` declarations point at `orgs.org_id`, which the migration never creates.

Renaming `__tablename__` alone would make the defect worse. The ORM would target `organizations` and then fail on a column that table does not have. The repair is a new migration plus an ORM alignment, and it needs a live PostgreSQL instance to verify. That work belongs in #1883, and I left the evidence there.

## Verification

- 300 passed, 32 skipped, 2 deselected.
- Coverage 53.91 percent against the 53 percent floor.
- `ruff check .` reports `All checks passed`.
- `black --check` leaves all 5 changed files unchanged.
