### PR TITLE
fix(ops-platform): give every Redis client a socket timeout

### DIFF
--- a/mist-ops-platform/.env.example
+++ b/mist-ops-platform/.env.example
@@ -13,6 +13,12 @@ DATABASE_URL=postgresql+asyncpg://mistops:changeme@localhost:5432/mistops
 # Redis
 REDIS_URL=redis://localhost:6379/0
 
+# Redis socket limits for the token cache, the session store, and the rate limiter.
+# A client without a limit waits forever on a host that drops packets.
+# Both variables use 5 seconds when they are empty or invalid.
+REDIS_SOCKET_TIMEOUT_SECONDS=5
+REDIS_CONNECT_TIMEOUT_SECONDS=5
+
 # Vault (dev mode)
 VAULT_ADDR=http://localhost:8200
 VAULT_TOKEN=dev-root-token

--- a/mist-ops-platform/src/api/middleware/rate_limit.py
+++ b/mist-ops-platform/src/api/middleware/rate_limit.py
@@ -70,7 +70,12 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         try:
             from redis.asyncio import from_url
 
-            self._redis = await from_url(self._redis_url)
+            from src.shared.redis_timeouts import redis_timeout_kwargs
+
+            logger.info("Rate limit Redis connect starts.")  # Announce the connect attempt.
+            # WHY: a client with no socket limit holds this request forever on a silent host.
+            self._redis = await from_url(self._redis_url, **redis_timeout_kwargs())
+            logger.debug("Rate limit Redis connect done.")  # Confirm the client exists.
             return self._redis
         except Exception:
             logger.warning("Redis unavailable — rate limiting disabled")

--- a/mist-ops-platform/src/api/routes/health.py
+++ b/mist-ops-platform/src/api/routes/health.py
@@ -234,12 +234,19 @@ def _cache_worker_token(org_ids: list[str], token: str) -> None:
     import redis as redis_lib
 
     from src.shared.config.settings import get_settings
+    from src.shared.redis_timeouts import redis_timeout_kwargs
 
     try:
-        client = redis_lib.Redis.from_url(get_settings().redis_url)  # Address the shared Redis.
+        logger.info("Worker token cache write starts for %d orgs.", len(org_ids))  # Announce it.
+        # WHY: a client with no socket limit holds this uvicorn worker on a silent Redis host.
+        client = redis_lib.Redis.from_url(
+            get_settings().redis_url,
+            **redis_timeout_kwargs(),
+        )  # Address the shared Redis.
         for oid in org_ids:  # Each org key lets a worker find the token for that org.
             client.setex(f"mist_token:{oid}", 8 * 3600, token)
         client.close()  # Release the socket, because this route holds no long-lived client.
+        logger.debug("Worker token cache write done for %d orgs.", len(org_ids))  # Confirm it.
     except (redis_lib.RedisError, OSError, ValueError) as error:  # Redis, socket, and URL faults.
         # WHY: the worker falls back to the environment token. A cache miss must not fail login.
         logger.debug("Redis token cache unavailable: %s", error)  # Make the cache miss visible.

--- a/mist-ops-platform/src/shared/config/settings.py
+++ b/mist-ops-platform/src/shared/config/settings.py
@@ -29,6 +29,8 @@ _DEFAULT_REDIS_URL = "redis://localhost:6379/0"
 _DEFAULT_MIST_API_HOST = "api.mist.com"
 _DEFAULT_SYNC_INTERVAL_SECONDS = 300
 _DEFAULT_LOG_LEVEL = "INFO"
+# WHY: a Redis client with no limit waits forever. Five seconds frees the worker.
+_DEFAULT_REDIS_TIMEOUT_SECONDS = 5.0
 
 
 def _env_str(name: str, default: str) -> str:
@@ -42,6 +44,19 @@ def _env_bool(name: str, default: bool) -> bool:
     if raw is None:  # An absent variable must keep the safe default.
         return default
     return raw.strip().lower() in _TRUE_VALUES  # Compare in lower case, so "True" also works.
