### PR TITLE
ci(ops-platform): gate the sub-project ruff config so its findings cannot regress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,6 +613,89 @@ jobs:
             --deselect tests/unit/shared/test_models_inventory.py::TestOrganization::test_tablename \
             --deselect tests/unit/shared/test_models_inventory.py::TestSyncLedgerEntry::test_tablename
 
+  ops_platform_ruff:
+    name: "Ruff (ops platform)"
+    # Issue #1974: mist-ops-platform/pyproject.toml declares its own stricter
+    # [tool.ruff] configuration, and no gate ever read it. The root
+    # pyproject.toml names the subtree in extend-exclude, and every root lint job
+    # runs from the repository root, so "ruff check ." skipped the whole
+    # sub-project. The sub-project declared a standard that nothing enforced.
+    #
+    # The cost was real. An F821 undefined name reached production in
+    # src/worker/sync/events.py, where the documented fallback called uuid4
+    # without an import. Issue #1975 repaired that crash. This job stops the next
+    # one.
+    #
+    # The job runs from mist-ops-platform, so ruff discovers the sub-project
+    # configuration. Config discovery, and not path exclusion, is the cause of
+    # the gap, so --force-exclude does not solve it.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: mist-ops-platform
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+      - name: Install ruff
+        # The root file pins the ruff version that the "Ruff (lint)" job uses
+        # (issue #1779). Both gates install the same pin, so a rule change
+        # between ruff releases cannot move one gate without the other. The
+        # sub-project requirements-dev.txt carries test packages only.
+        run: pip install -r ../requirements-dev.txt
+      - name: Confirm ruff reads the sub-project configuration
+        # A gate that falls back to the root configuration reports green while it
+        # checks nothing. That result is the exact defect this job repairs, so
+        # the job proves the config before it trusts the result. The step names
+        # the resolved settings file and fails on any other file.
+        run: |
+          ruff check --show-settings . > ruff-settings.txt
+          SETTINGS=$(grep '^Settings path:' ruff-settings.txt)
+          rm -f ruff-settings.txt
+          echo "$SETTINGS"
+          case "$SETTINGS" in
+            *mist-ops-platform*pyproject.toml*) ;;
+            *)
+              echo "::error::Ruff did not read mist-ops-platform/pyproject.toml."
+              exit 1
+              ;;
+          esac
+      - name: Ruff correctness gate (blocking)
+        # The full sub-project configuration reports 393 findings today. A gate
+        # that fails on the first day blocks every pull request, so this step
+        # is a ratchet. It selects the correctness families and it measures zero,
+        # which makes it green today and red on the first regression.
+        #
+        # F, B, and E9 hold the rules that find defects rather than style. F821
+        # (undefined name), F841 (unused variable), F811 (redefinition), F632
+        # (identity comparison), B006 (mutable default), and B904 (lost exception
+        # context) all block from this day.
+        #
+        # Three rules stay out, with the count each reports today. Each one is
+        # deferred, not accepted. Never widen this ignore list to clear a new
+        # finding. Fix the code, or clear the family and delete its entry here.
+        #   F401 unused-import (69). Mechanical. Issue #1974 tracks the sweep.
+        #   B008 function-call-in-default-argument (122). Every hit is the
+        #        FastAPI Depends and Query idiom. The repair is the
+        #        flake8-bugbear extend-immutable-calls setting, not a source
+        #        edit, so it belongs in a separate change.
+        #   B905 zip-without-explicit-strict (1). One call site.
+        #
+        # mist-ops-platform/docs/ruff-ratchet.md records the full split.
+        run: ruff check . --select F,B,E9 --ignore F401,B008,B905 --output-format=concise
+      - name: Ruff full configuration report (advisory)
+        # The blocking step above covers a subset. This step runs the whole
+        # sub-project configuration, so every remaining finding stays visible in
+        # the job log. It does not block, because 393 findings cannot clear in
+        # one change. Read the count here to tighten the blocking step.
+        continue-on-error: true
+        run: ruff check . --statistics
+
   # ──────────────────────────────────────────────────────────────
   # FAILURE → GITHUB ISSUES (auto-create issues for each failure)
   # ──────────────────────────────────────────────────────────────

