### PR TITLE
perf(rate-limit): pace six bulk write loops with the adaptive PID limiter

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -3356,6 +3356,7 @@ def _configure_site_config_manager() -> type[SiteConfigManager]:
             data_exporter=DataExporter,  # Result-report writer
             mistapi=mistapi,  # Root SDK module for calls + pagination
             default_api_page_limit=DEFAULT_API_PAGE_LIMIT,  # Bulk fetch page size
+            api_usage_cache=_api_usage_cache,  # Shared quota view for the adaptive rate limiter
         )
     )
     return SiteConfigManager  # Canonical class ready for menu callback dispatch

--- a/src/refactors/wanprobe_config_manager.py
+++ b/src/refactors/wanprobe_config_manager.py
@@ -32,6 +32,8 @@ from typing import Any  # Loose typing for late-bound MistHelper attributes and 
 import mistapi  # Direct dependency: Mist API SDK used to fetch/update gateway templates
 from tqdm import tqdm  # Progress bar used during parallel analyze and update loops
 
+from src.utils.rate_limiting import AdaptivePacer  # WHY: quota-aware pacing for the bulk template PUT loop
+
 
 class _MistHelperProxy:  # Attribute forwarder to MistHelper module attributes
     """Forward attribute access to the currently-loaded MistHelper module."""
@@ -367,10 +369,17 @@ class WANProbeConfigManager:  # WAN probe config manager (Menu 166 destructive e
         """Apply probe configuration changes to templates and return per-template results."""
         print("\n  Applying WAN probe configuration...")  # Tell the user.
         results: list[dict[str, Any]] = []  # Collect results.
+        mh = importlib.import_module("MistHelper")  # WHY: reach the live session and the shared quota cache.
+        pacer = AdaptivePacer(  # WHY: the bulk PUT loop had no pacing at all before this change.
+            getattr(mh, "apisession", None),  # WHY: the PID pipeline reads the quota through this session.
+            getattr(mh, "_api_usage_cache", None),  # WHY: share one quota view with every other menu.
+            not dry_run,  # WHY: a dry run sends no request, so it must not wait.
+        )
 
         for template in tqdm(templates_with_changes, desc="Updating templates", unit="template"):
             result = self._update_single_template(template, dry_run)  # Update one template.
             results.append(result)  # Collect the result.
+            pacer.pace()  # WHY: quota-aware wait protects the bulk gateway template PUT loop from HTTP 429.
 
         return results  # Return all results.
 

--- a/src/site/bulk_radius_wlan_config_manager.py
+++ b/src/site/bulk_radius_wlan_config_manager.py
@@ -20,11 +20,12 @@ import csv  # WHY: audit-trail CSV writer.
 import importlib  # WHY: lazy MistHelper import to reach live helper classes without circular load.
 import logging  # WHY: structured lifecycle + audit logging.
 import os  # WHY: env-var config + path helpers for the audit CSV.
-import time  # WHY: inter-call sleep to respect API rate limits.
 from datetime import datetime  # WHY: timestamps for scan snapshot + audit trail rows.
 from typing import Any  # WHY: raw WLAN rows are duck-typed dicts from mistapi.
 
 import mistapi  # WHY: direct SDK access for listOrgWlans + updateOrgWlan endpoints.
+
+from src.utils.rate_limiting import AdaptivePacer  # WHY: quota-aware pacing for the bulk WLAN timer PUT loop.
 
 
 class BulkRadiusWLANConfigManager:
@@ -364,12 +365,18 @@ class BulkRadiusWLANConfigManager:
         print(f"\n[*] {mode_label} configuration to {len(self.selected_wlans)} WLANs...")  # Announce.
         success_count = 0  # WLANs updated successfully.
         fail_count = 0  # WLANs that failed.
+        mh = importlib.import_module("MistHelper")  # WHY: reach the live session and the shared quota cache.
+        pacer = AdaptivePacer(  # WHY: quota-aware pacing replaces the fixed 0.3 second sleep.
+            getattr(mh, "apisession", None),  # WHY: the PID pipeline reads the quota through this session.
+            getattr(mh, "_api_usage_cache", None),  # WHY: share one quota view with every other menu.
+            not self.dry_run,  # WHY: a dry run sends no request, so it must not wait.
+        )
         for idx, wlan in enumerate(self.selected_wlans, 1):  # Process each (1-based for display).
             if self._update_one_wlan(idx, wlan):  # Dispatch the per-WLAN update.
                 success_count += 1  # Count success.
             else:
                 fail_count += 1  # Count failure.
-            time.sleep(0.3)  # Brief pause between writes to respect API rate limits.
+            pacer.pace()  # WHY: quota-aware wait replaces the fixed sleep between WLAN writes.
         result_label = "DRY-RUN complete" if self.dry_run else "Update complete"  # Final verb.
         print(f"\n[+] {result_label}: {success_count} successful, {fail_count} failed")  # Show totals.
         logging.info("%s: %s success, %s failed", result_label, success_count, fail_count)  # Log totals.

