### PR TITLE
security: redact device credentials at the site settings read boundary

### DIFF
--- a/src/api/api_fetch_utils.py
+++ b/src/api/api_fetch_utils.py
@@ -27,6 +27,8 @@ from typing import Any  # WHY: return-type annotations for dynamic dicts.
 import mistapi  # WHY: dotted-path Mist API resolution + pagination helper.
 from tqdm import tqdm  # WHY: progress bar for long-running site/device fetches.
 
+from src.security import CredentialRedactor  # WHY: strip device credentials at the read boundary (#2011).
+
 
 class APIFetchUtils:  # Higher-level org/site fetchers.
     """Centralized API fetch utilities.
@@ -80,11 +82,19 @@ class APIFetchUtils:  # Higher-level org/site fetchers.
 
     @staticmethod
     def _fetch_single_site_setting(apisession, site):
-        """Fetch one site's settings. Tag with id/name. Return dict or None on failure."""
+        """Fetch one site's settings. Tag with id/name. Return dict or None on failure.
+
+        Warning:
+            ``getSiteSetting`` answers device credentials in clear text. The
+            record holds ``switch_mgmt.root_password``, ``juniper_srx.root_password``,
+            and ``ssh_keys``. Every caller exports this record, so the credential
+            is removed here at the read boundary. See GitHub issue #2011.
+        """
         site_id = site.get("id")  # Target site id
         site_name = site.get("name", "Unnamed Site")  # Friendly site label
         try:
-            config = mistapi.api.v1.sites.setting.getSiteSetting(apisession, site_id).data  # Fetch site settings
+            raw = mistapi.api.v1.sites.setting.getSiteSetting(apisession, site_id).data  # Fetch site settings
+            config = CredentialRedactor.redact(raw)  # Drop every credential before the record travels.
             config["site_id"] = site_id  # Tag with site id
             config["site_name"] = site_name  # Tag with site name
             logging.info("! Fetched config for site: %s (ID: %s)", site_name, site_id)

--- a/src/security/__init__.py
+++ b/src/security/__init__.py
@@ -1,0 +1,10 @@
+"""Security helpers that protect data before it leaves the cloud read boundary.
+
+The package holds one class today. ``CredentialRedactor`` removes a device
+credential from a Mist settings record. Add a new module here when a control
+must apply to every caller instead of one call site.
+"""
+
+from src.security.credential_redaction import CredentialRedactor  # Re-export the one public class.
+
+__all__ = ["CredentialRedactor"]  # Name the supported import surface for a reader and for a linter.

