### PR TITLE
security(ops-platform): check org membership on every mutating config and deploy route

### DIFF
--- a/mist-ops-platform/src/api/routes/config.py
+++ b/mist-ops-platform/src/api/routes/config.py
@@ -419,6 +419,7 @@ async def create_baseline(
     user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[BaselineResponse]:
     """Create or update a baseline (intended state)."""
+    require_org_access(str(body.org_id), user)  # Refuse a caller outside the org named in the body
     existing = await _find_baseline_by_scope(
         db,
         body.org_id,
@@ -456,8 +457,8 @@ async def accept_drift(
     if not body.confirm:
         raise HTTPException(status_code=400, detail="confirm required")
 
-    baseline = await _load_baseline(db, baseline_id)
-    alert = await _load_drift_alert(db, body.alert_id)
+    baseline = await _load_baseline(db, baseline_id, user)
+    alert = await _load_drift_alert(db, body.alert_id, user)
 
     actual = await _latest_revision_for_baseline(db, baseline)
     if actual and actual.config_blob:
@@ -485,10 +486,10 @@ async def remediate(
     if not body.confirm:
         raise HTTPException(status_code=400, detail="confirm required")
 
-    baseline = await _load_baseline(db, baseline_id)
+    baseline = await _load_baseline(db, baseline_id, user)
 
     for alert_id in body.alert_ids:
-        alert = await _load_drift_alert(db, alert_id)
+        alert = await _load_drift_alert(db, alert_id, user)
         alert.status = "remediated"
         alert.resolved_by = user.email
         from datetime import UTC, datetime as _dt
@@ -518,24 +519,28 @@ async def remediate(
 async def _load_baseline(
     db: AsyncSession,
     baseline_id: UUID,
+    user: CurrentUser,
 ) -> Baseline:
-    """Load a baseline or raise 404."""
+    """Load a baseline or raise 404. Refuse a caller outside the org with 403."""
     stmt = select(Baseline).where(Baseline.baseline_id == baseline_id)
     row = (await db.execute(stmt)).scalar_one_or_none()
     if row is None:
         raise HTTPException(status_code=404, detail="Baseline not found")
+    require_org_access(str(row.org_id), user)  # Refuse a caller outside the org of this record
     return row
 
 
 async def _load_drift_alert(
     db: AsyncSession,
     alert_id: UUID,
+    user: CurrentUser,
 ) -> DriftAlert:
-    """Load a drift alert or raise 404."""
+    """Load a drift alert or raise 404. Refuse a caller outside the org with 403."""
     stmt = select(DriftAlert).where(DriftAlert.alert_id == alert_id)
     row = (await db.execute(stmt)).scalar_one_or_none()
     if row is None:
         raise HTTPException(status_code=404, detail="Alert not found")
+    require_org_access(str(row.org_id), user)  # Refuse a caller outside the org of this record
     return row
 
 

--- a/mist-ops-platform/src/api/routes/deploy.py
+++ b/mist-ops-platform/src/api/routes/deploy.py
@@ -25,7 +25,7 @@ from src.api.deps import (
     get_db_session,
     get_scoped_org_id,
 )
-from src.api.middleware.auth import CurrentUser
+from src.api.middleware.auth import CurrentUser, require_org_access
 from src.api.schemas.common import ResponseEnvelope
 from src.shared.sync_db import sync_engine
 from src.api.schemas.deploy import (
@@ -69,12 +69,14 @@ router = APIRouter(prefix="/deploy", tags=["deploy"])
 async def _load_job(
     db: AsyncSession,
     job_id: UUID,
+    user: CurrentUser,
 ) -> ScheduledJob:
-    """Load a job or raise 404."""
+    """Load a job or raise 404. Refuse a caller outside the org with 403."""
     stmt = select(ScheduledJob).where(ScheduledJob.job_id == job_id)
     row = (await db.execute(stmt)).scalar_one_or_none()
     if row is None:
         raise HTTPException(status_code=404, detail="Job not found")
+    require_org_access(str(row.org_id), user)  # Refuse a caller outside the org of this record
     return row
 
 
@@ -128,6 +130,7 @@ async def create_job(
     user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[JobSummary]:
     """Create a new scheduled deployment job."""
+    require_org_access(str(body.org_id), user)  # Refuse a caller outside the org named in the body
     conflict = await _check_conflicts(db, body)
     if conflict:
         raise HTTPException(status_code=409, detail=conflict)
@@ -162,10 +165,10 @@ async def create_job(
 async def get_job(
     job_id: UUID,
     db: AsyncSession = Depends(get_db_session),
-    _user: CurrentUser = Depends(get_authenticated_user),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[JobDetail]:
     """Get detailed job status with checkpoint progress."""
-    job = await _load_job(db, job_id)
+    job = await _load_job(db, job_id, user)
     checkpoints = _build_checkpoints(job)
     targets = _parse_targets(job)
 
@@ -190,10 +193,10 @@ async def update_job(
     job_id: UUID,
     body: JobUpdate,
     db: AsyncSession = Depends(get_db_session),
-    _user: CurrentUser = Depends(get_authenticated_user),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[JobSummary]:
     """Update a pending job (reschedule or modify)."""
-    job = await _load_job(db, job_id)
+    job = await _load_job(db, job_id, user)
     if job.status != JobStatus.PENDING.value:
         raise HTTPException(
             status_code=409,
@@ -209,10 +212,10 @@ async def update_job(
 async def cancel_job(
     job_id: UUID,
     db: AsyncSession = Depends(get_db_session),
-    _user: CurrentUser = Depends(get_authenticated_user),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[JobCancelledResponse]:
     """Cancel a pending job."""
-    job = await _load_job(db, job_id)
+    job = await _load_job(db, job_id, user)
     if job.status not in (JobStatus.PENDING.value, JobStatus.APPROVED.value):
         raise HTTPException(
             status_code=409,
@@ -247,7 +250,7 @@ async def approve_job(
             detail="confirm must be true",
         )
 
-    job = await _load_job(db, job_id)
+    job = await _load_job(db, job_id, user)
     if job.status != JobStatus.PENDING.value:
         raise HTTPException(
             status_code=409,
@@ -272,9 +275,10 @@ async def approve_job(
 async def dry_run(
     body: DryRunRequest,
     db: AsyncSession = Depends(get_db_session),
-    _user: CurrentUser = Depends(get_authenticated_user),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[DryRunResponse]:
     """Validate a change without applying it (FR-036, SC-013 <10s)."""
+    require_org_access(str(body.org_id), user)  # Refuse a caller outside the org named in the body
     from src.worker.deploy.dry_run import DryRunValidator
 
     validator = DryRunValidator(db)
@@ -395,6 +399,7 @@ async def create_rollout(
     user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[RolloutSummary]:
     """Create a multi-wave rollout plan."""
+    require_org_access(str(body.org_id), user)  # Refuse a caller outside the org named in the body
     plan = RolloutPlan(
         org_id=body.org_id,
         name=body.name,
@@ -424,13 +429,13 @@ async def activate_rollout(
     plan_id: UUID,
     body: JobApproveRequest,
     db: AsyncSession = Depends(get_db_session),
-    _user: CurrentUser = Depends(get_authenticated_user),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[dict]:
     """Activate a rollout (draft -> active, starts first wave)."""
     if not body.confirm:
         raise HTTPException(status_code=400, detail="confirm required")
 
-    plan = await _load_plan(db, plan_id)
+    plan = await _load_plan(db, plan_id, user)
     if plan.status != "draft":
         raise HTTPException(status_code=409, detail="Plan must be draft")
 
@@ -448,10 +453,10 @@ async def activate_rollout(
 async def pause_rollout(
     plan_id: UUID,
     db: AsyncSession = Depends(get_db_session),
-    _user: CurrentUser = Depends(get_authenticated_user),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[dict]:
     """Pause an active rollout."""
-    plan = await _load_plan(db, plan_id)
+    plan = await _load_plan(db, plan_id, user)
     if plan.status != "active":
         raise HTTPException(status_code=409, detail="Plan must be active")
     plan.status = "paused"
@@ -463,10 +468,10 @@ async def pause_rollout(
 async def resume_rollout(
     plan_id: UUID,
     db: AsyncSession = Depends(get_db_session),
-    _user: CurrentUser = Depends(get_authenticated_user),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[dict]:
     """Resume a paused rollout."""
-    plan = await _load_plan(db, plan_id)
+    plan = await _load_plan(db, plan_id, user)
     if plan.status != "paused":
         raise HTTPException(status_code=409, detail="Plan must be paused")
     plan.status = "active"
@@ -485,11 +490,13 @@ async def promote_wave(
     wave_number: int,
     body: JobApproveRequest,
     db: AsyncSession = Depends(get_db_session),
-    _user: CurrentUser = Depends(get_authenticated_user),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[dict]:
     """Manually promote to the next wave."""
     if not body.confirm:
         raise HTTPException(status_code=400, detail="confirm required")
+
+    await _load_plan(db, plan_id, user)  # Refuse a caller outside the org of this plan
 
     from src.worker.tasks.deploy_tasks import promote_rollout_wave
 
@@ -506,11 +513,13 @@ async def rollback_wave(
     wave_number: int,
     body: JobApproveRequest,
     db: AsyncSession = Depends(get_db_session),
-    _user: CurrentUser = Depends(get_authenticated_user),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[dict]:
     """Roll back a specific wave."""
     if not body.confirm:
         raise HTTPException(status_code=400, detail="confirm required")
+
+    await _load_plan(db, plan_id, user)  # Refuse a caller outside the org of this plan
 
     from src.worker.deploy.rollout import RolloutOrchestrator
     from sqlalchemy.orm import Session as _Sess
@@ -563,6 +572,7 @@ async def create_golden_image(
     user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[GoldenImageResponse]:
     """Register a new golden image."""
+    require_org_access(str(body.org_id), user)  # Refuse a caller outside the org named in the body
     image = GoldenImage(
         org_id=body.org_id,
         image_type=body.image_type,
@@ -589,7 +599,7 @@ async def approve_golden_image(
     if not body.confirm:
         raise HTTPException(status_code=400, detail="confirm required")
 
-    image = await _load_golden_image(db, image_id)
+    image = await _load_golden_image(db, image_id, user)
     if image.lifecycle_state != "draft":
         raise HTTPException(status_code=409, detail="Image must be draft")
     if image.created_by == user.email:
@@ -610,13 +620,13 @@ async def retire_golden_image(
     image_id: UUID,
     body: JobApproveRequest,
     db: AsyncSession = Depends(get_db_session),
-    _user: CurrentUser = Depends(get_authenticated_user),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[GoldenImageResponse]:
     """Retire a golden image (approved -> retired)."""
     if not body.confirm:
         raise HTTPException(status_code=400, detail="confirm required")
 
-    image = await _load_golden_image(db, image_id)
+    image = await _load_golden_image(db, image_id, user)
     if image.lifecycle_state != "approved":
         raise HTTPException(status_code=409, detail="Image must be approved")
 
@@ -628,24 +638,27 @@ async def retire_golden_image(
 # -- Rollout/golden image helpers ---
 
 
-async def _load_plan(db: AsyncSession, plan_id: UUID) -> RolloutPlan:
-    """Load a rollout plan or raise 404."""
+async def _load_plan(db: AsyncSession, plan_id: UUID, user: CurrentUser) -> RolloutPlan:
+    """Load a rollout plan or raise 404. Refuse a caller outside the org with 403."""
     stmt = select(RolloutPlan).where(RolloutPlan.plan_id == plan_id)
     row = (await db.execute(stmt)).scalar_one_or_none()
     if row is None:
         raise HTTPException(status_code=404, detail="Plan not found")
+    require_org_access(str(row.org_id), user)  # Refuse a caller outside the org of this record
     return row
 
 
 async def _load_golden_image(
     db: AsyncSession,
     image_id: UUID,
+    user: CurrentUser,
 ) -> GoldenImage:
-    """Load a golden image or raise 404."""
+    """Load a golden image or raise 404. Refuse a caller outside the org with 403."""
     stmt = select(GoldenImage).where(GoldenImage.image_id == image_id)
     row = (await db.execute(stmt)).scalar_one_or_none()
     if row is None:
         raise HTTPException(status_code=404, detail="Image not found")
+    require_org_access(str(row.org_id), user)  # Refuse a caller outside the org of this record
     return row
 
 
@@ -702,6 +715,7 @@ async def create_template(
     user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[TemplateResponse]:
     """Create a reusable change template."""
+    require_org_access(str(body.org_id), user)  # Refuse a caller outside the org named in the body
     tmpl = ChangeTemplate(
         org_id=body.org_id,
         name=body.name,
@@ -725,7 +739,7 @@ async def instantiate_template(
     user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[JobSummary]:
     """Instantiate a template to create a deployment job."""
-    tmpl = await _load_template(db, template_id)
+    tmpl = await _load_template(db, template_id, user)
 
     from src.shared.services.template import TemplateService
     from sqlalchemy.orm import Session as _Sess
@@ -764,12 +778,14 @@ async def instantiate_template(
 async def _load_template(
     db: AsyncSession,
     template_id: UUID,
+    user: CurrentUser,
 ) -> ChangeTemplate:
-    """Load a change template or raise 404."""
+    """Load a change template or raise 404. Refuse a caller outside the org with 403."""
     stmt = select(ChangeTemplate).where(
         ChangeTemplate.template_id == template_id,
     )
     row = (await db.execute(stmt)).scalar_one_or_none()
     if row is None:
         raise HTTPException(status_code=404, detail="Template not found")
+    require_org_access(str(row.org_id), user)  # Refuse a caller outside the org of this record
     return row

--- a/src/firmware/firmware_manager.py
+++ b/src/firmware/firmware_manager.py
@@ -58,6 +58,28 @@ except ImportError:  # pragma: no cover
 mistapi: Any = _mistapi_module
 
 
+_MISTHELPER_MODULE_NAME = "MistHelper"  # WHY: single spelling of the module name the proxy resolves
+# WHY: `tests/conftest.py` records the real import failure under this name when
+# WHY: `MistHelper.py` stops part way through its module body. Issue #1923.
+_IMPORT_ERROR_ATTRIBUTE = "__misthelper_import_error__"
+
+
+def _describe_partial_import(name: str, cause: BaseException) -> str:
+    """Build one message that names the real cause of an unbound attribute."""
+    logging.info("Building the partial-import report for the attribute %s", name)  # Log before the build.
+    cause_text = f"{type(cause).__name__}: {cause}"  # Name the class and the text, so the reader sees both.
+    message = (  # Return one block, because an AttributeError carries a single string.
+        f"MistHelper stopped part way through its import, so the attribute "
+        f"'{name}' never bound. The import failed with:\n"
+        f"    {cause_text}\n"
+        f"This is an environment gap, not a missing declaration. Install the "
+        f"project dependencies with 'python scripts/bootstrap_worktree.py'. "
+        f"See issue #1866 for the empty worktree case."
+    )
+    logging.debug("Built a partial-import report of %d characters", len(message))  # Log the result size.
+    return message  # Give the caller the finished message.
+
+
 class _MistHelperProxy:  # WHY: attribute forwarder to live MistHelper module
     """Forward attribute access to the currently-loaded MistHelper module.
 
@@ -66,12 +88,26 @@ class _MistHelperProxy:  # WHY: attribute forwarder to live MistHelper module
     without importing MistHelper at module load time (which would create a
     circular import). Attributes are resolved at call time so test
     monkey-patches applied to MistHelper are honoured.
+
+    When `MistHelper.py` stops part way through its module body, the half-built
+    module stays in `sys.modules`. A plain `getattr` then reports a missing
+    attribute and hides the real cause. This proxy reports the recorded cause
+    instead. See issue #1923.
     """
 
     def __getattr__(self, name: str) -> Any:  # WHY: only invoked when the attr is missing normally
         """Resolve name against the live MistHelper module (call-time lookup)."""
-        misthelper_module = importlib.import_module("MistHelper")  # WHY: lazy import at call time
-        return getattr(misthelper_module, name)  # WHY: fetch current bound value from MistHelper
+        try:  # Guard the import, because an absent dependency raises here.
+            misthelper_module = importlib.import_module(_MISTHELPER_MODULE_NAME)  # WHY: lazy import at call time
+        except ImportError as import_error:  # The module cannot load at all.
+            raise AttributeError(_describe_partial_import(name, import_error)) from import_error  # Name the real cause.
+        try:  # Guard the lookup, because a half-built module has no such name.
+            return getattr(misthelper_module, name)  # WHY: fetch current bound value from MistHelper
+        except AttributeError:  # The name did not bind on this module.
+            cause = getattr(misthelper_module, _IMPORT_ERROR_ATTRIBUTE, None)  # Read the recorded import failure.
+            if cause is None:  # No record exists, so the module loaded and the name is truly absent.
+                raise  # Keep the original error, because it already states the truth.
+            raise AttributeError(_describe_partial_import(name, cause)) from cause  # Name the real cause.
 
 
 _MH = _MistHelperProxy()  # WHY: sole module-level proxy handle used by FirmwareUpgradeStatusChecker

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,11 +18,18 @@ from pathlib import Path
 import pytest
 
 # Runtime packages that almost every test module imports through `src`. Keep the
-# list short, because the guard runs before every test session.
-_REQUIRED_RUNTIME_PACKAGES: tuple[str, ...] = ("mistapi", "structlog", "dotenv")
+# list short, because the guard runs before every test session. `paramiko` sits
+# on the import path of `MistHelper.py`, so its absence stops that module part
+# way and hides the cause behind a wrong AttributeError. See issue #1923.
+_REQUIRED_RUNTIME_PACKAGES: tuple[str, ...] = ("mistapi", "structlog", "dotenv", "paramiko")
 
 # The documented command that creates `.venv` and installs the dependencies.
 _BOOTSTRAP_COMMAND = "python scripts/bootstrap_worktree.py"
+
+# The attribute that records why `MistHelper.py` stopped part way through its
+# module body. `src/firmware/firmware_manager.py` reads this name and reports the
+# recorded cause instead of a wrong "no attribute" message. See issue #1923.
+_IMPORT_ERROR_ATTRIBUTE = "__misthelper_import_error__"
 
 
 def _find_missing_packages(names: tuple[str, ...]) -> list[str]:
@@ -75,10 +82,17 @@ if _mh_path.exists() and (_existing is None or _is_init):
     sys.modules["MistHelper"] = _mod
     try:
         _spec.loader.exec_module(_mod)  # type: ignore[union-attr]
-    except SystemExit:
-        pass  # MistHelper.py calls sys.exit(); ignore during import
-    except (ImportError, ModuleNotFoundError):
-        pass  # Missing dependencies (e.g., mistapi); tests for src/ still work
+    except SystemExit as _exit_signal:
+        # MistHelper.py calls sys.exit() during import. The module body stops at
+        # that call, so the names below it never bind. Record the cause. #1923.
+        setattr(_mod, _IMPORT_ERROR_ATTRIBUTE, _exit_signal)  # Keep the real cause on the half-built module.
+    except (ImportError, ModuleNotFoundError) as _import_failure:
+        # A dependency is absent, so the module body stops at that import and the
+        # names below it never bind. Record the cause, because the half-built
+        # module stays in sys.modules and later hides this error. See #1923.
+        logging.info("MistHelper.py stopped part way through its import: %s", _import_failure)  # Log the cause.
+        setattr(_mod, _IMPORT_ERROR_ATTRIBUTE, _import_failure)  # Keep the real cause on the half-built module.
+        logging.debug("Recorded the import failure as %s", _IMPORT_ERROR_ATTRIBUTE)  # Log the result.
 
 
 @pytest.fixture

--- a/tests/unit/firmware/test_firmware_manager_proxy.py
+++ b/tests/unit/firmware/test_firmware_manager_proxy.py
@@ -46,9 +46,7 @@ class TestMistHelperProxyPartialImport:
         assert "bootstrap_worktree.py" in message  # The repair step must appear.
         assert error_info.value.__cause__ is cause  # The chain must keep the original exception.
 
-    def test_keeps_the_original_error_when_the_module_loaded(
-        self, stub_misthelper_module: types.ModuleType
-    ) -> None:
+    def test_keeps_the_original_error_when_the_module_loaded(self, stub_misthelper_module: types.ModuleType) -> None:
         """With no recorded failure the proxy reports the plain missing name."""
         proxy = _MistHelperProxy()  # Build the proxy under test.
 

--- a/tests/unit/firmware/test_firmware_manager_proxy.py
+++ b/tests/unit/firmware/test_firmware_manager_proxy.py
@@ -1,0 +1,84 @@
+"""Tests for the MistHelper attribute proxy in `src/firmware/firmware_manager.py`.
+
+`MistHelper.py` can stop part way through its module body when a dependency is
+absent. The half-built module stays in `sys.modules`, so a plain `getattr`
+reports a missing attribute and hides the real cause. These tests hold the proxy
+to the rule that it reports the recorded cause. See issue #1923.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from src.firmware.firmware_manager import (
+    _IMPORT_ERROR_ATTRIBUTE,
+    _MISTHELPER_MODULE_NAME,
+    _MistHelperProxy,
+)
+
+
+@pytest.fixture
+def stub_misthelper_module(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    """Install an empty stand-in for `MistHelper` and remove it after the test."""
+    module = types.ModuleType(_MISTHELPER_MODULE_NAME)  # Build an empty module, so no name binds by accident.
+    monkeypatch.setitem(sys.modules, _MISTHELPER_MODULE_NAME, module)  # Install it, because the proxy imports by name.
+    return module  # Give the test the module, so it can bind or record on it.
+
+
+class TestMistHelperProxyPartialImport:
+    """The proxy must name the real cause when the module stopped part way."""
+
+    def test_reports_the_recorded_import_failure(self, stub_misthelper_module: types.ModuleType) -> None:
+        """A recorded dependency failure appears in the message, not a bare miss."""
+        cause = ModuleNotFoundError("No module named 'paramiko'")  # Build the exact cause from issue #1923.
+        setattr(stub_misthelper_module, _IMPORT_ERROR_ATTRIBUTE, cause)  # Record it, as tests/conftest.py does.
+        proxy = _MistHelperProxy()  # Build the proxy under test.
+
+        with pytest.raises(AttributeError) as error_info:  # The proxy must still raise AttributeError.
+            _ = proxy.InputUtils  # Ask for the name that issue #1923 reports as missing.
+
+        message = str(error_info.value)  # Read the message, because the message is the defect.
+        assert "paramiko" in message  # The real cause must appear, so the reader looks in the right place.
+        assert "ModuleNotFoundError" in message  # The class of the cause must appear.
+        assert "bootstrap_worktree.py" in message  # The repair step must appear.
+        assert error_info.value.__cause__ is cause  # The chain must keep the original exception.
+
+    def test_keeps_the_original_error_when_the_module_loaded(
+        self, stub_misthelper_module: types.ModuleType
+    ) -> None:
+        """With no recorded failure the proxy reports the plain missing name."""
+        proxy = _MistHelperProxy()  # Build the proxy under test.
+
+        with pytest.raises(AttributeError) as error_info:  # A truly absent name still raises.
+            _ = proxy.NameThatDoesNotExist  # Ask for a name that no module binds.
+
+        message = str(error_info.value)  # Read the message for the plain case.
+        assert "has no attribute" in message  # Keep the standard text, because the module did load.
+        assert "bootstrap_worktree.py" not in message  # Do not offer a repair step that does not apply.
+
+    def test_forwards_a_bound_attribute(self, stub_misthelper_module: types.ModuleType) -> None:
+        """A bound name resolves through the proxy without change."""
+        stub_misthelper_module.InputUtils = "bound-value"  # Bind a name, so the lookup succeeds.
+        proxy = _MistHelperProxy()  # Build the proxy under test.
+
+        assert proxy.InputUtils == "bound-value"  # The proxy must return the live value.
+
+    def test_reports_a_failed_import_of_the_module_itself(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An ImportError from the import call becomes a named AttributeError."""
+        cause = ModuleNotFoundError("No module named 'paramiko'")  # Build the cause the import would raise.
+
+        def raise_import_error(name: str) -> types.ModuleType:
+            """Stand in for importlib.import_module and always fail."""
+            raise cause  # Raise the prepared cause, so the proxy sees a failed import.
+
+        monkeypatch.setattr("src.firmware.firmware_manager.importlib.import_module", raise_import_error)  # Install it.
+        proxy = _MistHelperProxy()  # Build the proxy under test.
+
+        with pytest.raises(AttributeError) as error_info:  # The proxy must not leak ImportError to the caller.
+            _ = proxy.InputUtils  # Ask for any name, because the import fails first.
+
+        assert "paramiko" in str(error_info.value)  # The real cause must appear in the message.
+        assert error_info.value.__cause__ is cause  # The chain must keep the original exception.


### PR DESCRIPTION
Closes #2013.
Closes #1923.

## Summary

This branch closes a cross-organization authorization gap in `mist-ops-platform`
and repairs a misleading error message in the firmware proxy.

The finding is recorded as issue #2013.

## Defect 1: mutating routes never checked org membership

`mist-ops-platform` authenticated a caller on every mutating route. It never
checked that the caller belonged to the organization the route changed. The
route loaded a record by its identifier and then wrote it.

The read routes were correct, because they depend on `get_scoped_org_id`, which
calls `require_org_access`. The write routes were not.

`config.py` called `require_org_access` two times only, on the two routes that
read `org_id` from the request body. `deploy.py` held no call at all.

### Routes that were open

| File | Route | Effect |
| - | - | - |
| `config.py` | `POST /config/baselines` | Wrote an intended state for a caller-supplied `org_id` |
| `config.py` | `POST /config/baselines/{id}/accept-drift` | Overwrote another org intended state and silenced the next drift alert |
| `config.py` | `POST /config/baselines/{id}/remediate` | Pushed config to another org devices through Celery |
| `deploy.py` | `POST`, `PUT`, `DELETE /deploy/jobs...` and `approve` | Created, changed, cancelled, or approved another org job |
| `deploy.py` | `POST /deploy/rollouts` and `activate`, `pause`, `resume`, `promote`, `rollback` | Started or disturbed a firmware rollout in another org |
| `deploy.py` | `POST /deploy/golden-images` and `approve`, `retire` | Changed another org image lifecycle |
| `deploy.py` | `POST /deploy/templates` and `instantiate` | Created a job in another org from a template |
| `deploy.py` | `POST /deploy/dry-run` | Read another org job rows during conflict detection |

### Severity

Critical for `remediate` and `activate`. Both reach production hardware. High
for the rest.

### The fix

The check now sits in the shared loader, so a later route cannot forget it:

- `_load_baseline` and `_load_drift_alert` in `config.py`
- `_load_job`, `_load_plan`, `_load_golden_image`, and `_load_template` in `deploy.py`

Each loader takes the caller and calls `require_org_access(str(row.org_id), user)`
after the 404 check and before the return.

Each create route that reads `org_id` from the request body checks that value
directly.

`promote_wave` and `rollback_wave` dispatched a Celery task on `plan_id` without
loading the plan, so neither had a record to check. Both now load the plan first.

`require_org_access` call count in the two files rose from 2 to 15.

## Defect 2: the firmware proxy named the wrong cause (#1923)

`_MistHelperProxy.__getattr__` reported a missing attribute when the real cause
was an absent dependency. The message sent the reader to the wrong file. Issue
#1923 records that this wrong conclusion cost two engineers real time in one
session.

Root cause, found in `tests/conftest.py`: the loader put the module into
`sys.modules` before it executed the module body, then swallowed the
`ImportError` and left the half-built module in the cache. The recorded cause was
discarded.

The fix has three parts:

1. `paramiko` joins `_REQUIRED_RUNTIME_PACKAGES`, so the session guard stops with
   the bootstrap message instead of letting the half-built module load. `paramiko`
   sits on the import path of `MistHelper.py` at line 629.
2. `tests/conftest.py` records the real failure on the module under
   `__misthelper_import_error__` instead of discarding it. The `SystemExit` path
   gets the same treatment, because it leaves the same half-built module.
3. The proxy reads that record and reports the real cause, chained with `from`.

A caller now reads this instead of a wrong "no attribute" line:

```
MistHelper stopped part way through its import, so the attribute 'InputUtils'
never bound. The import failed with:
    ModuleNotFoundError: No module named 'paramiko'
This is an environment gap, not a missing declaration. Install the project
dependencies with 'python scripts/bootstrap_worktree.py'. See issue #1866 for
the empty worktree case.
```

Closes #1923.

## Verification

| Check | Result |
| - | - |
| `python -m py_compile` on all 5 changed files | Passed |
| `ruff check` on `firmware_manager.py`, `conftest.py`, the new test | `All checks passed` |
| `ruff check` on the two ops platform routes, with the sub-project config | 92 findings before, 91 after. No regression |
| `pytest tests/unit/firmware/` | 692 passed |
| `pytest tests/unit/firmware/test_firmware_manager_proxy.py` | 4 passed, new |

The ruff comparison used `git stash` to measure the same two files at `HEAD`
under the same config. Issue #1974 covers the missing gate for that config.

## Tests added

`tests/unit/firmware/test_firmware_manager_proxy.py`, 4 cases:

1. A recorded dependency failure appears in the message, with the chain kept.
2. With no recorded failure the proxy still reports the plain missing name.
3. A bound name resolves through the proxy without change.
4. An `ImportError` raised by the import call becomes a named `AttributeError`.

## Follow-up work this branch does not cover

1. **A 403 test for each ops platform route.** The fix is in the shared loader,
   and the existing suite covers the loaders, but a direct 403 assertion per
   route would stop a regression. This needs the ops platform test fixtures.
2. **Issue #1893 reproduced.** Every push from this worktree returned
   `403 ... denied to jmorrison_JNPR`. The cause is the `GIT_CONFIG_PARAMETERS`
   environment variable, which injects a `copilot` credential helper that wins
   over the `gh` helper. The workaround that succeeded:

   ```powershell
   Remove-Item Env:GIT_CONFIG_PARAMETERS
   Remove-Item Env:GH_TOKEN
   git -c "credential.https://github.com.helper=" `
       -c "credential.https://github.com.helper=!gh auth git-credential" push
   ```

   `gh auth switch` alone does not fix it, because `git` never consults the
   account that `gh` reports.
3. **Issue #1989 is not on `main`.** The reported portal lives in
   `src/upgrade_portal/`, which exists only on `feat/1823-upgrade-capture-portal`
   (pull request #1825). A fix belongs on that branch, not here.

## Conformance

- [x] The change is limited to the defect and its test.
- [x] No secret is added.
- [x] The prose follows Simplified Technical English.
- [x] The lint result does not regress.
- [x] The existing tests pass.