--- a/src/site/site_config_manager.py
+++ b/src/site/site_config_manager.py
@@ -5,9 +5,10 @@ from __future__ import annotations  # WHY: enable PEP 604 union syntax across Py
 import csv  # WHY: parse CSV rows into per-site payload dicts.
 import logging  # WHY: emit structured audit trail for destructive ops.
 import os  # WHY: verify CSV presence before opening.
-import time  # WHY: throttle sequential API calls to avoid rate limits.
 from dataclasses import dataclass, field  # WHY: group callable dependencies into typed containers.
 from typing import Any  # WHY: dependencies are duck-typed injection surfaces.
+
+from src.utils.rate_limiting import AdaptivePacer  # WHY: quota-aware pacing replaces the fixed sleep calls.
 
 # --- Module-level dependency container (populated by configure_...) ---------
 
@@ -23,6 +24,13 @@ class SiteConfigDependencies:  # WHY: typed container consumed by every helper v
     data_exporter: Any = None  # WHY: exports run reports in operator-chosen format.
     mistapi: Any = None  # WHY: root SDK module used for both calls and pagination.
     default_api_page_limit: int = 1000  # WHY: paginate wide list endpoints in one call when possible.
+    api_usage_cache: dict[str, Any] | None = None  # WHY: shared quota view for the adaptive rate limiter.
+
+
+def _pacer(enabled: bool = True) -> AdaptivePacer:  # WHY: one builder keeps every bulk loop on the same quota view.
+    """Return a pacer bound to the live session and the shared API usage cache."""
+    deps = _deps()  # WHY: read the wired collaborators one time per loop.
+    return AdaptivePacer(deps.apisession, deps.api_usage_cache, enabled)  # WHY: PID pacing replaces a fixed sleep.
 
 
 _DEPS: SiteConfigDependencies = SiteConfigDependencies()  # WHY: single shared holder mutated at wire-up.
@@ -190,6 +198,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
         created_sites: list[dict[str, Any]] = []  # WHY: collect successful records for later export.
         failed_sites: list[dict[str, Any]] = []  # WHY: collect failed records for later export.
         total = len(sites_data)  # WHY: cache for progress lines.
+        pacer = _pacer()  # WHY: one pacer per loop carries the PID state across every create call.
         print(f"\n Creating sites in organization {org_id}...")  # WHY: operator visibility for long loop.
         for index, site_data in enumerate(sites_data, start=1):  # WHY: 1-based indices align with CSV rows.
             site_payload = SiteConfigManager._build_site_payload(site_data)  # WHY: shape payload for API.
@@ -203,7 +212,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
                 created_sites.append(created)  # WHY: capture success record.
             if failed:  # WHY: at most one of the two is non-None per call.
                 failed_sites.append(failed)  # WHY: capture failure record.
-            time.sleep(0.5)  # WHY: throttle to stay under Mist per-org rate limits.
+            pacer.pace()  # WHY: quota-aware wait replaces the fixed sleep between site creates.
         return created_sites, failed_sites  # WHY: hand paired result buckets to caller.
 
     @staticmethod
@@ -500,7 +509,9 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
         }
 
     @staticmethod
-    def _update_one_rf_template(org_id: str, template_info: dict[str, Any], mapping: dict[str, dict[str, str]]) -> None:
+    def _update_one_rf_template(
+        org_id: str, template_info: dict[str, Any], mapping: dict[str, dict[str, str]], pacer: AdaptivePacer
+    ) -> None:
         """Update a single existing RF template and record mapping on success."""
         country = template_info["country"]  # WHY: local key for mapping insertion.
         payload = SiteConfigManager._build_rf_template_payload(country, template_info["name"])  # WHY: fresh body.
@@ -512,12 +523,14 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
             if response.status_code == 200:  # WHY: only accept HTTP 200 as successful update.
                 mapping[country] = {"id": template_info["id"], "name": template_info["name"]}
                 print(f"  Updated: {template_info['name']}")  # WHY: operator progress line.
-            time.sleep(0.5)  # WHY: throttle sequential updates.
+            pacer.pace()  # WHY: quota-aware wait replaces the fixed sleep between template updates.
         except (RuntimeError, ValueError, OSError, KeyError) as error:  # WHY: narrow set.
             logging.error("Failed to update template %s: %s", template_info["name"], error)  # WHY: audit.
 
     @staticmethod
-    def _create_one_rf_template(org_id: str, template_info: dict[str, Any], mapping: dict[str, dict[str, str]]) -> None:
+    def _create_one_rf_template(
+        org_id: str, template_info: dict[str, Any], mapping: dict[str, dict[str, str]], pacer: AdaptivePacer
+    ) -> None:
         """Create a single new RF template and record mapping on success."""
         country = template_info["country"]  # WHY: local key for mapping insertion.
         payload = SiteConfigManager._build_rf_template_payload(country, template_info["name"])  # WHY: body.
@@ -530,7 +543,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
                 created_id = response.data.get("id")  # WHY: extract new template id.
                 mapping[country] = {"id": created_id, "name": template_info["name"]}
                 print(f" Created: {template_info['name']}")  # WHY: operator feedback.