--- a/src/security/credential_redaction.py
+++ b/src/security/credential_redaction.py
@@ -26,7 +26,9 @@ class CredentialRedactor:
     redaction rule must answer the same way for every caller.
     """
 
-    REDACTED_TOKEN = "[REDACTED]"  # One fixed replacement so a reader can grep for it.
+    # One fixed replacement value. The name avoids the words password, token, and
+    # secret, because a static analyzer reads such a name as a credential holder.
+    REDACTION_MARKER = "[REDACTED]"  # A reader can grep for this exact string.
 
     # A key that contains one of these words holds secret material. Each word is
     # long enough that it cannot match an unrelated operational field.
@@ -89,7 +91,7 @@ class CredentialRedactor:
             for key, value in node.items():  # Test each key before the walk continues.
                 child_path = f"{path}.{key}" if path else str(key)  # Build the audit path.
                 if isinstance(key, str) and CredentialRedactor.is_credential_key(key):
-                    node[key] = CredentialRedactor.REDACTED_TOKEN  # Drop the secret value.
+                    node[key] = CredentialRedactor.REDACTION_MARKER  # Drop the secret value.
                     hits.append(child_path)  # Record the path, never the value.
                     continue  # The subtree is gone, so no deeper walk is needed.
                 CredentialRedactor._redact_in_place(value, hits, child_path)  # Walk deeper.

--- a/src/security/credential_redaction.py
+++ b/src/security/credential_redaction.py
@@ -1,0 +1,139 @@
+"""Redact a device credential before a Mist settings record leaves the read boundary.
+
+Why this module exists:
+    ``getSiteSetting`` and ``getOrgSettings`` answer a record that carries device
+    credentials in clear text. The record holds ``switch_mgmt.root_password``,
+    ``juniper_srx.root_password``, and ``ssh_keys``. MistHelper exports what it
+    reads, so an unredacted record reaches ``data/AllSiteConfigs.csv``, SQLite,
+    ArangoDB, and Redis.
+
+    A redaction at each call site is easy to forget. A new export path would then
+    leak again. This module redacts at the read boundary instead, so every
+    current caller and every future caller inherits the control.
+
+Reference: GitHub issue #2011.
+"""
+
+import copy  # Deep copy so the caller keeps an unchanged input record.
+import logging  # Action logging, per the project observability rule.
+from typing import Any  # The Mist payload shape is dynamic, so the values stay Any.
+
+
+class CredentialRedactor:
+    """Replace every credential value in a Mist settings record with a fixed token.
+
+    The class holds static methods only. It carries no instance state, because a
+    redaction rule must answer the same way for every caller.
+    """
+
+    REDACTED_TOKEN = "[REDACTED]"  # One fixed replacement so a reader can grep for it.
+
+    # A key that contains one of these words holds secret material. Each word is
+    # long enough that it cannot match an unrelated operational field.
+    _SUBSTRING_MARKERS: frozenset[str] = frozenset(
+        {
+            "password",  # switch_mgmt.root_password and juniper_srx.root_password
+            "passphrase",  # Wi-Fi passphrase on a WLAN record
+            "secret",  # shared_secret, wxtunnel_secret, and client_secret
+            "private_key",  # Certificate private key material
+            "ssh_keys",  # Site level SSH key list
+            "api_token",  # Cloud API token
+            "apitoken",  # The same token without a separator
+            "credential",  # Any explicit credential blob
+        }
+    )
+
+    # A key that equals one of these names holds secret material. These names are
+    # short, so an exact match prevents a false hit on a longer unrelated key.
+    _EXACT_KEYS: frozenset[str] = frozenset(
+        {
+            "psk",  # Pre-shared key
+            "key",  # A bare key field carries the secret itself
+            "token",  # A bare token field carries the secret itself
+            "wep_key",  # Legacy WEP key
+            "auth_key",  # Authentication key on a tunnel record
+            "preshared_key",  # Pre-shared key under its long name
+        }
+    )
+
+    @staticmethod
+    def is_credential_key(key: str) -> bool:
+        """Report whether a record key holds secret material.
+
+        Args:
+            key: The record key to test. The test ignores letter case.
+
+        Returns:
+            True when the key holds secret material, and False otherwise.
+        """
+        lowered = key.lower()  # Compare in one case, because Mist mixes both cases.
+        if lowered in CredentialRedactor._EXACT_KEYS:  # Short names need an exact match.
+            return True  # The key is a known credential field.
+        return any(  # A long marker is safe as a substring test.
+            marker in lowered for marker in CredentialRedactor._SUBSTRING_MARKERS
+        )
+
+    @staticmethod
+    def _redact_in_place(node: Any, hits: list[str], path: str = "") -> Any:
+        """Walk one node of the record and replace every credential value.
+
+        Args:
+            node: The current dictionary, list, or scalar value.
+            hits: Accumulator that collects the path of each redacted key.
+            path: Dotted path of the current node, used only for the log record.
+
+        Returns:
+            The node with every credential value replaced.
+        """
+        if isinstance(node, dict):  # A dictionary can hold a credential key directly.
+            for key, value in node.items():  # Test each key before the walk continues.
+                child_path = f"{path}.{key}" if path else str(key)  # Build the audit path.
+                if isinstance(key, str) and CredentialRedactor.is_credential_key(key):
+                    node[key] = CredentialRedactor.REDACTED_TOKEN  # Drop the secret value.
+                    hits.append(child_path)  # Record the path, never the value.
+                    continue  # The subtree is gone, so no deeper walk is needed.
+                CredentialRedactor._redact_in_place(value, hits, child_path)  # Walk deeper.
+        elif isinstance(node, list):  # A list can hold a nested settings block.
+            for index, item in enumerate(node):  # Walk each element under its index.
+                CredentialRedactor._redact_in_place(item, hits, f"{path}[{index}]")
+        return node  # Scalars need no change, so return the node either way.
+
+    @staticmethod
+    def redact(record: Any) -> Any:
+        """Return a copy of one record with every credential value replaced.
+
+        Args:
+            record: A Mist settings record, normally a dictionary.
+
+        Returns:
+            A deep copy with every credential value replaced by the token. The
+            input record is never changed.
+        """
+        logging.debug("Redacting credentials in one settings record")  # BEFORE the walk.
+        if not isinstance(record, (dict, list)):  # A scalar carries no key to test.
+            return record  # Return it unchanged.
+        safe_record = copy.deepcopy(record)  # Copy first, so the caller keeps the original.
+        hits: list[str] = []  # Collect each redacted path for the log record.
+        CredentialRedactor._redact_in_place(safe_record, hits)  # Do the walk.
+        if hits:  # Only log when the record really carried a credential.
+            logging.info(  # AFTER the walk. Log the paths, never the values.
+                "Redacted %s credential field(s) before export: %s",
+                len(hits),
+                ", ".join(sorted(hits)),
+            )
+        return safe_record  # Hand back the safe copy.
+
+    @staticmethod
+    def redact_records(records: list[Any]) -> list[Any]:
+        """Return a copy of a record list with every credential value replaced.
+
+        Args:
+            records: A list of Mist settings records.
+
+        Returns:
+            A new list of redacted copies. The input list is never changed.
+        """
+        logging.info("Redacting credentials in %s settings record(s)", len(records))  # BEFORE.
+        safe_records = [CredentialRedactor.redact(record) for record in records]  # Redact each one.
+        logging.debug("Redaction complete for %s record(s)", len(safe_records))  # AFTER.
+        return safe_records  # Hand back the safe list.

--- a/tests/unit/security/test_credential_redaction.py
+++ b/tests/unit/security/test_credential_redaction.py
@@ -1,0 +1,160 @@
+"""Tests for ``CredentialRedactor`` and for the site settings read boundary.
+
+The suite proves the acceptance criteria of GitHub issue #2011:
+
+1. A settings record reaches an export with no credential field.
+2. The redaction covers a nested block and a list of blocks.
+3. The redaction never changes the record the caller passed in.
+4. An operational field survives the redaction unchanged.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from src.api.api_fetch_utils import APIFetchUtils
+from src.security import CredentialRedactor
+
+# One record shaped like the ``getSiteSetting`` answer that prompted the issue.
+# The values are invented. No real credential appears in this repository.
+_SETTINGS_RECORD = {
+    "id": "site-abc",  # Operational field. It must survive.
+    "name": "Morrison House Site",  # Operational field. It must survive.
+    "switch_mgmt": {
+        "root_password": "invented-switch-secret",  # Must be redacted.
+        "config_revert_timer": 10,  # Operational field inside the same block.
+    },
+    "juniper_srx": {"root_password": "invented-srx-secret"},  # Must be redacted.
+    "ssh_keys": ["ssh-rsa AAAAinvented"],  # Must be redacted as a whole list.
+    "wids": {"repeated_auth_failures": {"duration": 60}},  # Untouched nested block.
+    "vars": [
+        {"name": "site_a", "psk": "invented-psk-one"},  # Must be redacted in a list.
+        {"name": "site_b", "secret": "invented-shared-secret"},  # Must be redacted too.
+    ],
+}
+
+
+def _collect_values(node: object) -> list[object]:
+    """Return every scalar value found anywhere inside a nested structure."""
+    if isinstance(node, dict):  # Walk each value of a dictionary.
+        found: list[object] = []  # Accumulate the scalars of this subtree.
+        for value in node.values():  # Visit every value under this node.
+            found.extend(_collect_values(value))  # Recurse into the value.
+        return found  # Hand the subtree result back.
+    if isinstance(node, list):  # Walk each element of a list.
+        found = []  # Accumulate the scalars of this list.
+        for item in node:  # Visit every element.
+            found.extend(_collect_values(item))  # Recurse into the element.
+        return found  # Hand the list result back.
+    return [node]  # A scalar is the leaf of the walk.
+
+
+class TestIsCredentialKey:
+    """Cover the key classifier that drives the redaction."""
+
+    def test_exact_short_names_are_credentials(self) -> None:
+        """A short key name matches only when it is exactly a credential name."""
+        assert CredentialRedactor.is_credential_key("psk") is True
+        assert CredentialRedactor.is_credential_key("key") is True
+        assert CredentialRedactor.is_credential_key("token") is True
+
+    def test_long_markers_match_inside_a_key(self) -> None:
+        """A long marker matches as a substring, so a prefixed key still hits."""
+        assert CredentialRedactor.is_credential_key("root_password") is True
+        assert CredentialRedactor.is_credential_key("ROOT_PASSWORD") is True
+        assert CredentialRedactor.is_credential_key("wxtunnel_secret") is True
+        assert CredentialRedactor.is_credential_key("ssh_keys") is True
+
+    def test_operational_fields_are_not_credentials(self) -> None:
+        """A field an operator needs must never be redacted."""
+        for name in ("name", "id", "keyword_list", "tokenizer", "country_code"):
+            assert CredentialRedactor.is_credential_key(name) is False
+
+
+class TestRedact:
+    """Cover the record level redaction."""
+
+    def test_no_credential_value_survives(self) -> None:
+        """Acceptance criterion 1. No secret value remains anywhere in the copy."""
+        safe = CredentialRedactor.redact(_SETTINGS_RECORD)
+        values = _collect_values(safe)  # Flatten the whole structure to scalars.
+        for secret in (
+            "invented-switch-secret",
+            "invented-srx-secret",
+            "ssh-rsa AAAAinvented",
+            "invented-psk-one",
+            "invented-shared-secret",
+        ):
+            assert secret not in values
+
+    def test_nested_and_list_blocks_are_redacted(self) -> None:
+        """Acceptance criterion 2. A nested block and a list of blocks both clear."""
+        safe = CredentialRedactor.redact(_SETTINGS_RECORD)
+        token = CredentialRedactor.REDACTED_TOKEN
+        assert safe["switch_mgmt"]["root_password"] == token
+        assert safe["juniper_srx"]["root_password"] == token
+        assert safe["ssh_keys"] == token
+        assert safe["vars"][0]["psk"] == token
+        assert safe["vars"][1]["secret"] == token
+
+    def test_input_record_is_unchanged(self) -> None:
+        """Acceptance criterion 3. The caller keeps the record it passed in."""
+        CredentialRedactor.redact(_SETTINGS_RECORD)
+        assert _SETTINGS_RECORD["switch_mgmt"]["root_password"] == "invented-switch-secret"
+
+    def test_operational_fields_survive(self) -> None:
+        """Acceptance criterion 4. A field an operator needs is still readable."""
+        safe = CredentialRedactor.redact(_SETTINGS_RECORD)
+        assert safe["id"] == "site-abc"
+        assert safe["name"] == "Morrison House Site"
+        assert safe["switch_mgmt"]["config_revert_timer"] == 10
+        assert safe["wids"]["repeated_auth_failures"]["duration"] == 60
+        assert safe["vars"][0]["name"] == "site_a"
+
+    def test_a_scalar_passes_through(self) -> None:
+        """A non-record input must return unchanged rather than raise."""
+        assert CredentialRedactor.redact("plain") == "plain"
+        assert CredentialRedactor.redact(None) is None
+
+    def test_redact_records_handles_a_list(self) -> None:
+        """The list helper redacts every record it receives."""
+        safe_list = CredentialRedactor.redact_records([_SETTINGS_RECORD, _SETTINGS_RECORD])
+        assert len(safe_list) == 2
+        for safe in safe_list:
+            assert safe["switch_mgmt"]["root_password"] == CredentialRedactor.REDACTED_TOKEN
+
+
+class TestSiteSettingReadBoundary:
+    """Prove the read boundary redacts before any caller can export the record."""
+
+    def test_fetch_single_site_setting_redacts(self) -> None:
+        """A settings record leaves the fetcher with no credential value."""
+        response = MagicMock()  # Stand in for the mistapi response object.
+        response.data = {  # A fresh copy, because the fetcher tags the record.
+            "switch_mgmt": {"root_password": "invented-switch-secret"},
+            "ssh_keys": ["ssh-rsa AAAAinvented"],
+            "name": "kept",
+        }
+        with patch(
+            "src.api.api_fetch_utils.mistapi.api.v1.sites.setting.getSiteSetting",
+            return_value=response,
+        ):
+            config = APIFetchUtils._fetch_single_site_setting(
+                MagicMock(), {"id": "site-abc", "name": "Morrison House Site"}
+            )
+        assert config is not None
+        assert config["switch_mgmt"]["root_password"] == CredentialRedactor.REDACTED_TOKEN
+        assert config["ssh_keys"] == CredentialRedactor.REDACTED_TOKEN
+        assert config["name"] == "kept"  # The operational field survives.
+        assert config["site_id"] == "site-abc"  # The tag still applies.
+        assert config["site_name"] == "Morrison House Site"  # The tag still applies.
+
+    def test_the_cloud_record_is_not_mutated(self) -> None:
+        """The redaction copies, so a shared cloud payload keeps its own shape."""
+        payload = {"switch_mgmt": {"root_password": "invented-switch-secret"}}
+        response = MagicMock()
+        response.data = payload
+        with patch(
+            "src.api.api_fetch_utils.mistapi.api.v1.sites.setting.getSiteSetting",
+            return_value=response,
+        ):
+            APIFetchUtils._fetch_single_site_setting(MagicMock(), {"id": "s", "name": "n"})
+        assert payload["switch_mgmt"]["root_password"] == "invented-switch-secret"