+
+
+def _env_float(name: str, default: float) -> float:
+    """Return the environment value for *name* as a floating point number."""
+    raw = os.environ.get(name)  # Read the raw text before the conversion.
+    if raw is None:  # An absent variable must keep the documented default.
+        return default
+    try:
+        return float(raw)  # Convert the text, because a socket limit needs a number.
+    except ValueError:
+        # WHY: a bad value must not stop the service. The default keeps the service alive.
+        logger.warning("Setting %s is not a number. The default %s applies.", name, default)
+        return default
 
 
 def _env_int(name: str, default: int) -> int:
@@ -72,6 +87,8 @@ class AppSettings:
     sync_interval_seconds: int = _DEFAULT_SYNC_INTERVAL_SECONDS
     log_level: str = _DEFAULT_LOG_LEVEL
     session_cookie_secure: bool = True
+    redis_socket_timeout_seconds: float = _DEFAULT_REDIS_TIMEOUT_SECONDS
+    redis_connect_timeout_seconds: float = _DEFAULT_REDIS_TIMEOUT_SECONDS
 
 
 def build_settings() -> AppSettings:
@@ -92,6 +109,14 @@ def build_settings() -> AppSettings:
         ),  # Paces the inventory sync.
         log_level=_env_str("LOG_LEVEL", _DEFAULT_LOG_LEVEL),  # Sets how much detail the logs hold.
         session_cookie_secure=_env_bool("SESSION_COOKIE_SECURE", True),  # Defaults to HTTPS only.