-            time.sleep(0.5)  # WHY: throttle create loop.
+            pacer.pace()  # WHY: quota-aware wait replaces the fixed sleep between template creates.
         except (RuntimeError, ValueError, OSError, KeyError) as error:  # WHY: narrow set.
             logging.error("Failed to create template %s: %s", template_info["name"], error)  # WHY: audit.
 
@@ -552,13 +565,14 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
     ) -> dict[str, dict[str, str]]:
         """Execute RF template create/update operations. Returns country->template mapping."""
         template_mapping: dict[str, dict[str, str]] = {}  # WHY: country -> {id,name} lookup for assignment.
+        pacer = _pacer()  # WHY: one pacer spans both write phases so the PID state survives the whole run.
         if update_mode == "update":  # WHY: only touch existing templates on explicit update.
             for template_info in to_update:  # WHY: iterate updates individually so one failure is isolated.
-                SiteConfigManager._update_one_rf_template(org_id, template_info, template_mapping)
+                SiteConfigManager._update_one_rf_template(org_id, template_info, template_mapping, pacer)
         else:  # WHY: skip mode reuses existing ids without API mutation.
             SiteConfigManager._apply_existing_templates_mapping(to_update, template_mapping)
         for template_info in to_create:  # WHY: create fresh templates last so failures do not block updates.
-            SiteConfigManager._create_one_rf_template(org_id, template_info, template_mapping)
+            SiteConfigManager._create_one_rf_template(org_id, template_info, template_mapping, pacer)
         return template_mapping
 
     @staticmethod
@@ -566,6 +580,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
         site_info: dict[str, Any],
         template: dict[str, str],
         buckets: tuple[list[dict[str, Any]], list[dict[str, Any]]],
+        pacer: AdaptivePacer,
     ) -> None:
         """Assign one site to its RF template and record success/failure."""
         success, failed = buckets  # WHY: unpack shared result accumulators.
@@ -584,7 +599,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
                 )
             else:  # WHY: non-200 is recorded as HTTP-level failure with status.
                 failed.append({"site_name": site_info["name"], "error": f"HTTP {response.status_code}"})
-            time.sleep(0.3)  # WHY: shorter throttle for site updates than template creates.
+            pacer.pace()  # WHY: quota-aware wait replaces the fixed sleep between site assignments.
         except (RuntimeError, ValueError, OSError, KeyError) as error:  # WHY: narrow set.
             failed.append({"site_name": site_info["name"], "error": str(error)})
 
@@ -597,6 +612,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
         success: list[dict[str, Any]] = []  # WHY: success bucket for report + export.
         failed: list[dict[str, Any]] = []  # WHY: failure bucket for report + export.
         deps = _deps()  # WHY: local ref shared by whole assignment loop.
+        pacer = _pacer()  # WHY: one pacer spans every country so the PID state tracks the whole assignment run.
         for country, sites in sites_by_country.items():  # WHY: iterate one country at a time.
             if country not in template_mapping:  # WHY: no mapping means we skip that whole country.
                 continue
@@ -608,7 +624,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
             for site_info in sites:  # WHY: iterate sites within country.
                 if deps.config_utils.check_stop_signal():  # WHY: honor cancel semantics between requests.
                     return success, failed
-                SiteConfigManager._assign_one_site_to_template(site_info, template, (success, failed))
+                SiteConfigManager._assign_one_site_to_template(site_info, template, (success, failed), pacer)
         return success, failed
 
     @staticmethod
@@ -772,6 +788,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
         profile_info: dict[str, Any],
         created: list[dict[str, Any]],
         failed: list[dict[str, Any]],
+        pacer: AdaptivePacer,
     ) -> None:
         """Create one device profile and append to created/failed bucket."""
         payload = {"name": profile_info["name"], "type": "ap"}  # WHY: minimal API contract for AP profile.
@@ -781,7 +798,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
                 deps.apisession, org_id, body=payload
             )
             SiteConfigManager._record_profile_create_response(response, profile_info, created, failed)
-            time.sleep(0.5)  # WHY: throttle sequential creates.
+            pacer.pace()  # WHY: quota-aware wait replaces the fixed sleep between profile creates.
         except (RuntimeError, ValueError, OSError, KeyError) as error:  # WHY: narrow set.
             failed.append({"model": profile_info["model"], "name": profile_info["name"], "error": str(error)})
 
@@ -814,8 +831,9 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
         created: list[dict[str, Any]] = []  # WHY: success bucket.
         failed: list[dict[str, Any]] = []  # WHY: failure bucket.
         print(f"\n  Step 3: Creating {len(to_create)} new Device Profiles...")  # WHY: legacy step header.
+        pacer = _pacer()  # WHY: one pacer per run carries the PID state across every profile create.
         for profile_info in to_create:  # WHY: iterate sequentially to keep rate under limits.
-            SiteConfigManager._create_one_device_profile(org_id, profile_info, created, failed)
+            SiteConfigManager._create_one_device_profile(org_id, profile_info, created, failed, pacer)
         return created, failed
 
     @staticmethod
@@ -1000,6 +1018,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
         ap_info: dict[str, Any],
         success: list[dict[str, Any]],
         failed: list[dict[str, Any]],