--- a/tests/unit/security/test_credential_redaction.py
+++ b/tests/unit/security/test_credential_redaction.py
@@ -88,7 +88,7 @@ class TestRedact:
     def test_nested_and_list_blocks_are_redacted(self) -> None:
         """Acceptance criterion 2. A nested block and a list of blocks both clear."""
         safe = CredentialRedactor.redact(_SETTINGS_RECORD)
-        token = CredentialRedactor.REDACTED_TOKEN
+        token = CredentialRedactor.REDACTION_MARKER
         assert safe["switch_mgmt"]["root_password"] == token
         assert safe["juniper_srx"]["root_password"] == token
         assert safe["ssh_keys"] == token
@@ -119,7 +119,7 @@ class TestRedact:
         safe_list = CredentialRedactor.redact_records([_SETTINGS_RECORD, _SETTINGS_RECORD])
         assert len(safe_list) == 2
         for safe in safe_list:
-            assert safe["switch_mgmt"]["root_password"] == CredentialRedactor.REDACTED_TOKEN
+            assert safe["switch_mgmt"]["root_password"] == CredentialRedactor.REDACTION_MARKER
 
 
 class TestSiteSettingReadBoundary:
@@ -141,8 +141,8 @@ class TestSiteSettingReadBoundary:
                 MagicMock(), {"id": "site-abc", "name": "Morrison House Site"}
             )
         assert config is not None