--- a/mist-ops-platform/docs/ruff-ratchet.md
+++ b/mist-ops-platform/docs/ruff-ratchet.md
@@ -1,0 +1,119 @@
+# The ruff ratchet for mist-ops-platform
+
+This page tells you how the CI job `Ruff (ops platform)` works. It also tells
+you how to tighten the job. Issue #1974 created the job.
+
+## Why the job exists
+
+`mist-ops-platform/pyproject.toml` declares its own `[tool.ruff]` configuration.
+That configuration is stricter than the root configuration. It sets
+`line-length = 99`, it selects the extra rule families `N`, `A`, `C4`, `SIM`,
+`TCH`, `RUF`, and `PLR`, and it sets `max-args = 5` and `max-statements = 15`.
+
+No gate ever read it. The root `pyproject.toml` names `mist-ops-platform` in
+`extend-exclude`, and every root lint job runs from the repository root. The
+`pytest (ops platform)` job runs inside the sub-project, but it runs pytest
+only.
+
+The gap had a cost. `src/worker/sync/events.py` called `uuid4` without an
+import. The documented fallback in `_extract_entity_id` raised `NameError` on
+every execution, and the Celery worker crashed on any Mist audit event with no
+usable identifier. Ruff reports that defect as `F821`. Issue #1975 repaired the
+crash. This job stops the next one.
+
+## The config discovery trap
+
+Ruff picks the configuration file closest to the file that it checks. Two
+commands therefore give two different answers for the same file.
+
+```powershell
+# Reads the SUB-PROJECT config. Reports findings.
+python -m ruff check mist-ops-platform/src/api/routes/health.py
+
+# Reads the ROOT config. Reports nothing, because extend-exclude skips the path.
+python -m ruff check .
+```
+
+The cause is config discovery, not path exclusion. `--force-exclude` does not
+change the result.
+
+Warning: a verification command must match the gate command. If you name a file
+inside `mist-ops-platform` from the repository root, you read a different rule
+set than the root gate reads. To reproduce this job, change into the
+sub-project directory first.
+
+```powershell
+cd mist-ops-platform
+python -m ruff check . --select F,B,E9 --ignore F401,B008,B905 --output-format=concise
+```
+
+## What the job blocks on today
+
+The blocking step selects the correctness families. Those families hold the
+rules that find defects rather than style.
+
+```
+ruff check . --select F,B,E9 --ignore F401,B008,B905 --output-format=concise
+```
+
+The step measures zero findings, so it is green today and red on the first
+regression. It blocks on `F821` (undefined name), `F841` (unused variable),
+`F811` (redefinition), `F632` (identity comparison), `B006` (mutable default
+argument), `B904` (lost exception context), and every other rule in `F`, `B`,
+and `E9` except the three named below.
+
+A second step runs the whole sub-project configuration with
+`continue-on-error: true`. That step prints every remaining finding, so the
+work stays visible. It does not block.
+
+## The deferred rules
+
+The full configuration reports 393 findings. Measured with ruff 0.16.3 against
+commit `4e1b69e6`.
+
+These three rules sit inside the blocking families, so the job names each one in
+its `--ignore` list.
+
+| Rule | Count | Why it waits |
+| - | - | - |
+| `B008` function-call-in-default-argument | 122 | Every hit is the FastAPI `Depends` and `Query` idiom. The repair is the `flake8-bugbear` `extend-immutable-calls` setting, not a source edit. |
+| `F401` unused-import | 69 | Mechanical. `ruff check --select F401 --fix` clears it. |
+| `B905` zip-without-explicit-strict | 1 | One call site. Add `strict=`. |
+
+These rules sit outside the blocking families. The advisory step reports them.
+
+| Rule | Count |
+| - | - |
+| `E501` line-too-long | 33 |
+| `TC003` typing-only-standard-library-import | 32 |
+| `PLR2004` magic-value-comparison | 27 |
+| `TC002` typing-only-third-party-import | 23 |
+| `N815` mixed-case-variable-in-class-scope | 17 |
+| `I001` unsorted-imports | 14 |
+| `TC001` typing-only-first-party-import | 14 |
+| `RUF100` unused-noqa | 13 |
+| `PLR0915` too-many-statements | 8 |
+| `PLR0917` too-many-positional-arguments | 8 |
+| `SIM117` multiple-with-statements | 4 |
+| `PLR0402` manual-from-import | 3 |
+| `RUF023` unsorted-dunder-slots | 2 |
+| `RUF022` unsorted-dunder-all | 1 |
+| `UP043` unnecessary-default-type-args | 1 |
+| `UP046` non-pep695-generic-class | 1 |
+
+## How to tighten the ratchet
+
+Follow these steps for each family.
+
+1. Clear one family in the source. Start with `F401`, because
+   `ruff check . --select F401 --fix` clears it.
+2. Confirm the family reports zero. Run
+   `ruff check . --select <RULE> --statistics` from inside the sub-project.
+3. Delete that rule from the `--ignore` list in the blocking step, or add its
+   family to the `--select` list.
+4. Run the blocking command and confirm exit code 0.
+5. Update the table above with the new counts.
+
+Never add a rule to the `--ignore` list to clear a new finding. The repository
+rule is fix over suppress. If a rule reports a false positive, change the ruff
+configuration for that rule, and record the reason.