+        pacer: AdaptivePacer,
     ) -> None:
         """Assign one AP to its device profile, updating success/failed buckets."""
         try:
@@ -1008,7 +1027,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
                 deps.apisession, org_id, ap_info["profile_id"], body={"macs": [ap_info["mac"]]}
             )
             SiteConfigManager._record_ap_assign_response(response, ap_info, success, failed)
-            time.sleep(0.3)  # WHY: shorter throttle for assignment calls.
+            pacer.pace()  # WHY: quota-aware wait replaces the fixed sleep between AP assignments.
         except (RuntimeError, ValueError, OSError, KeyError) as error:  # WHY: narrow set.
             failed.append({"mac": ap_info["mac"], "name": ap_info["name"], "error": str(error)})
 
@@ -1042,8 +1061,9 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
         success: list[dict[str, Any]] = []  # WHY: success bucket.
         failed: list[dict[str, Any]] = []  # WHY: failure bucket.
         print(f"\n  Step 3: Assigning {len(with_profile)} APs to Device Profiles...")  # WHY: legacy header.
+        pacer = _pacer()  # WHY: one pacer per run carries the PID state across every assignment call.
         for ap_info in with_profile:  # WHY: iterate sequentially to stay under rate limits.
-            SiteConfigManager._assign_one_ap_to_profile(org_id, ap_info, success, failed)
+            SiteConfigManager._assign_one_ap_to_profile(org_id, ap_info, success, failed, pacer)
         return success, failed
 
     @staticmethod

--- a/src/utils/rate_limiting.py
+++ b/src/utils/rate_limiting.py
@@ -593,3 +593,50 @@ class RateLimitingUtils:  # WHY: static-method facade groups rate-limit helpers 
         return RateLimitingUtils._try_pipeline_or_fallback(
             apisession, api_usage_cache, tuning_data, smoothed_delay
         )  # WHY: safe execution of PID cycle.
+
+
+class AdaptivePacer:  # WHY: hold the PID state that a sequential write loop must carry between iterations.
+    """Pace a sequential write loop with the adaptive PID rate limiter.
+
+    A bulk write loop must wait between requests to stay below the Mist
+    per-org quota. A fixed sleep cannot read the real quota. A fixed sleep
+    therefore wastes headroom on a small org, and it still permits HTTP 429
+    on a large org that shares the quota with another tool. This class
+    keeps the smoothed delay between iterations. It then applies the delay
+    that RateLimitingUtils.get_rate_limited_delay computes.
+    """
+
+    def __init__(
+        self,
+        apisession: Any = None,
+        api_usage_cache: dict[str, Any] | None = None,
+        enabled: bool = True,
+    ) -> None:  # WHY: one pacer instance owns one loop, so the PID state cannot leak between loops.
+        """Store the session, the shared usage cache, and the enable flag."""
+        self._apisession = apisession  # WHY: the PID pipeline reads the quota through this session.
+        self._api_usage_cache = api_usage_cache  # WHY: shared cache keeps every menu on one quota view.
+        self._enabled = enabled  # WHY: a dry run must not spend wall-clock time on a sleep.
+        self._smoothed_delay: float | None = None  # WHY: None marks the first call of this loop.
+        logging.debug(
+            "AdaptivePacer created (enabled=%s, cache_present=%s)", enabled, api_usage_cache is not None
+        )  # WHY: record the pacing decision for a later audit of a bulk run.
+
+    @property
+    def smoothed_delay(self) -> float | None:  # WHY: expose read-only state so a test can assert the PID carry-over.
+        """Return the current smoothed delay in seconds, or None before the first call."""
+        return self._smoothed_delay  # WHY: callers must not mutate the PID state directly.
+
+    def next_delay(self) -> float:  # WHY: split the computation from the sleep so a test can run without waiting.
+        """Compute the next delay in seconds and keep the smoothed PID state."""
+        self._smoothed_delay, delay_in_seconds = RateLimitingUtils.get_rate_limited_delay(
+            self._smoothed_delay, self._apisession, self._api_usage_cache
+        )  # WHY: the helper returns the new smoothed value and the delay to apply.
+        return delay_in_seconds  # WHY: caller decides whether to sleep for this delay.
+
+    def pace(self) -> float:  # WHY: single call site replaces the hard-coded time.sleep in every bulk write loop.
+        """Wait for the computed delay and return the number of seconds waited."""
+        if not self._enabled:  # WHY: a disabled pacer reports zero wait and performs no sleep.
+            return 0.0  # WHY: keep the return type stable for the caller.
+        delay_in_seconds = self.next_delay()  # WHY: ask the PID controller for the current quota-aware delay.
+        time.sleep(delay_in_seconds)  # WHY: hold the loop for the delay the controller selected.
+        return delay_in_seconds  # WHY: report the wait so a caller can log or assert it.

--- a/tests/unit/site/test_site_config_manager_extended.py
+++ b/tests/unit/site/test_site_config_manager_extended.py
@@ -15,6 +15,13 @@ from src.site.site_config_manager import (  # WHY: import public surface + datac
     SiteConfigManager,
     configure_site_config_manager_dependencies,
 )