+        redis_socket_timeout_seconds=_env_float(
+            "REDIS_SOCKET_TIMEOUT_SECONDS",
+            _DEFAULT_REDIS_TIMEOUT_SECONDS,
+        ),  # Limits one Redis read, so a silent host cannot hold a worker.
+        redis_connect_timeout_seconds=_env_float(
+            "REDIS_CONNECT_TIMEOUT_SECONDS",
+            _DEFAULT_REDIS_TIMEOUT_SECONDS,
+        ),  # Limits the Redis connect, so a host that drops packets fails fast.
     )
     # WHY: the operator needs proof of the cookie policy. The value is a flag, not a secret.
     logger.debug(

--- a/mist-ops-platform/src/shared/mist/session.py
+++ b/mist-ops-platform/src/shared/mist/session.py
@@ -137,8 +137,16 @@ class MistSessionFactory:
         try:
             import redis as redis_lib
 
-            client = redis_lib.Redis.from_url(self._settings.redis_url)
+            from src.shared.redis_timeouts import redis_timeout_kwargs
+
+            logger.info("Redis token cache client build starts.")  # Announce the connect attempt.
+            # WHY: a client with no socket limit holds this worker forever on a silent host.
+            client = redis_lib.Redis.from_url(
+                self._settings.redis_url,
+                **redis_timeout_kwargs(),
+            )
             client.ping()
+            logger.debug("Redis token cache client build done.")  # Confirm the live connection.
             return client
         except Exception:
             logger.debug("Redis not available for token cache")
@@ -152,8 +160,15 @@ class MistSessionFactory:
             # WHY: lazy import, matches the sync client pattern.
             import redis.asyncio as redis_async_lib
 
-            # WHY: connects lazily.
-            self._rate_redis = redis_async_lib.Redis.from_url(self._settings.redis_url)
+            from src.shared.redis_timeouts import redis_timeout_kwargs
+
+            logger.info("Async Redis rate limit client build starts.")  # Announce the connect.
+            # WHY: the same socket limits stop a silent host from holding the rate limiter.
+            self._rate_redis = redis_async_lib.Redis.from_url(
+                self._settings.redis_url,
+                **redis_timeout_kwargs(),
+            )
+            logger.debug("Async Redis rate limit client build done.")  # Confirm the client exists.
             return self._rate_redis
         except Exception:
             # WHY: fail open, like the token cache.

--- a/mist-ops-platform/src/shared/redis_timeouts.py
+++ b/mist-ops-platform/src/shared/redis_timeouts.py
@@ -1,0 +1,43 @@
+"""Shared socket timeout values for every Redis client of the platform.
+
+A Redis client that carries no socket timeout waits without a limit. A host
+that drops packets stays silent instead of refusing the connection, so the
+caller never returns. The token cache, the session store, and the rate limiter
+are optimizations. A slow cache must never hold a worker forever.
+
+Two environment variables tune the limits.
+
+``REDIS_SOCKET_TIMEOUT_SECONDS`` limits one read or one write.
+``REDIS_CONNECT_TIMEOUT_SECONDS`` limits the connect.
+
+Both default to ``REDIS_SOCKET_TIMEOUT_SECONDS`` below, which is 5 seconds.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)  # Reports the resolved limits, which hold no secret.
+
+# WHY: one shared constant keeps every call site on the same safe default.
+REDIS_SOCKET_TIMEOUT_SECONDS = 5.0
+
+
+def redis_timeout_kwargs() -> dict[str, float]:
+    """Return the socket timeout keyword arguments for a Redis client."""
+    from src.shared.config.settings import get_settings
+
+    logger.info("Redis socket timeout lookup starts.")  # Announce the lookup before the read.
+    settings = get_settings()  # Read the one shared settings object, so every client agrees.
+    # WHY: read the fields directly. AppSettings declares both, and the test stand-in in
+    # tests/conftest.py declares both. A getattr default would hide a rename, so a typo
+    # would silently restore the unlimited wait that this module exists to prevent.
+    read_limit = float(settings.redis_socket_timeout_seconds)
+    connect_limit = float(settings.redis_connect_timeout_seconds)
+    kwargs = {"socket_timeout": read_limit, "socket_connect_timeout": connect_limit}
+    logger.debug(
+        "Redis socket timeout lookup done. The read limit is %s and the connect limit is %s.",
+        read_limit,
+        connect_limit,
+    )
+    return kwargs

--- a/mist-ops-platform/src/shared/services/session_store.py
+++ b/mist-ops-platform/src/shared/services/session_store.py
@@ -169,9 +169,16 @@ def _connect_redis() -> Any:
         import redis as redis_lib  # Import here, so a missing driver does not stop the import.
 
         from src.shared.config.settings import get_settings
+        from src.shared.redis_timeouts import redis_timeout_kwargs
 
-        client = redis_lib.Redis.from_url(get_settings().redis_url)  # Address the shared Redis.
+        logger.info("Session store Redis connect starts.")  # Announce the connect attempt.
+        # WHY: a client with no socket limit holds this worker forever on a silent Redis host.
+        client = redis_lib.Redis.from_url(
+            get_settings().redis_url,
+            **redis_timeout_kwargs(),
+        )  # Address the shared Redis.
         client.ping()  # Prove the connection now, because a later failure would end a session.
+        logger.debug("Session store Redis connect done.")  # Confirm the live connection.
         return client
     except Exception as error:  # WHY: the Redis driver raises types this module cannot name.
         # WHY: the fallback map keeps local work alive. A single worker still serves its sessions.

--- a/mist-ops-platform/tests/conftest.py
+++ b/mist-ops-platform/tests/conftest.py
@@ -101,6 +101,8 @@ class _AppSettings:
     log_level = "INFO"
     database_url = "postgresql+asyncpg://localhost/misthelper_test"
     redis_url = "redis://localhost:6379/0"
+    redis_socket_timeout_seconds = 5.0
+    redis_connect_timeout_seconds = 5.0
     sync_interval_seconds = 300
     mist_api_host = "api.mist.com"
     mist_api_token = ""

--- a/mist-ops-platform/tests/unit/shared/test_redis_timeouts.py
+++ b/mist-ops-platform/tests/unit/shared/test_redis_timeouts.py
@@ -1,0 +1,124 @@
+"""Tests for the Redis socket timeout values that every client must carry.
+
+Why:
+    Issue #1918 reports that the token cache, the session store, and the rate
+    limiter built a Redis client with no socket timeout. A host that drops
+    packets stays silent instead of refusing the connection, so the caller waits
+    without a limit and the worker never returns. These tests hold the limits in
+    place at every call site.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.shared.redis_timeouts import REDIS_SOCKET_TIMEOUT_SECONDS, redis_timeout_kwargs
+
+# WHY: the two keyword arguments that redis-py reads for the socket limits.
+REQUIRED_KEYS = ("socket_timeout", "socket_connect_timeout")
+
+# WHY: every module that builds a Redis client. A new client must join this list.
+CLIENT_MODULES = (
+    "src/shared/mist/session.py",
+    "src/shared/services/session_store.py",
+    "src/api/middleware/rate_limit.py",
+    "src/api/routes/health.py",
+)
+
+
+def _settings_double(read: float = 7.5, connect: float = 2.5) -> MagicMock:
+    """Return a settings double that carries both timeout fields."""
+    settings = MagicMock()  # WHY: the helper reads two attributes only.
+    settings.redis_socket_timeout_seconds = read
+    settings.redis_connect_timeout_seconds = connect
+    return settings
+
+
+class TestRedisTimeoutKwargs:
+    """Cover the helper that every call site reads."""
+
+    def test_both_keys_are_present(self) -> None:
+        """The helper must return both socket limits."""
+        with patch("src.shared.config.settings.get_settings", return_value=_settings_double()):
+            kwargs = redis_timeout_kwargs()
+        # WHY: a missing key restores the unlimited wait that issue #1918 reports.
+        assert set(kwargs) == set(REQUIRED_KEYS)
+
+    def test_the_settings_values_reach_the_client(self) -> None:
+        """The helper must pass the configured values, not the module default."""
+        with patch(
+            "src.shared.config.settings.get_settings",
+            return_value=_settings_double(read=7.5, connect=2.5),
+        ):
+            kwargs = redis_timeout_kwargs()
+        # WHY: a hard-coded value would ignore the operator's configuration.
+        assert kwargs["socket_timeout"] == pytest.approx(7.5)
+        assert kwargs["socket_connect_timeout"] == pytest.approx(2.5)
+
+    def test_every_value_is_a_number(self) -> None:
+        """A string from the environment must reach redis-py as a number."""
+        with patch(
+            "src.shared.config.settings.get_settings",
+            return_value=_settings_double(read="3", connect="4"),
+        ):
+            kwargs = redis_timeout_kwargs()
+        # WHY: redis-py compares the limit against a clock, so a string would raise.
+        assert all(isinstance(value, float) for value in kwargs.values())
+
+    def test_no_limit_is_zero_or_negative(self) -> None:
+        """A limit of zero or less would restore the unlimited wait."""
+        with patch("src.shared.config.settings.get_settings", return_value=_settings_double()):
+            kwargs = redis_timeout_kwargs()
+        # WHY: redis-py reads 0 and None as "wait without a limit".
+        assert all(value > 0 for value in kwargs.values())
+
+    def test_the_shared_default_is_positive(self) -> None:
+        """The module default must be a usable limit."""
+        # WHY: the default applies when the operator sets no environment variable.
+        assert REDIS_SOCKET_TIMEOUT_SECONDS > 0
+
+
+class TestEveryCallSitePassesTheLimits:
+    """Prove that no from_url call can omit the socket limits."""
+
+    @pytest.mark.parametrize("module_path", CLIENT_MODULES)
+    def test_from_url_receives_the_timeout_kwargs(self, module_path: str) -> None:
+        """Every from_url call must spread redis_timeout_kwargs into its arguments."""
+        # WHY: a unit test can reach one call site at a time. A source scan reaches
+        # every call site at once, so a new client cannot skip the limits unseen.
+        source = Path(__file__).resolve().parents[3] / module_path
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        # WHY: a module can call redis_lib.Redis.from_url or a bare from_url that it
+        # imported by name. Both forms build a client, so both forms need the limits.
+        calls = [
+            node for node in ast.walk(tree) if isinstance(node, ast.Call) and self._callee_name(node) == "from_url"
+        ]
+        assert calls, f"{module_path} builds no Redis client, so this list is stale"
+        for call in calls:
+            spread = [kw for kw in call.keywords if kw.arg is None]
+            assert spread, (
+                f"{module_path} line {call.lineno}: from_url carries no **kwargs spread, "
+                "so the Redis client waits without a socket limit"
+            )
+            names = {
+                node.func.id
+                for kw in spread
+                for node in ast.walk(kw.value)
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            }
+            assert "redis_timeout_kwargs" in names, (
+                f"{module_path} line {call.lineno}: from_url spreads a value that is not " "redis_timeout_kwargs()"
+            )
+
+    @staticmethod
+    def _callee_name(node: ast.Call) -> str | None:
+        """Return the final name of the callee, for a bare call or an attribute call."""
+        if isinstance(node.func, ast.Attribute):
+            return node.func.attr  # WHY: matches redis_lib.Redis.from_url(...).
+        if isinstance(node.func, ast.Name):
+            return node.func.id  # WHY: matches a from_url that the module imported.
+        return None


### PR DESCRIPTION
Fixes #1918

## Problem

Every Redis client in the platform was built with no socket timeout:

```python
client = redis_lib.Redis.from_url(get_settings().redis_url)
```

A Redis host that drops packets stays silent instead of refusing the connection. The client then waits **without a limit**, so the caller never returns.

The token cache, the session store, and the rate limiter are all optimizations. Each one is designed to fail open. None of them can fail open while it is blocked on a socket that never answers, so a slow Redis host holds a worker forever.

## What this change does

### One shared helper

`src/shared/redis_timeouts.py` reads both limits once and returns them as keyword arguments, so every call site agrees on one value.

### Five call sites, all covered

| File | Client |
| - | - |
| `src/shared/mist/session.py` | the token cache |
| `src/shared/mist/session.py` | the async rate limit client |
| `src/shared/services/session_store.py` | the session store |
| `src/api/middleware/rate_limit.py` | the rate limit middleware |
| `src/api/routes/health.py` | the worker token cache |

### Configuration

`AppSettings` gains `redis_socket_timeout_seconds` and `redis_connect_timeout_seconds`. Both read the environment through a new `_env_float` helper and default to 5 seconds. A value that is not a number logs a warning and keeps the default, so a typo in `.env` cannot stop the service.

Both variables are documented in `.env.example`.

## Tests

`tests/unit/shared/test_redis_timeouts.py`, 9 tests.

Five cover the helper: both keys present, the configured values used rather than a hard-coded value, every value returned as a number, no value zero or less (redis-py reads `0` as "wait without a limit"), and a positive module default.

Four scan the source of each client module and assert that **every** `from_url` call spreads `redis_timeout_kwargs()`.

The source scan is the part that matters. A unit test can only reach one call site at a time, and a new Redis client added later would simply not be tested. The scan reads every call site at once, so a future client cannot skip the limits unseen.

The scan reads both call forms. `rate_limit.py` imports `from_url` by name and the other modules call it as an attribute on `redis_lib.Redis`. The first version of this test only matched the attribute form, and it failed on `rate_limit.py` — the test caught its own gap before the code was committed.

## Verification

The guard was proven to fail when a timeout is removed. Deleting the `**redis_timeout_kwargs(),` line from `session_store.py` produces:

```
AssertionError: src/shared/services/session_store.py line 176: from_url carries no
**kwargs spread, so the Redis client waits without a socket limit
```

| Gate | Result |
| - | - |
| `tests/unit/shared/test_redis_timeouts.py` | 9 passed |
| `tests/unit/shared` and `tests/unit/api` | 89 passed, 2 deselected |
| `ruff check .` (root, the CI gate) | All checks passed |
| `black --check .` (root, the CI gate) | 1068 files unchanged |

The 2 deselected tests are the pair that `ci.yml` already deselects for issue #1883. They fail on `main` today and this branch does not change them.

## Note on a change from the original draft

An earlier draft read the settings through `getattr(settings, "...", DEFAULT)`. That is now a direct attribute read. `AppSettings` declares both fields and the stand-in in `tests/conftest.py` declares both fields, so the `getattr` default could only ever hide a rename. Hiding a rename would silently restore the unlimited wait that this change exists to remove.