### PR DESCRIPTION
Fixes #1974

## Problem

`mist-ops-platform/pyproject.toml` declares its own stricter `[tool.ruff]`
configuration. No CI job ever read it.

The root `pyproject.toml` names `mist-ops-platform` in `extend-exclude`, and
every root lint job runs from the repository root. The `pytest (ops platform)`
job runs inside the sub-project, but it runs pytest only.

The gap had a real cost. `src/worker/sync/events.py` called `uuid4` without an
import, so the documented fallback in `_extract_entity_id` raised `NameError`
on every execution. Ruff reports that defect as `F821`. Issue #1975 repaired
the crash in commit `2d05ece0`. This change stops the next one.

## Solution

The change adds one CI job, `Ruff (ops platform)`. The job sets
`working-directory: mist-ops-platform`, so ruff discovers the sub-project
configuration. Config discovery, and not path exclusion, is the cause of the
gap, so `--force-exclude` does not solve it.

The gate is a ratchet. It is green on the first day, and it turns red on the
first regression.

| Step | Blocks | Command |
| - | - | - |
| Confirm the config | Yes | `ruff check --show-settings .`, then assert the settings path is the sub-project `pyproject.toml` |
| Correctness gate | Yes | `ruff check . --select F,B,E9 --ignore F401,B008,B905 --output-format=concise` |
| Full report | No (`continue-on-error: true`) | `ruff check . --statistics` |

The job installs `../requirements-dev.txt`, which carries the same
`ruff==0.16.3` pin that the root `Ruff (lint)` job uses. One pin serves both
gates, so a rule change between ruff releases cannot move one gate without the
other.

The config guard exists because the defect this issue reports is a gate that
reports green while it checks nothing. The job proves the config before it
trusts the result.

## Measured counts

Measured with the pinned ruff 0.16.3, from inside `mist-ops-platform`, against
base commit `4e1b69e6`.

**Total findings under the full sub-project configuration: 393.**

### The gate blocks on these families today

`F`, `B`, and `E9`, minus the three deferred rules below. Every other rule in
those families measures zero, so the step exits 0. The blocked set includes
`F821` (undefined name), `F841` (unused variable), `F811` (redefinition),
`F632` (identity comparison), `B006` (mutable default argument), and `B904`
(lost exception context).

### Deferred rules inside the blocking families

| Rule | Count | Why it waits |
| - | - | - |
| `B008` function-call-in-default-argument | 122 | Every hit is the FastAPI `Depends` and `Query` idiom. The repair is the `flake8-bugbear` `extend-immutable-calls` setting, not a source edit. |
| `F401` unused-import | 69 | Mechanical. `ruff check --select F401 --fix` clears it. |
| `B905` zip-without-explicit-strict | 1 | One call site needs `strict=`. |