+from src.utils.rate_limiting import AdaptivePacer  # WHY: build an inert pacer for the write-loop helpers.
+
+
+def _idle_pacer() -> AdaptivePacer:  # WHY: a disabled pacer keeps every unit test free of a real sleep.
+    """Return a disabled pacer so a helper under test never waits."""
+    return AdaptivePacer(apisession=None, api_usage_cache=None, enabled=False)  # WHY: no sleep, no PID call.
+
 
 # --- Test fixtures & helpers -----------------------------------------------
 
@@ -467,7 +474,9 @@ def test_update_one_rf_template_success_populates_mapping() -> None:
     )
     _wire(mistapi_ns=mistapi_ns)
     mapping: dict[str, dict[str, str]] = {}
-    SiteConfigManager._update_one_rf_template("org-1", {"country": "US", "id": "t-1", "name": "RF-US"}, mapping)
+    SiteConfigManager._update_one_rf_template(
+        "org-1", {"country": "US", "id": "t-1", "name": "RF-US"}, mapping, _idle_pacer()
+    )
     assert mapping["US"] == {"id": "t-1", "name": "RF-US"}
 
 
@@ -484,7 +493,9 @@ def test_update_one_rf_template_exception_skips_mapping() -> None:
     )
     _wire(mistapi_ns=mistapi_ns)
     mapping: dict[str, dict[str, str]] = {}
-    SiteConfigManager._update_one_rf_template("org-1", {"country": "US", "id": "t-1", "name": "RF-US"}, mapping)
+    SiteConfigManager._update_one_rf_template(
+        "org-1", {"country": "US", "id": "t-1", "name": "RF-US"}, mapping, _idle_pacer()
+    )
     assert mapping == {}
 
 
@@ -500,7 +511,7 @@ def test_create_one_rf_template_success() -> None:
     )
     _wire(mistapi_ns=mistapi_ns)
     mapping: dict[str, dict[str, str]] = {}
-    SiteConfigManager._create_one_rf_template("org-1", {"country": "CA", "name": "RF-CA"}, mapping)
+    SiteConfigManager._create_one_rf_template("org-1", {"country": "CA", "name": "RF-CA"}, mapping, _idle_pacer())
     assert mapping["CA"]["id"] == "new-1"
 
 
@@ -583,6 +594,7 @@ def test_assign_one_site_to_template_success() -> None:
         {"id": "s1", "name": "Alpha"},
         {"id": "t-1", "name": "RF-US", "country": "US"},
         (success, failed),
+        _idle_pacer(),
     )
     assert success[0]["country"] == "US"
     assert failed == []
@@ -605,6 +617,7 @@ def test_assign_one_site_to_template_http_failure() -> None:
         {"id": "s1", "name": "Alpha"},
         {"id": "t-1", "name": "RF-US", "country": "US"},
         (success, failed),
+        _idle_pacer(),
     )
     assert failed[0]["error"] == "HTTP 500"
 
@@ -625,6 +638,7 @@ def test_assign_one_site_to_template_exception() -> None:
         {"id": "s1", "name": "Alpha"},
         {"id": "t-1", "name": "RF-US", "country": "US"},
         (success, failed),
+        _idle_pacer(),
     )
     assert "nope" in failed[0]["error"]
 
@@ -912,7 +926,9 @@ def test_create_one_device_profile_exception_path() -> None:
     _wire(mistapi_ns=mistapi_ns)
     created: list[dict[str, Any]] = []
     failed: list[dict[str, Any]] = []
-    SiteConfigManager._create_one_device_profile("org-1", {"model": "AP32", "name": "AP-AP32"}, created, failed)
+    SiteConfigManager._create_one_device_profile(
+        "org-1", {"model": "AP32", "name": "AP-AP32"}, created, failed, _idle_pacer()
+    )
     assert failed[0]["model"] == "AP32"
 
 
@@ -1098,6 +1114,7 @@ def test_assign_one_ap_to_profile_exception() -> None:
         },
         success,
         failed,
+        _idle_pacer(),
     )
     assert failed[0]["mac"] == "aa"
 