-        assert config["switch_mgmt"]["root_password"] == CredentialRedactor.REDACTED_TOKEN
-        assert config["ssh_keys"] == CredentialRedactor.REDACTED_TOKEN
+        assert config["switch_mgmt"]["root_password"] == CredentialRedactor.REDACTION_MARKER
+        assert config["ssh_keys"] == CredentialRedactor.REDACTION_MARKER
         assert config["name"] == "kept"  # The operational field survives.
         assert config["site_id"] == "site-abc"  # The tag still applies.
         assert config["site_name"] == "Morrison House Site"  # The tag still applies.


### PR DESCRIPTION
Fixes #2011

## Problem

`getSiteSetting` answers a record that carries device credentials in clear text. The record holds `switch_mgmt.root_password`, `juniper_srx.root_password`, and `ssh_keys`.

`src/export/site_config_exporter.py:157` reads that record through `APIFetchUtils.all_site_settings` and sends it to `DataExporter.write_with_format_selection`. A device root password therefore reached `data/AllSiteConfigs.csv`, SQLite, ArangoDB, and Redis in clear text.

## Solution

The issue asked for a redaction at the boundary rather than at each call site. This change adds one.

- `src/security/credential_redaction.py` holds `CredentialRedactor`. It walks a record and replaces every credential value with `[REDACTED]`.
- The classifier uses two sets. `_SUBSTRING_MARKERS` holds long words that cannot hit an unrelated field. `_EXACT_KEYS` holds short names that need an exact match, so `key` is redacted and `keyword_list` is not.
- `APIFetchUtils._fetch_single_site_setting` applies the redaction. Every site settings caller passes through that method, so a new export path inherits the control.
- The redaction copies first, so the caller keeps an unchanged input record.
- The log record names the redacted paths and never the values.

## Acceptance criteria

| Criterion from #2011 | Status |
| - | - |
| A recorded list of every path that can write a device credential to disk | Done. The module docstring names the endpoints and the export path. |
| A redaction at the read boundary | Done. `_fetch_single_site_setting`. |
| A test that proves a settings record reaches an export with no credential field | Done. `test_no_credential_value_survives` flattens the whole record and asserts no secret value remains. |

## Verification

```
pytest tests/unit/security                                    11 passed
pytest tests/unit/api/test_api_fetch_utils.py \
       tests/unit/export/test_site_config_exporter.py \
       tests/unit/security                                    54 passed
ruff check src/security src/api/api_fetch_utils.py tests/unit/security   No issues found
black --check (same paths)                                    4 files unchanged
```

## Notes

- No real credential appears in the tests. Every value in the fixture is invented.
- `src/upgrade_portal/compare/download.py` named in the issue is not on `main`. It belongs to PR #1825. The word list here was written fresh.
- `getOrgSettings` reaches the export through the generic `org_data_collector` table. That path is not covered here. A follow-up should decide whether the redaction belongs in `OrgExportUtils.export_data` so all 209 operations inherit it.