### Deferred families outside the blocking selection

| Rule | Count |
| - | - |
| `E501` line-too-long | 33 |
| `TC003` typing-only-standard-library-import | 32 |
| `PLR2004` magic-value-comparison | 27 |
| `TC002` typing-only-third-party-import | 23 |
| `N815` mixed-case-variable-in-class-scope | 17 |
| `I001` unsorted-imports | 14 |
| `TC001` typing-only-first-party-import | 14 |
| `RUF100` unused-noqa | 13 |
| `PLR0915` too-many-statements | 8 |
| `PLR0917` too-many-positional-arguments | 8 |
| `SIM117` multiple-with-statements | 4 |
| `PLR0402` manual-from-import | 3 |
| `RUF023` unsorted-dunder-slots | 2 |
| `RUF022` unsorted-dunder-all | 1 |
| `UP043` unnecessary-default-type-args | 1 |
| `UP046` non-pep695-generic-class | 1 |

The advisory step prints this list on every run, so none of it stays hidden.

## Local verification

The exact command that the blocking step runs, with the pinned ruff version:

```
PS> cd mist-ops-platform
PS> uvx ruff@0.16.3 check . --select F,B,E9 --ignore F401,B008,B905 --output-format=concise
All checks passed!
---PINNED_EXIT=0---
```

The `F821` defect that the issue names is gone:

```
PS> python -m ruff check src/worker/sync/events.py --select F821
All checks passed!
---F821_EXIT=0---
```

The config guard, run through bash exactly as CI runs it:

```
Settings path: "...\mist-ops-platform\pyproject.toml"
GUARD_OK
---GUARD_EXIT=0---
```

The workflow parses, and the job wiring is correct:

```
PS> python -c "import yaml,pathlib;yaml.safe_load(pathlib.Path('.github/workflows/ci.yml').read_text());print('yaml ok')"
yaml ok
name: Ruff (ops platform)
wd: mist-ops-platform
steps: ['actions/checkout@v7', 'actions/setup-python@v7', 'Install ruff',
        'Confirm ruff reads the sub-project configuration',
        'Ruff correctness gate (blocking)',
        'Ruff full configuration report (advisory)']
```

The diagram reference gate still passes:

```
PS> python scripts/lint_diagram_refs.py
OK: 125 references validated across 16 diagram files
```

## What this change does not do

No source file changed. `B008` needs a ruff configuration setting rather than a
source edit, and the other families need a sweep that does not belong in a gate
change. The gate scope is narrow for that reason, and
`mist-ops-platform/docs/ruff-ratchet.md` records every deferred rule with its
count.

No exclude list grew, and no `noqa` comment was added. The repository rule is
fix over suppress. Each deferred rule is named with its count, so the ratchet
can tighten one family at a time.

## Follow-up work

1. Clear `F401` with `ruff check . --select F401 --fix`, then delete `F401`
   from the `--ignore` list.
2. Add `extend-immutable-calls` for `fastapi.Depends` and `fastapi.Query`, then
   delete `B008` from the `--ignore` list.
3. Add `strict=` to the single `zip` call, then delete `B905`.
4. Write the config discovery trap into `.github/copilot-instructions.md`. The
   current guidance tells an agent to run `ruff check <file>`, and that command
   can select a different configuration than the gate uses.

## Files changed

| File | Change |
| - | - |
| `.github/workflows/ci.yml` | Add the `ops_platform_ruff` job |
| `mist-ops-platform/docs/ruff-ratchet.md` | New. Record the split and the steps to tighten the gate. |

## Conformance

- [x] The gate is green against the current tree. Exit code 0 is shown above.
- [x] No source file, test file, or migration changed.
- [x] No secret is added.
- [x] No exclude list grew, and no blanket `noqa` was added.
- [x] Every deferred rule is recorded with its count.
- [x] The `auto-merge` label is not applied.