--- a/tests/unit/test_adaptive_pacer.py
+++ b/tests/unit/test_adaptive_pacer.py
@@ -1,0 +1,123 @@
+"""Unit tests for the AdaptivePacer quota-aware pacing class.
+
+These tests cover issues #1695 through #1699. Each of those issues replaced a
+hard-coded sleep in a bulk write loop with the PID rate limiter. The tests
+prove three properties. The pacer asks the rate limiter for every delay. The
+pacer carries the smoothed PID state between iterations. A disabled pacer
+performs no sleep, so a dry run costs no wall-clock time.
+"""
+
+from __future__ import annotations  # WHY: enable PEP 604 unions on the helper signatures.
+
+from typing import Any  # WHY: the fake session and cache are duck-typed stand-ins.
+
+import pytest  # WHY: fixtures and monkeypatch drive the isolation of the sleep call.
+
+from src.utils import rate_limiting  # WHY: patch the module attributes the pacer reads.
+from src.utils.rate_limiting import AdaptivePacer  # WHY: the class under test.
+
+
+class _DelayRecorder:  # WHY: capture every rate-limiter call so a test can assert the sequence.
+    """Record each get_rate_limited_delay call and return a scripted result."""
+
+    def __init__(self, results: list[tuple[float | None, float]]) -> None:
+        """Store the scripted results and prepare the call log."""
+        self._results = list(results)  # WHY: copy so the caller list stays unchanged.
+        self.calls: list[tuple[float | None, Any, Any]] = []  # WHY: one entry per call for assertions.
+
+    def __call__(
+        self, smoothed_delay: float | None = None, apisession: Any = None, api_usage_cache: Any = None
+    ) -> tuple[float | None, float]:
+        """Log the arguments and return the next scripted result."""
+        self.calls.append((smoothed_delay, apisession, api_usage_cache))  # WHY: record the exact inputs.
+        if self._results:  # WHY: fall back to a constant once the script runs out.
+            return self._results.pop(0)  # WHY: consume the scripted results in order.
+        return smoothed_delay, 0.0  # WHY: a stable tail keeps a long loop from raising IndexError.
+
+
+@pytest.fixture
+def no_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Replace time.sleep with a recorder so the test suite never waits."""
+    slept: list[float] = []  # WHY: collect every requested wait for assertions.
+    monkeypatch.setattr(rate_limiting.time, "sleep", slept.append)  # WHY: remove real wall-clock delay.
+    return slept  # WHY: hand the log to the test body.
+
+
+def test_pace_asks_the_rate_limiter_and_sleeps(monkeypatch: pytest.MonkeyPatch, no_sleep: list[float]) -> None:
+    """The pacer must request a delay and then wait for exactly that delay."""
+    recorder = _DelayRecorder([(0.4, 0.4)])  # WHY: one scripted call returns a 0.4 second delay.
+    monkeypatch.setattr(rate_limiting.RateLimitingUtils, "get_rate_limited_delay", recorder)  # WHY: isolate PID.
+    pacer = AdaptivePacer(apisession="session", api_usage_cache={"limit": 5000})  # WHY: build the object under test.
+
+    waited = pacer.pace()  # WHY: exercise the single public entry point.
+
+    assert waited == 0.4  # WHY: the pacer must report the delay it applied.
+    assert no_sleep == [0.4]  # WHY: the pacer must sleep one time for the computed delay.
+    assert len(recorder.calls) == 1  # WHY: one pace call means one rate-limiter call.
+
+
+def test_pace_carries_the_smoothed_delay_between_iterations(
+    monkeypatch: pytest.MonkeyPatch, no_sleep: list[float]
+) -> None:
+    """The pacer must feed the previous smoothed delay into the next call."""
+    recorder = _DelayRecorder([(0.2, 0.2), (0.6, 0.6), (0.9, 0.9)])  # WHY: three iterations of a bulk loop.
+    monkeypatch.setattr(rate_limiting.RateLimitingUtils, "get_rate_limited_delay", recorder)  # WHY: isolate PID.
+    pacer = AdaptivePacer(apisession="session", api_usage_cache={"limit": 5000})  # WHY: object under test.
+
+    for _ in range(3):  # WHY: simulate a three-item bulk write loop.
+        pacer.pace()  # WHY: each iteration must advance the PID state.
+
+    smoothed_inputs = [call[0] for call in recorder.calls]  # WHY: read the first argument of every call.
+    assert smoothed_inputs == [None, 0.2, 0.6]  # WHY: the state must carry forward, not reset to None.
+    assert pacer.smoothed_delay == 0.9  # WHY: the final smoothed value must remain readable.
+    assert no_sleep == [0.2, 0.6, 0.9]  # WHY: every iteration waits for its own computed delay.
+
+
+def test_pace_passes_the_shared_session_and_cache(monkeypatch: pytest.MonkeyPatch, no_sleep: list[float]) -> None:
+    """The pacer must forward the injected session and the shared usage cache."""
+    recorder = _DelayRecorder([(0.1, 0.1)])  # WHY: a single call is enough to inspect the arguments.
+    monkeypatch.setattr(rate_limiting.RateLimitingUtils, "get_rate_limited_delay", recorder)  # WHY: isolate PID.
+    shared_cache = {"limit": 5000, "used": 10}  # WHY: stand in for the module-level MistHelper cache.
+    pacer = AdaptivePacer(apisession="live-session", api_usage_cache=shared_cache)  # WHY: object under test.
+
+    pacer.pace()  # WHY: trigger the single rate-limiter call.
+
+    _, session, cache = recorder.calls[0]  # WHY: unpack the recorded arguments.
+    assert session == "live-session"  # WHY: the PID pipeline needs the live session to read the quota.
+    assert cache is shared_cache  # WHY: identity proves every menu shares one quota view.
+
+
+def test_disabled_pacer_never_sleeps(monkeypatch: pytest.MonkeyPatch, no_sleep: list[float]) -> None:
+    """A disabled pacer must report a zero wait and must not call the rate limiter."""
+    recorder = _DelayRecorder([(0.5, 0.5)])  # WHY: a call would show up here if the guard failed.
+    monkeypatch.setattr(rate_limiting.RateLimitingUtils, "get_rate_limited_delay", recorder)  # WHY: isolate PID.
+    pacer = AdaptivePacer(apisession="session", api_usage_cache={}, enabled=False)  # WHY: model a dry run.
+
+    waited = pacer.pace()  # WHY: a dry run must return immediately.
+
+    assert waited == 0.0  # WHY: a dry run sends no request, so it must not wait.
+    assert no_sleep == []  # WHY: no sleep may occur in a dry run.
+    assert recorder.calls == []  # WHY: a dry run must not spend a rate-limiter cycle either.
+
+
+def test_next_delay_computes_without_sleeping(monkeypatch: pytest.MonkeyPatch, no_sleep: list[float]) -> None:
+    """next_delay must return the delay and update the state without waiting."""
+    recorder = _DelayRecorder([(0.7, 0.7)])  # WHY: one scripted result is enough.
+    monkeypatch.setattr(rate_limiting.RateLimitingUtils, "get_rate_limited_delay", recorder)  # WHY: isolate PID.
+    pacer = AdaptivePacer(apisession=None, api_usage_cache={})  # WHY: object under test.
+
+    delay = pacer.next_delay()  # WHY: exercise the computation-only entry point.
+
+    assert delay == 0.7  # WHY: the caller decides whether to wait for this delay.
+    assert pacer.smoothed_delay == 0.7  # WHY: the state must advance even without a sleep.
+    assert no_sleep == []  # WHY: next_delay must never sleep by itself.
+
+
+def test_missing_cache_falls_back_without_raising(no_sleep: list[float]) -> None:
+    """A pacer built without a cache must still return a usable fallback delay."""
+    pacer = AdaptivePacer(apisession=None, api_usage_cache=None)  # WHY: model a wire-up that forgot the cache.
+
+    delay = pacer.next_delay()  # WHY: the real rate limiter runs here, with no cache available.
+
+    assert delay > 0.0  # WHY: a missing cache must degrade to a safe non-zero delay, not to zero.
+    assert no_sleep == []  # WHY: next_delay must never sleep by itself.

--- a/tests/unit/test_bulk_radius_wlan_config_manager.py
+++ b/tests/unit/test_bulk_radius_wlan_config_manager.py
@@ -667,7 +667,10 @@ def test_apply_changes_dry_run_label(capsys: pytest.CaptureFixture[str]) -> None
     manager.selected_wlans = [{"id": "w1", "ssid": "A"}]
     manager.dry_run = True
     fake = _make_mh()
-    with patch.object(brwcm.importlib, "import_module", return_value=fake), patch.object(brwcm.AdaptivePacer, "pace", return_value=0.0):
+    with (
+        patch.object(brwcm.importlib, "import_module", return_value=fake),
+        patch.object(brwcm.AdaptivePacer, "pace", return_value=0.0),
+    ):
         manager._apply_changes()
     out = capsys.readouterr().out
     assert "DRY-RUN: Simulating" in out
@@ -904,7 +907,10 @@ def test_confirm_and_apply_proceeds_on_apply(capsys: pytest.CaptureFixture[str])
     manager.selected_wlans = [{"id": "w", "ssid": "S"}]
     fake = _make_mh()
     fake.InputUtils.safe_input.return_value = "APPLY"
-    with patch.object(brwcm.importlib, "import_module", return_value=fake), patch.object(brwcm.AdaptivePacer, "pace", return_value=0.0):
+    with (
+        patch.object(brwcm.importlib, "import_module", return_value=fake),
+        patch.object(brwcm.AdaptivePacer, "pace", return_value=0.0),
+    ):
         manager._confirm_and_apply()
     out = capsys.readouterr().out
     assert "Bulk RADIUS WLAN configuration completed" in out

--- a/tests/unit/test_bulk_radius_wlan_config_manager.py
+++ b/tests/unit/test_bulk_radius_wlan_config_manager.py
@@ -654,7 +654,7 @@ def test_apply_changes_counts_success_and_failure(capsys: pytest.CaptureFixture[
     with (
         patch.object(brwcm.importlib, "import_module", return_value=fake),
         patch.object(brwcm.mistapi.api.v1.orgs.wlans, "updateOrgWlan", side_effect=lambda *a, **k: next(responses)),
-        patch.object(brwcm.time, "sleep"),
+        patch.object(brwcm.AdaptivePacer, "pace", return_value=0.0),
     ):
         manager._apply_changes()
     out = capsys.readouterr().out
@@ -667,7 +667,7 @@ def test_apply_changes_dry_run_label(capsys: pytest.CaptureFixture[str]) -> None
     manager.selected_wlans = [{"id": "w1", "ssid": "A"}]
     manager.dry_run = True
     fake = _make_mh()
-    with patch.object(brwcm.importlib, "import_module", return_value=fake), patch.object(brwcm.time, "sleep"):
+    with patch.object(brwcm.importlib, "import_module", return_value=fake), patch.object(brwcm.AdaptivePacer, "pace", return_value=0.0):
         manager._apply_changes()
     out = capsys.readouterr().out
     assert "DRY-RUN: Simulating" in out
@@ -904,7 +904,7 @@ def test_confirm_and_apply_proceeds_on_apply(capsys: pytest.CaptureFixture[str])
     manager.selected_wlans = [{"id": "w", "ssid": "S"}]
     fake = _make_mh()
     fake.InputUtils.safe_input.return_value = "APPLY"
-    with patch.object(brwcm.importlib, "import_module", return_value=fake), patch.object(brwcm.time, "sleep"):
+    with patch.object(brwcm.importlib, "import_module", return_value=fake), patch.object(brwcm.AdaptivePacer, "pace", return_value=0.0):
         manager._confirm_and_apply()
     out = capsys.readouterr().out
     assert "Bulk RADIUS WLAN configuration completed" in out
@@ -937,7 +937,7 @@ def _run_manage(
             "updateOrgWlan",
             return_value=SimpleNamespace(status_code=200, data={}),
         ),
-        patch.object(brwcm.time, "sleep"),
+        patch.object(brwcm.AdaptivePacer, "pace", return_value=0.0),
     ):
         manager.manage(dry_run=dry_run)
 


### PR DESCRIPTION
Closes #1695
Closes #1696
Closes #1697
Closes #1698
Closes #1699

## Problem

Six bulk write loops paced themselves badly.

- Menu 166 (`WANProbeConfigManager._apply_changes`) ran a bulk `PUT` loop against `updateOrgGatewayTemplate` with **no inter-call pacing at all**. Issue #1695 recorded it as the highest HTTP 429 risk in the tool.
- Menus 170 through 174 used a hard-coded `time.sleep(0.3)` or `time.sleep(0.5)`.

A fixed sleep cannot read the real org quota. It therefore wastes headroom on a small org, and it still permits HTTP 429 on a large org that shares the quota with another tool.

## Change

`src/utils/rate_limiting.py` gains an `AdaptivePacer` class. The existing `RateLimitingUtils.get_rate_limited_delay` helper is stateless, so every caller had to thread the `smoothed_delay` value through its own loop by hand. The class owns that state instead.

| Method | Purpose |
| - | - |
| `pace()` | Compute the delay, wait for it, return the seconds waited. |
| `next_delay()` | Compute the delay and advance the state without waiting. |
| `smoothed_delay` | Read-only view of the PID state, for assertions. |

A disabled pacer returns 0.0 and spends no rate-limiter cycle, so a dry run costs no wall-clock time.

### Call sites

| Menu | File | Before | After |
| - | - | - | - |
| 166 | `src/refactors/wanprobe_config_manager.py` | no pacing | `pacer.pace()` |
| 170 | `src/site/bulk_radius_wlan_config_manager.py` | `sleep(0.3)` | `pacer.pace()` |
| 171 | `src/site/site_config_manager.py` | `sleep(0.5)` | `pacer.pace()` |
| 172 | `src/site/site_config_manager.py` | `sleep(0.5)` x3 | `pacer.pace()` |
| 173 | `src/site/site_config_manager.py` | `sleep(0.5)` | `pacer.pace()` |
| 174 | `src/site/site_config_manager.py` | `sleep(0.3)` | `pacer.pace()` |

Menu 174 was not in the issue set. It shares `site_config_manager.py` with menus 171 through 173, and it held the same defect. Removing `import time` from that module would have left menu 174 with a latent `NameError`, so this pull request fixes it in the same pass.

`SiteConfigDependencies` gains an `api_usage_cache` field. `MistHelper.py` wires the module-level `_api_usage_cache` into it. Every paced menu now reads one quota view rather than a private one.

## Tests

`tests/unit/test_adaptive_pacer.py` adds 6 tests. They prove that:

- `pace()` asks the rate limiter one time and waits for exactly the returned delay.
- The smoothed delay carries forward across iterations (`[None, 0.2, 0.6]`), and does not reset.
- The injected session and the shared cache reach the rate limiter by identity.
- A disabled pacer performs no sleep and spends no rate-limiter cycle.
- `next_delay()` advances the state without sleeping.
- A pacer built without a cache degrades to a safe non-zero fallback delay.

`tests/unit/site/test_site_config_manager_extended.py` passes an inert pacer through the 8 helper call sites that gained the parameter.

## Verification

```text
python -m pytest tests/unit/site tests/unit/test_rate_limiting.py tests/unit/test_adaptive_pacer.py
382 passed in 15.67s

python -m ruff check src/ MistHelper.py tests/...
All checks passed!
```

## Conformance

- [x] Acceptance criteria of #1695 through #1699 met
- [x] Tests added for the new behavior
- [x] No secret added
- [x] Inline comments on every changed executable line
- [x] Simplified Technical English in all prose and comments
- [x] Ruff, Black, and the targeted test suite pass locally

## Risk

Menus 166 and 170 through 174 are destructive operations. This change alters only the wait between requests. It does not alter any payload, any endpoint, or any confirmation gate.
