### PR TITLE
docs(noc-runbooks): add NODE_DOWN and GW_PORT_DOWN reference articles

### DIFF
--- a/documentation/noc-runbooks/GATEWAY_DOWN.md
+++ b/documentation/noc-runbooks/GATEWAY_DOWN.md
@@ -7,17 +7,19 @@
 | **Alert Name** | GATEWAY_DOWN |
 | **Mist alarm key** | `gateway_down` (fires when Mist stops receiving heartbeat / telemetry from the gateway — the box is unreachable from the cloud) |
 | **Platform** | Juniper SSR130 (single gateway at a retail branch — no local HA peer). The same alarm key also fires on SRX gateways — an SRX-specific runbook is planned as Phase 2 because the CLI (Junos) differs from SSR PCLI. |
-| **Mist native severity** | `critical` |
-| **NOC severity** | **Critical** (native — no override) |
+| **Mist native severity** | `warn` (verified against `GET /api/v1/const/alarm_defs`) |
+| **NOC severity** | **Critical** (override — see rationale below) |
 | **Group** | `infrastructure` |
 | **Clear event key** | No distinct clear-event key is enumerated in the Mist OpenAPI catalog for `gateway_down`. The alarm auto-clears when Mist starts receiving heartbeat / telemetry from the gateway again; treat the disappearance of the alarm on the device — and the gateway showing `Connected` in `WAN Edges → *SSR130* → Health` — as the machine-verifiable close signal. Verify current auto-clear behavior against `GET /api/v1/const/alarm_defs` at runtime; the alarm-definition catalog is dynamic and may add an explicit clear key in future firmware/cloud releases. |
 | **Correlated alarms** | `switch_down`, `gw_bgp_neighbor_down`, `gw_vpn_path_down`, `vpn_peer_down`, `bad_wan_uplink`, `intermittent_wan_connectivity`, `sw_alarm_chassis_mgmt_link_down`, `sw_critical_port_down` |
 | **Prerequisites** | None — fires automatically when Mist declares the gateway unreachable. |
 | **Description** | Mist has stopped receiving heartbeat / telemetry from the branch SSR130. From the cloud's perspective the gateway is down. Because there is only a single SSR130 at the branch and no local HA peer, this alarm means the branch has either lost management visibility, lost WAN, or both. Treat this alarm as a **branch outage** until proven otherwise. |
 
-### Severity note (no override)
+### Severity rationale (Mist `warn` → NOC `critical`)
 
-Mist ships `gateway_down` as `critical` natively — with a single-gateway branch, gateway loss is site-impacting by construction. No override is applied.
+Mist ships `gateway_down` as `warn` natively, because many customers run gateways in redundant pairs where losing one node is a degraded state rather than an outage. This environment does not. The branch runs a single SSR130 with no local HA peer, so gateway loss is site-impacting by construction. We page it as **critical**.
+
+The override lives in the downstream paging and ticketing layer, keyed off the alarm payload `type` value `gateway_down`. It does not live in Mist. See Shared Appendix §2.
 
 ### What this alarm does *not* tell you
 

--- a/documentation/noc-runbooks/GW_PORT_DOWN.md
+++ b/documentation/noc-runbooks/GW_PORT_DOWN.md
@@ -1,0 +1,275 @@
+# GW_PORT_DOWN
+
+> **Read this first — `GW_PORT_DOWN` names two different objects in Mist.** The alarm you page on is catalogued as **`gw_critical_port_down`**, but the webhook payload it sends carries `"type": "gw_port_down"`. A separate, unrelated **device event** also uses the key `GW_PORT_DOWN`. The two objects have different trigger rules and different noise levels. Section 1.1 tells them apart. If your ticket source is a Mist webhook, you have the **alarm**. If your ticket source is an event search or an event-stream subscription, you have the **event**.
+
+## 1. Overview
+
+| Field | Value |
+|---|---|
+| **Alert Name** | GW_PORT_DOWN |
+| **Mist alarm key** | `gw_critical_port_down` (alarm-definition catalog key). **The webhook payload `type` is `gw_port_down`** — filter downstream rules on `gw_port_down`, not on the catalog key. |
+| **Platform** | Juniper SSR130 (single gateway at a retail branch — no local HA peer). The same alarm key also fires on SRX gateways. SRX uses Junos, not SSR PCLI, so an SRX-specific runbook is planned as Phase 2. |
+| **Mist native severity** | `warn` |
+| **NOC severity** | **Critical** (override — see rationale below) |
+| **Group** | `infrastructure` |
+| **Clear event key** | `gw_critical_port_up` (payload `type` is `gw_port_up`, native severity `info`) |
+| **Default enabled** | `true` — the alarm is on by default in a new alarm template. |
+| **Correlated alarms** | `gw_bgp_neighbor_down`, `gw_vpn_path_down`, `vpn_peer_down`, `vpn_path_down`, `bad_wan_uplink`, `intermittent_wan_connectivity`, `gateway_down`, `gw_bad_cable`, `gw_negotiation_mismatch`, `gw_mtu_mismatch`, `port_flap`, `port_stuck`, `switch_down` |
+| **Prerequisites** | **The port must be flagged as critical on the gateway port configuration.** Without that flag the port transition raises only the `GW_PORT_DOWN` device event, and no alarm fires. See §1.2. |
+| **Payload fields** | `hostnames`, `nodes`, `gateways`, `reasons` (per the alarm-definition catalog) |
+| **Description** | A gateway port flagged as **critical** has transitioned to Down. At a retail branch the branch runs a single SSR130, so a critical gateway port is almost always an ISP transport port, the LAN uplink to the EX4100 Virtual Chassis, or a member of the uplink aggregate. Treat this alarm as **branch-impacting until the port role is confirmed**. |
+
+### Severity rationale (Mist `warn` → NOC `critical`)
+
+Mist ships this alarm as `warn` because gateway port-down events span a wide impact range across its whole customer base. In this environment the alarm fires **only** for ports an engineer explicitly flagged as critical, and the branch has a single SSR130 with no local HA peer. Every critical port on that gateway is therefore either WAN transport or the branch LAN uplink. We page it as **critical**.
+
+The override lives in the downstream paging and ticketing layer, keyed off the payload `type` value `gw_port_down`. It does not live in Mist. See Shared Appendix §2.
+
+If the critical-port flags turn out to be over-applied, retune the gateway port configuration. Do not lower the NOC severity.
+
+### 1.1 Alarm or event? Tell them apart
+
+| | **Alarm** | **Device event** |
+|---|---|---|
+| Catalog key | `gw_critical_port_down` | `GW_PORT_DOWN` |
+| Payload `type` value | `gw_port_down` | `GW_PORT_DOWN` |
+| Display name | Critical WAN Edge Port Down | WAN Edge Port Down |
+| Catalog endpoint | `GET /api/v1/const/alarm_defs` | `GET /api/v1/const/device_events` |
+| Has a severity | Yes — `warn` | **No** — events carry no severity |
+| Has a group | Yes — `infrastructure` | No |
+| Fires for | **Critical-flagged ports only** | **Every** gateway port transition |
+| Delivered by | Alarm webhook, Monitor → Alerts | Event search, event webhook, Monitor → Events |
+| Paired clear | `gw_critical_port_up` | `GW_PORT_UP` |
+| Use it for | Paging and ticketing | Timeline reconstruction and flap counting |
+
+**Operator rule:** page on the alarm. Investigate with the event. The event fires on every port on the box, including access and unused ports, so it is far noisier. Never wire the uppercase `GW_PORT_DOWN` event key into a paging rule.
+
+A device-event record looks like this. Note that Mist derives it from the device SNMP trap:
+
+```json
+{
+  "type": "GW_PORT_DOWN",
+  "timestamp": 1575935387,
+  "org_id": "b4e16c72-d50e-4c03-a952-a3217e231e2c",
+  "site_id": "57b2f891-09c1-4dcc-8ff1-2f9fb3ff7d39",
+  "mac": "0c8126c7054d",
+  "version": "18.1R3.3",
+  "text": "SNMP_TRAP_LINK_DOWN: ifIndex 515, ifAdminStatus up(1), ifOperStatus down(2), ifName ge-0/0/2",
+  "model": "EX2300-C-12P",
+  "port_id": "ge-0/0/2"
+}
+```
+
+### 1.2 Prerequisite — the critical-port flag
+
+The alarm is silent unless an engineer flags the port. Set the flag in **WAN Edges → *SSR130* → Port Configuration**, or in the gateway template that the site inherits.
+
+At a retail branch, flag these gateway ports as critical:
+
+- Both ISP-facing WAN transport ports.
+- The LAN uplink to the EX4100 Virtual Chassis, and every member of that aggregate.
+- Any dedicated out-of-band management port, where the branch has one.
+
+Do not flag unused ports or ports that serve a single endpoint. Over-flagging turns a paging alarm into noise.
+
+### 1.3 Read the `reasons` string
+
+The alarm carries a `reasons` array. Each entry is a raw interface state string:
+
+```text
+ifIndex 564, ifAdminStatus up(1), ifOperStatus down(2), ifName ae0
+```
+
+Decode the two status values before you touch anything. They separate a human action from a real fault:
+
+| `ifAdminStatus` | `ifOperStatus` | Meaning | First action |
+|---|---|---|---|
+| `up(1)` | `down(2)` | The port is enabled but the link is dead. This is a real fault — cable, optic, remote end, or ISP. | Work §5 from the top. |
+| `down(2)` | `down(2)` | Somebody disabled the port, or a configuration push disabled it. | Check Organization → Audit Logs first. This is a change, not a fault. |
+| `up(1)` | `up(1)` | The port recovered before you opened the ticket. | Confirm `gw_critical_port_up` arrived. Then count flaps — see §5. |
+
+Read `ifName` to classify the port. `ae0` and similar names are aggregates, so the branch may still be forwarding on a surviving member. A `ge-` or `xe-` name is a single physical port with no member to fall back on.
+
+## 2. Impact
+
+Impact depends entirely on the role of the flagged port. Classify the port before you declare an outage.
+
+- **ISP transport port (single-ISP branch).** The branch loses WAN. Both SVR overlays to the DC hubs (Dallas and Chicago) fail, both BGP sessions withdraw, and the store loses card processing, IP phones, and back-office access. This is a full branch outage.
+- **ISP transport port (dual-ISP branch).** The branch fails over to the surviving ISP. Service continues in a degraded state with no transport redundancy. A second transport failure now goes straight to full outage.
+- **LAN uplink aggregate member.** The aggregate loses a member and forwards on the survivor. Throughput to the EX4100 Virtual Chassis drops. The store normally sees no change.
+- **LAN uplink at zero surviving members, or a single-link LAN uplink.** The gateway is isolated from the branch LAN. Every wired and wireless user loses WAN. Mist may also lose sight of the gateway and raise `gateway_down`, because branch management is usually in band.
+- **Management port.** Mist loses remote visibility, configuration push, and Marvis analytics for the gateway. The data plane keeps forwarding, and branch users normally notice nothing.
+
+## 3. Required Information
+
+| Category | Data to capture |
+|---|---|
+| Device | Site name, site ID, hostname, serial number, SSR software version, Mist device ID, gateway MAC from the payload `gateways` array |
+| Port classification | `ISP-A-transport` / `ISP-B-transport` / `LAN-uplink-member` / `LAN-uplink-single` / `management` / `unused` |
+| Raw reason | The full `reasons` string, plus the decoded `ifAdminStatus` and `ifOperStatus` values from §1.3 |
+| Interface | `ifName`, `ifIndex`, media type (copper or fiber), configured speed, aggregate name and surviving member count |
+| HA node | The `nodes` value, where present. This field identifies the cluster node on an SRX HA pair. A branch SSR130 is a single node, so this field is normally empty. |
+| Optics (fiber only) | Transmit power, receive power, laser bias, temperature, and the vendor threshold for each |
+| Transport peer | ISP circuit ID, demarcation device, and any open ISP ticket for that circuit |
+| Timing | Alarm timestamp in UTC, `last_seen`, `count` of repeats, time of the last known-good state |
+| Timeline | Recent configuration pushes, recent firmware upgrades, scheduled ISP maintenance windows |
+| Correlated alarms | Any alarm active on the SSR130, on the EX4100 Virtual Chassis, or on either ISP underlay in the last 15 minutes |
+
+See Shared Appendix §5 for the always-required ticket fields.
+
+## 4. Validation
+
+Validate from the Mist cloud first. The gateway is usually still reachable when this alarm fires, because only one port went down, so PCLI is normally available.
+
+### From Mist cloud
+
+| Check | Command or action |
+|---|---|
+| Confirm the alarm and read `reasons` | Monitor → Alerts → filter by `gw_critical_port_down` |
+| Port state on the front panel | WAN Edges → *SSR130* → Front Panel |
+| Critical-port flag on the affected port | WAN Edges → *SSR130* → Port Configuration |
+| Raw port transitions and flap count | Monitor → Events → filter by device, type `GW_PORT_DOWN` and `GW_PORT_UP` |
+| WAN link history for both ISPs | Monitor → Service Levels → WAN |
+| SVR peer-path history to both hubs | Monitor → Service Levels → WAN → Peer Paths |
+| Gateway reachability | WAN Edges → *SSR130* → Insights |
+| Recent configuration pushes | Organization → Audit Logs → filter by device |
+
+### From SSR PCLI
+
+| Check | Command |
+|---|---|
+| System, model, and uptime | `show system` |
+| Cloud connectivity | `show system connected` |
+| Physical port state | `show device-interface` |
+| Logical interface state | `show network-interface` |
+| Alarms on the box | `show alarms` |
+| Recent events | `show events` |
+| Routing table | `show route` |
+| SVR peer paths | `show peers` |
+| BGP session summary | `show bgp summary` |
+| Reachability to the hub with a pinned source | `ping <hub-public-ip> source <local-transport-ip>` |
+
+**Never** run a bare `ping <target>` on an SSR. The packet may leave through the wrong interface and report a false negative. Always pin the source with `source <local-transport-ip>`. See Shared Appendix §7.
+
+### On an SRX gateway (Junos, not SSR)
+
+If the alarm fired on an SRX rather than an SSR130, use Junos syntax. Do not paste PCLI into an SRX.
+
+| Check | Command |
+|---|---|
+| Interface summary | `show interfaces terse` |
+| Interface detail | `show interfaces <ifName> extensive` |
+| Admin-down or link-down | `show configuration interfaces <ifName>` |
+| Optics readings | `show interfaces diagnostics optics <ifName>` |
+| Aggregate member state | `show lacp interfaces` |
+| Chassis alarms | `show chassis alarms` |
+| Interface-scoped logs | `show log messages \| match <ifName>` |
+
+## 5. Resolution
+
+Classify the port first, using `ifName` from the `reasons` string. The correct response differs completely between a transport port and a LAN uplink member.
+
+| Area | Action |
+|---|---|
+| Administrative disable | If `ifAdminStatus` is `down(2)`, this is a change and not a fault. Review Organization → Audit Logs for the last 24 hours. If a push disabled the port, roll the push back through Mist. |
+| ISP transport port | Verify the ISP demarcation device shows link. Open a ticket with that ISP and supply the circuit ID. A dead transport port on the branch side and a dark demarcation device look identical from Mist. |
+| Dual-ISP branch | Confirm the surviving ISP carries the load. Verify both SVR peer paths and both BGP sessions on the surviving transport before you downgrade the ticket. |
+| Cable or optic | Reseat or replace the cable, the direct-attach cable, or the transceiver. For fiber, compare the transmit and receive readings against the vendor threshold. |
+| LAN uplink member | Confirm the surviving member carries traffic. Check the matching port on the EX4100 Virtual Chassis, which usually raises `sw_critical_port_down` at the same time. Fix whichever end shows the fault. |
+| LAN uplink at zero members | Treat this as a branch outage. Follow the `GATEWAY_DOWN` runbook in parallel, because Mist will lose the gateway shortly. |
+| Marvis co-fires | If `gw_bad_cable`, `gw_negotiation_mismatch`, or `gw_mtu_mismatch` is active on the same port, act on that alarm first. Marvis has already identified the physical or negotiation fault. |
+| Flapping port | If `port_flap` is co-firing, or the event search shows repeated `GW_PORT_DOWN` and `GW_PORT_UP` pairs, do not close on the first recovery. A flapping transport port destabilizes both overlays and is worse than a clean failure. |
+| Hardware | If `show alarms` reports a port or transceiver fault that survives a cable and optic swap, plan a replacement. Raise an RMA for the SSR130 where the port itself has failed. |
+| Firmware | If the alarm started right after a firmware upgrade, prepare a rollback. Any change on the only branch gateway is a Tier 2 decision. |
+| Recovery | Confirm the port is up, the `gw_critical_port_up` clear has arrived, both SVR peer paths are up, and both BGP sessions are established. |
+
+## 6. Closure Criteria
+
+- The affected port reports `ifAdminStatus up(1)` and `ifOperStatus up(1)`.
+- **The paired clear alarm `gw_critical_port_up` has been received** (payload `type` is `gw_port_up`).
+- Where the port is an aggregate member, the aggregate has recovered its full designed member count.
+- Where the port is ISP transport, that WAN link is up and inside its performance baseline.
+- Both SVR peer paths to the DC hubs (Dallas and Chicago) are up.
+- Both BGP overlay sessions to the DC hubs are established.
+- No recurrence of `gw_critical_port_down` on this port within a 30-minute debounce window.
+- The `GW_PORT_DOWN` event search over the last hour shows no continuing flap on this port.
+- No Marvis alarm (`gw_bad_cable`, `gw_negotiation_mismatch`, `gw_mtu_mismatch`, `port_flap`, `port_stuck`) remains active on the port.
+- Every co-fired alarm has cleared on its own ticket. Do not close those tickets from this one.
+- The root cause is documented on the ticket, including the port role and the decoded `ifAdminStatus` and `ifOperStatus` values.
+
+## 7. Mist GUI Navigation
+
+| Task | Navigation |
+|---|---|
+| Verify alert | Monitor → Alerts → filter by `gw_critical_port_down` |
+| Raw port events and flap count | Monitor → Events → filter by device, type `GW_PORT_DOWN` |
+| Gateway health | WAN Edges → *SSR130* → Insights |
+| Port status | WAN Edges → *SSR130* → Front Panel |
+| Critical-port flag | WAN Edges → *SSR130* → Port Configuration |
+| WAN link history | Monitor → Service Levels → WAN |
+| SVR peer-path history | Monitor → Service Levels → WAN → Peer Paths |
+| Downstream switch view | Switches → *EX4100 VC* → Front Panel |
+| Audit logs | Organization → Audit Logs |
+
+**Legacy path note:** older documents may say `Routers → SSR130`. The current Mist interface groups all gateways under `WAN Edges → …`.
+
+## 8. SSR PCLI Commands (quick reference)
+
+SSR uses PCLI. Do not paste Junos syntax into an SSR.
+
+| Purpose | Command |
+|---|---|
+| System, model, and uptime | `show system` |
+| Cloud connectivity | `show system connected` |
+| Physical ports | `show device-interface` |
+| Logical interfaces | `show network-interface` |
+| Alarms | `show alarms` |
+| Events | `show events` |
+| Routing table | `show route` |
+| SVR peer paths | `show peers` |
+| BGP summary | `show bgp summary` |
+| BGP peer detail | `show bgp neighbor <peer-ip>` |
+| Active sessions | `show sessions summary` |
+| Reachability with a pinned source | `ping <target> source <local-transport-ip>` |
+| Path to a remote target | `traceroute <target>` |
+
+See Shared Appendix §7 for the full SSR PCLI reference, and §6 for the Junos reference used on SRX gateways.
+
+## 9. Cross-references (sibling alarms)
+
+If any of these are co-firing, resolve the co-fired alarm first. A port-down alarm is often the root cause of the alarms above it, and a symptom of the Marvis alarms below it.
+
+**This alarm is usually the root cause of:**
+
+- `gw_bgp_neighbor_down` — the BGP control-plane session rode the failed transport port.
+- `gw_vpn_path_down`, `vpn_peer_down`, `vpn_path_down` — the SVR overlay rode the failed transport port.
+- `bad_wan_uplink`, `intermittent_wan_connectivity` — Marvis has judged the surviving transport degraded.
+- `gateway_down` — the failed port was the LAN uplink, and Mist has now lost the gateway entirely.
+
+**This alarm is usually a symptom of:**
+
+- `gw_bad_cable` — Marvis has identified a physical cable fault on the port.
+- `gw_negotiation_mismatch` — speed or duplex disagreement with the peer.
+- `gw_mtu_mismatch` — MTU disagreement with the peer.
+- `port_flap` — the port is cycling rather than failing cleanly.
+- `port_stuck` — the port reports up but passes no traffic.
+
+**Peer alarm on the other end of the LAN uplink:**
+
+- `sw_critical_port_down` — the matching EX4100 port. When both fire together, one physical link is at fault. Investigate the cable and both transceivers once, not twice.
+
+**Triage rule:** `gw_critical_port_down` with a Marvis alarm on the same port means the Marvis alarm holds the root cause. `gw_critical_port_down` with overlay alarms above it means this alarm holds the root cause.
+
+## 10. Escalation
+
+Per Shared Appendix §8.
+
+- **Tier 1 NOC** can self-clear cable, transceiver, administrative-disable, and remote-end causes, provided the branch keeps a working transport path throughout.
+- **Escalate to Tier 2 immediately** for:
+  - A branch with no surviving WAN transport, which is a full store outage.
+  - A LAN uplink at zero surviving members.
+  - A port that keeps flapping after a cable and transceiver replacement.
+  - Suspected firmware or configuration rollback on the only branch gateway.
+  - Hardware replacement of the SSR130.
+- **Open an ISP ticket in parallel** whenever the failed port faces a carrier demarcation device. Do not wait for internal triage to finish before you start the carrier clock.
+- **Change Advisory Board** for any planned configuration or firmware change on the recovered gateway, because it is the branch's single point of failure.

--- a/documentation/noc-runbooks/NODE_DOWN.md
+++ b/documentation/noc-runbooks/NODE_DOWN.md
@@ -1,0 +1,322 @@
+# NODE_DOWN
+
+> **Read this first — this alert does not come from Mist.** `Node Down` is raised by **NNMi**, which polls the device by SNMP and ICMP. Mist has no alarm with this key. Confirm this by searching the Mist alarm-definition catalog (`GET /api/v1/const/alarm_defs`): there is no `node_down` entry. The closest Mist alarms are `switch_down` and `gateway_down`, and they are **corroborating evidence, not the same alert**.
+>
+> Because the alert starts outside Mist, the first job is not to fix anything. The first job is to answer one question: **is this device managed by Mist?** That answer decides who owns the ticket and which runbook applies. Section 4.2 answers it in one lookup.
+
+## 1. Overview
+
+| Field | Value |
+|---|---|
+| **Alert Name** | Node Down |
+| **Source system** | **NNMi** (Network Node Manager i), by SNMP and ICMP polling |
+| **Mist alarm key** | **n/a — this is not a Mist alarm.** Corroborating Mist alarms are `switch_down` (display "Switch offline") and `gateway_down` (display "WAN Edge offline"). |
+| **Mist device events** | `SW_DISCONNECTED` and `SW_CONNECTED` for switches. `GW_DISCONNECTED` and `GW_CONNECTED` for gateways. |
+| **Platform** | Juniper **EX4400** access switch. See §1.1 — the reported model string "EX400" is not a real model and must be resolved before triage. |
+| **Mist native severity** | n/a. For reference, `switch_down` is native `warn` and `gateway_down` is native `warn`. |
+| **NOC severity** | **Critical** |
+| **Group** | n/a in Mist. The corroborating Mist alarms sit in group `infrastructure`. |
+| **Clear event key** | NNMi raises its own `Node Up` correlation. On the Mist side the corroborating clear signals are the `SW_CONNECTED` event and the disappearance of `switch_down`. |
+| **Correlated alarms** | `switch_down`, `gateway_down`, `sw_vc_port_down`, `vc_member_deleted`, `vc_master_changed`, `sw_alarm_chassis_mgmt_link_down`, `sw_critical_port_down`, `gw_critical_port_down` |
+| **Prerequisites** | The node must be in the NNMi topology with a working SNMP community or SNMPv3 credential. A node that NNMi never discovered cannot raise this alert. |
+| **Description** | NNMi has stopped receiving SNMP and ICMP responses from a node and has declared it down. The node is an EX4400 access switch. NNMi and Mist are two independent monitoring systems with two independent management paths, so they can disagree. That disagreement is diagnostic information, not a fault in either tool. Section 4.2 turns the disagreement into a routing decision. |
+
+### 1.1 Model name — resolve "EX400" before you triage
+
+**"EX400" is not a Juniper switch model, and it is not in the Mist supported-model catalog.** Verified against `GET /api/v1/const/device_models`. Treat the string as a transcription error and resolve it to a real model before continuing.
+
+| Candidate | Real model? | Where it is used | How to confirm |
+|---|---|---|---|
+| **EX4400** | **Yes** | Access and small-aggregation switching. The most likely intended model. Variants include EX4400-24P, EX4400-48P, EX4400-48MP, and EX4400-24X. | Read the `model` field from the Mist lookup in §4.2, or run `show chassis hardware`. |
+| EX4100 | Yes | The standard access switch in this library's retail branch reference topology, deployed as a 2-member Virtual Chassis. | Same as above. |
+| EX4000 | Yes | Newer entry access family. Named close enough to "EX400" to be worth ruling out. | Same as above. |
+
+Do not guess. The `model` field returned by the Mist lookup in §4.2 is authoritative when the device is in Mist. Where the device is not in Mist, take the model from the NNMi node record or from `show chassis hardware` on the console.
+
+### 1.2 Topology note — EX4400 against the library baseline
+
+The Shared Appendix §0 reference topology specifies a 2-member **EX4100** Virtual Chassis at a retail branch. An **EX4400** in the same fleet normally means one of the following. Confirm which one applies, because it changes the blast radius:
+
+- A larger branch or a back-office closet that needs more ports or higher uplink speed than an EX4100 provides.
+- An aggregation or distribution switch at a site that has one, which the flat retail branch does not.
+- A newer or a legacy refresh tier that sits beside the EX4100 standard.
+
+EX4400 and EX4100 both run Junos and both raise the same Mist `switch_down` alarm. Every Junos command in §8 works on both. The difference that matters is **redundancy**: confirm whether this EX4400 is a standalone switch or a Virtual Chassis member. A standalone switch going down takes every port with it.
+
+## 2. Impact
+
+Impact depends on the role of the node and on whether it is a Virtual Chassis member. Establish both before you declare a scope.
+
+- **Standalone EX4400 access switch down.** Every endpoint on that switch loses the network. At a retail site that means point-of-sale lanes, IP phones, access points, and back-office hosts on those ports. Access points served by that switch also drop, so wireless coverage in that area fails as well.
+- **EX4400 as a Virtual Chassis member.** The Virtual Chassis survives on the remaining member. Ports on the failed member are dead, and the Virtual Chassis is now a single point of failure. Expect `vc_member_deleted` or `vc_master_changed` to co-fire.
+- **EX4400 in an aggregation role.** Every access switch behind it is isolated. The blast radius is the whole downstream tree, not one closet. Treat this as a site outage.
+- **Uplink path to the gateway lost.** If the failed node carried the path to the branch SSR130, the site loses WAN even though the gateway itself is healthy. Expect `gateway_down` to follow, because branch management is normally in band.
+- **Monitoring visibility only.** If the node is up and only the SNMP or management path failed, there is **no user impact**. Section 4.2 separates this case from a real outage. Do not declare a store outage before you complete that check.
+
+## 3. Required Information
+
+| Category | Data to capture |
+|---|---|
+| From NNMi | Node name, management IP address, resolved model, NNMi node UUID, incident ID, incident type (`Node Down` or `Node or Connection Down`), first-seen time in UTC |
+| Poll detail | Which poll failed — SNMP, ICMP, or both. Configured poll interval and retry count. Time of the last successful poll. |
+| Neighbor confirmation | Whether NNMi confirmed the failure through neighbor analysis. See §4.1 — this changes how much you trust the alert. |
+| From Mist | `managed` value, `status` value, site ID, Mist device ID, MAC, serial number, Junos version, `last_disconnected` timestamp |
+| Model resolution | The real model from §1.1, and how it was confirmed |
+| Redundancy role | Standalone switch, Virtual Chassis master, or Virtual Chassis backup |
+| Power | Power over Ethernet budget, uninterruptible power supply status, and any site power event in the same window |
+| Timeline | Recent configuration pushes, recent firmware upgrades, scheduled maintenance windows, recent physical work at the site |
+| Correlated alarms | Every Mist alarm active on this device, on its Virtual Chassis peer, and on the site gateway in the last 15 minutes |
+
+See Shared Appendix §5 for the always-required ticket fields.
+
+## 4. Validation
+
+Validate in three stages, in this order. Do not skip stage two.
+
+### 4.1 Stage one — qualify the NNMi alert
+
+NNMi raises two similar incidents. They carry different confidence, so read the incident type before you act:
+
+| NNMi incident | What NNMi established | Confidence |
+|---|---|---|
+| **Node Down** | Every address on the node stopped responding, **and** a neighbor confirmed the failure. | High. The node is very probably down. |
+| **Node or Connection Down** | The node stopped responding, but NNMi could **not** confirm through a neighbor. | Lower. The node may be up behind a broken path. |
+
+Also capture these, because each one produces a false Node Down on a healthy device:
+
+- Was the SNMP credential rotated or the community string changed recently?
+- Did an access list or firewall rule change block the NNMi poller?
+- Did the management address change, so NNMi is polling an address the device no longer owns?
+- Is NNMi itself healthy, and are other nodes at the same site still polling normally?
+
+### 4.2 Stage two — is the device managed by Mist?
+
+**This is the decision point.** One lookup answers it. Run the graphical check for speed, or the API check when you need the exact field values on the ticket.
+
+**Graphical check.** Open **Organization → Inventory** and search for the node by name, MAC address, or serial number. Read the **Managed** column and the **Status** column.
+
+**API check.** The inventory search returns both fields directly. This call is verified working:
+
+```bash
+curl -s -H "Authorization: Token $MIST_APITOKEN" \
+  "https://api.mist.com/api/v1/orgs/$ORG_ID/inventory/search?text=<node-name-or-mac-or-serial>"
+```
+
+The response carries the two fields that decide ownership:
+
+```json
+{
+  "results": [
+    {
+      "type": "switch",
+      "name": "Morrison-Switch",
+      "mac": "209339051780",
+      "model": "EX4100-F-12P",
+      "serial": "FJ3724AV0131",
+      "site_id": "cf36153a-97bb-4974-8f8f-e9cc25d64d83",
+      "version": "25.4R1-S2.3",
+      "managed": true,
+      "status": "connected",
+      "last_disconnected": 1787598084
+    }
+  ],
+  "total": 1
+}
+```
+
+Read the two fields as follows:
+
+- **`managed`** — `true` means Mist owns the configuration of this device. `false` means Mist can see the device but does not manage it, which covers monitor-only and unadopted devices.
+- **`status`** — `connected` means Mist is in contact with the device right now. `disconnected` means Mist has lost it too.
+
+NNMi identifies a node by IP address, and Mist inventory does not search on IP address. Use the device search instead when the IP address is all you have. This call is also verified working:
+
+```bash
+curl -s -H "Authorization: Token $MIST_APITOKEN" \
+  "https://api.mist.com/api/v1/orgs/$ORG_ID/devices/search?type=switch&ip=<nnmi-management-ip>"
+```
+
+**Two verified lookup gotchas.** Both will cost you time if you do not know them:
+
+1. The `hostname` filter on the device search requires an **exact** match. A partial name returns zero results and looks identical to "device not found". Use the inventory search with `text=` when you need a wildcard on name, MAC address, or serial number.
+2. The `hostname` field comes back as a **list**, not a string, because a Virtual Chassis reports one entry per member.
+
+### 4.3 Stage three — route the ticket
+
+Cross the NNMi result with the Mist result. This table is the whole point of the runbook.
+
+| Mist result | Meaning | Who owns it | Next action |
+|---|---|---|---|
+| `managed: true`, `status: disconnected` | **Both systems agree the device is down.** This is a real outage. | Network operations | Treat as a confirmed outage. Follow §5. Expect `switch_down` to be active in Mist. |
+| `managed: true`, `status: connected` | **The systems disagree.** Mist is talking to the device right now, so the device is alive. NNMi has lost its own polling path. | Monitoring team, with network operations assisting | Do **not** declare a store outage. Investigate the NNMi path — SNMP credential, access list, management address. Confirm health from Mist, then work §5.2. |
+| `managed: false` (any status) | Mist can see the device but does not manage it. Mist telemetry is incomplete by design, so Mist silence proves nothing. | Network operations, using the Junos path | **NNMi is authoritative here.** Do not wait for a Mist alarm, because a monitor-only device may never raise one. Go straight to console and Junos in §4.4. |
+| `total: 0` — no result | The device is not in Mist at all. | Network operations, using the Junos path | **NNMi is the only source of truth.** Follow the non-Mist switch process. Also raise a records ticket, because an unmanaged production switch is an inventory gap. |
+
+**Rule:** never close a Node Down ticket on Mist silence alone. Mist silence is meaningful only when the device is `managed: true`.
+
+### 4.4 Device-level validation
+
+Where the device is reachable, or once console access is available:
+
+| Check | Command or action |
+|---|---|
+| Mist health view (managed devices) | Switches → *device* → Insights |
+| Mist connect and disconnect history | Monitor → Events → filter by device, type `SW_DISCONNECTED` and `SW_CONNECTED` |
+| System, model, and uptime | `show system information` |
+| Junos version | `show version` |
+| Confirm the real model | `show chassis hardware` |
+| Chassis alarms | `show chassis alarms` |
+| Power, fan, and temperature | `show chassis environment` |
+| Reboot cause | `show system reboot` |
+| Virtual Chassis membership | `show virtual-chassis` |
+| Management interface state | `show interfaces terse \| match "me0\|vme"` |
+| Uplink state | `show interfaces terse` |
+| Neighbor visibility | `show lldp neighbors` |
+| SNMP configuration, for a suspected polling fault | `show configuration snmp` |
+| Recent log entries | `show log messages \| last 100` |
+| Recent configuration changes | `show system commit` |
+
+## 5. Resolution
+
+Work the branch that matches your §4.3 routing decision.
+
+### 5.1 Confirmed outage (`managed: true`, `status: disconnected`)
+
+| Area | Action |
+|---|---|
+| Power | Confirm the switch has power and check for a site power event in the same window. Loss of power is the most common cause of a clean, simultaneous NNMi and Mist loss. |
+| Upstream path | Check the upstream switch or gateway port. If `sw_critical_port_down` or `gw_critical_port_down` is co-firing upstream, that port is the root cause. Fix it and this alert clears on its own. |
+| Virtual Chassis | If the node is a Virtual Chassis member, check `show virtual-chassis` from the surviving member. If `vc_member_deleted` or `vc_master_changed` is co-firing, follow the `SW_VC_PORT_DOWN` runbook, which owns Virtual Chassis recovery. |
+| Reboot loop | If the device returns and drops repeatedly, capture `show system reboot` and `show chassis alarms` while it is up. A power supply fault or a thermal fault presents exactly this way. |
+| Firmware | If the loss started right after an upgrade, prepare a rollback. Treat an upgrade fault on an access switch that serves point-of-sale lanes as urgent. |
+| Configuration | Review Organization → Audit Logs for the last 24 hours. A push that breaks the management path takes the device off both monitoring systems at once. |
+| Hardware | If the switch is powered, shows no link, and does not respond on console, raise an RMA. |
+| Site dispatch | Where no remote path exists, dispatch a technician. Ask for the front-panel indicator state and the power state before the technician leaves the site. |
+
+### 5.2 Monitoring disagreement (`managed: true`, `status: connected`)
+
+The device is alive. Mist proves it. Do not dispatch a technician and do not declare a store outage.
+
+| Area | Action |
+|---|---|
+| Confirm health first | Verify in Mist that clients are attached and the uplink is passing traffic. Record this on the ticket as the evidence that the device is serving users. |
+| SNMP credential | Compare the community string or the SNMPv3 credential on the device against the NNMi configuration. Run `show configuration snmp`. A credential rotation that missed one device produces exactly this alert. |
+| Poller reachability | Verify the NNMi poller address is permitted. Check the SNMP client list on the device and any access list on the path. |
+| Management address | Confirm the address NNMi polls is the address the device still owns. Run `show interfaces terse \| match "me0\|vme"`. |
+| Out-of-band path | Where the branch has a separate out-of-band management network, confirm that path is up. Mist uses the in-band path at these branches, so an out-of-band failure hides from Mist and shows only in NNMi. |
+| NNMi health | Confirm other nodes at the same site still poll normally. If they do not, the fault is in NNMi or in the path to the site, not in this switch. |
+| Close the loop | Correct the polling fault, then force an NNMi rediscovery or poll to clear the incident. Record the root cause as a monitoring fault, not a network outage. |
+
+### 5.3 Unmanaged or absent in Mist (`managed: false`, or no result)
+
+| Area | Action |
+|---|---|
+| Trust NNMi | Treat NNMi as authoritative. Mist will not raise `switch_down` for a device it does not manage, so waiting for a Mist alarm wastes time. |
+| Reach the device | Use the documented console or jump-host path for unmanaged devices. Work §4.4 from the console. |
+| Recover | Apply §5.1 for the physical and power checks. Every Junos command in §8 still applies. |
+| Close the records gap | Raise a separate records ticket. A production switch that is absent from Mist, or present but unmanaged, is an inventory and compliance gap. Note whether it should be adopted. |
+
+## 6. Closure Criteria
+
+Close against the branch you worked.
+
+**Common to every branch:**
+
+- The NNMi incident has cleared, and NNMi shows the node up on its next poll.
+- The root cause is documented on the ticket, including the resolved model from §1.1 and the §4.3 routing decision that was applied.
+- Every co-fired alarm has cleared on its own ticket. Do not close those tickets from this one.
+
+**Confirmed outage (§5.1) adds:**
+
+- The device is `status: connected` in Mist, where it is `managed: true`.
+- **The Mist `SW_CONNECTED` event has been received for this device.**
+- Any corroborating `switch_down` alarm has cleared.
+- Every affected endpoint is back on the network — point-of-sale lanes, IP phones, access points, and back-office hosts.
+- Where the node is a Virtual Chassis member, `show virtual-chassis` reports the full designed member count with the intended roles.
+- No recurrence within a 30-minute debounce window.
+
+**Monitoring disagreement (§5.2) adds:**
+
+- The polling fault is identified and corrected, not merely worked around.
+- NNMi polls the device successfully on two consecutive intervals.
+- The ticket records that there was **no user impact**, so that trend reporting does not count this as an outage.
+
+**Unmanaged or absent (§5.3) adds:**
+
+- The device responds on its documented management path.
+- A records ticket exists for the inventory gap, and its number is recorded here.
+
+## 7. Mist GUI Navigation
+
+| Task | Navigation |
+|---|---|
+| **Confirm managed status and current state** | **Organization → Inventory → search by name, MAC address, or serial number → read the Managed and Status columns** |
+| Switch health | Switches → *device* → Insights |
+| Connect and disconnect history | Monitor → Events → filter by device, type `SW_DISCONNECTED` and `SW_CONNECTED` |
+| Corroborating alarm | Monitor → Alerts → filter by `switch_down` |
+| Port status and front panel | Switches → *device* → Front Panel |
+| Virtual Chassis members | Switches → *device* → Front Panel |
+| Upstream gateway state | WAN Edges → *SSR130* → Insights |
+| Attached clients | Clients → Wired Clients |
+| Audit logs | Organization → Audit Logs |
+
+## 8. Junos Commands (quick reference)
+
+These apply to EX4400 and EX4100 alike. Both run Junos.
+
+| Purpose | Command |
+|---|---|
+| System, model, and uptime | `show system information` |
+| Junos version | `show version` |
+| Chassis hardware and field-replaceable units | `show chassis hardware` |
+| Chassis alarms | `show chassis alarms` |
+| Power, fan, and temperature | `show chassis environment` |
+| Reboot cause | `show system reboot` |
+| Routing engine state | `show chassis routing-engine` |
+| Virtual Chassis state | `show virtual-chassis` |
+| Virtual Chassis ports | `show virtual-chassis vc-port` |
+| Interface summary | `show interfaces terse` |
+| Management interface state | `show interfaces terse \| match "me0\|vme"` |
+| Neighbor visibility | `show lldp neighbors` |
+| Power over Ethernet state | `show poe interface` |
+| SNMP configuration | `show configuration snmp` |
+| Recent log entries | `show log messages \| last 100` |
+| Commit history | `show system commit` |
+| Configuration difference | `show configuration \| compare rollback 1` |
+
+See Shared Appendix §6 for the full Junos reference.
+
+## 9. Cross-references (sibling alarms)
+
+**Mist alarms that corroborate a real outage.** When one of these is active alongside the NNMi alert, the outage is confirmed:
+
+- `switch_down` — Mist has lost the switch. This is the direct Mist counterpart to Node Down.
+- `gateway_down` — Mist has lost the site gateway. If both fire, suspect a site-wide power or transport fault rather than a switch fault.
+
+**Mist alarms that usually hold the root cause.** Resolve these first, because Node Down is the symptom:
+
+- `sw_critical_port_down` — the upstream switch port serving this node is down. See `SW_CRITICAL_PORT_DOWN.md`.
+- `gw_critical_port_down` — the gateway port serving this node's path is down. See `GW_PORT_DOWN.md`.
+- `sw_vc_port_down` — a Virtual Chassis port failed, and the node may be an isolated fragment rather than a dead switch. See `SW_VC_PORT_DOWN.md`.
+- `vc_member_deleted`, `vc_master_changed` — the Virtual Chassis lost or re-elected a member. See `SW_VC_PORT_DOWN.md`.
+
+**Mist alarm that points at a monitoring fault rather than an outage:**
+
+- `sw_alarm_chassis_mgmt_link_down` — the management link is down while the data plane keeps forwarding. This is the classic cause of the §4.3 disagreement row. See `SW_ALARM_CHASSIS_MGMT_LINK_DOWN.md`.
+
+**Triage rule:** NNMi Node Down with a Mist `switch_down` is a real outage. NNMi Node Down with the device `connected` in Mist is a monitoring fault. NNMi Node Down on a device that Mist does not manage is a real outage that only NNMi can see.
+
+## 10. Escalation
+
+Per Shared Appendix §8.
+
+- **Tier 1 NOC** owns the §4.2 managed-status lookup and the §4.3 routing decision. Tier 1 can self-clear a monitoring disagreement (§5.2) once the polling fault is corrected, and can self-clear a confirmed outage where an upstream port alarm is clearly the root cause and the sibling runbook resolves it.
+- **Escalate to Tier 2** for:
+  - A confirmed outage with no upstream alarm to explain it, which implies a device-local fault in power, hardware, or firmware.
+  - A suspected or confirmed Virtual Chassis split.
+  - A repeating reboot or a repeating disconnect on the same device.
+  - Hardware replacement of the EX4400.
+  - Suspected firmware or configuration rollback.
+- **Engage the monitoring team** for every §5.2 disagreement, and for any suspected NNMi platform fault. Where several nodes at one site raise Node Down at the same time while Mist shows them all connected, treat this as an NNMi or poller-path fault and escalate to the monitoring team first.
+- **Raise a records ticket** for every §5.3 device. An unmanaged production switch is an inventory and compliance gap, and it will produce this same ambiguity on its next failure.
+- **Change Advisory Board** for any out-of-window configuration or firmware change needed to recover the node.


### PR DESCRIPTION
Closes #2022

## Summary

Adds two NOC runbook reference articles to `documentation/noc-runbooks/`, requested by the customer for the **Node Down** and **GW_PORT_DOWN** alerts. Both follow the existing 10-section library template and reference `_shared_common.md` instead of duplicating shared content.

Every alarm key, event key, and severity in both files was verified against the live Mist constants API (`/api/v1/const/alarm_defs` and `/api/v1/const/device_events`) rather than assumed.

## Files

| File | Change |
|---|---|
| `documentation/noc-runbooks/NODE_DOWN.md` | New |
| `documentation/noc-runbooks/GW_PORT_DOWN.md` | New |
| `documentation/noc-runbooks/GATEWAY_DOWN.md` | Severity correction |

## Findings that shaped the content

**1. `GW_PORT_DOWN` names two different objects.** The pageable alarm is catalogued `gw_critical_port_down`, but its webhook payload carries `"type": "gw_port_down"` -- which is why the alert reached the NOC under that name. A separate uppercase `GW_PORT_DOWN` **device event** also exists, fires on every gateway port, and carries no severity at all. The runbook opens with a disambiguation table. Paging rules must key on `gw_port_down` and never on the event.

**2. Node Down is not a Mist alarm.** There is no `node_down` key in the alarm catalog. The runbook is therefore built around the customer's actual ask: a **managed-device decision matrix**. A single inventory lookup returns `managed` and `status`, and those two fields route the ticket four ways. It explicitly separates the case where Mist shows the device `connected` while NNMi calls it down -- that is a monitoring fault with **no user impact** and must not be dispatched as a store outage.

**3. `EX400` is not a real model.** It is absent from the Mist supported-model catalog. `EX4400` is the intended model, with `EX4000` and `EX4100` as the other candidates. Resolving the model is step zero of triage so nobody troubleshoots the wrong platform.

## Why `GATEWAY_DOWN.md` changed

That file claimed `gateway_down` is natively `critical`. The live catalog reports `warn`. Since `NODE_DOWN.md` cites this value as corroborating evidence, leaving the stale entry would have put a direct contradiction inside the library. Corrected to `warn` and reframed as a documented override, matching the convention already used in `SW_CRITICAL_PORT_DOWN.md`.

## Verification

- All 20 cited alarm keys and 6 cited event keys confirmed present in the live catalog. `node_down` confirmed absent.
- Both documented `curl` calls executed live and returned HTTP 200 with the expected fields.
- Markdown checked: heading sequence 1-10 matches the library template, zero malformed table rows, all in-table pipes escaped per house style.
- Library-wide severity sweep run against the live catalog. Both new files pass.

## Known pre-existing issues, not addressed here

The sweep surfaced two errors in files outside this request. Flagging rather than silently expanding scope:

- `GW_VPN_PEER_DOWN.md` declares alarm key `gw_vpn_peer_down`, which **does not exist** in Mist. An operator filtering on it gets nothing. The correct key is `vpn_peer_down` (`warn`), clear `vpn_peer_up` (`info`).
- `GW_VPN_PATH_DOWN.md` claims native `critical`. The actual value is `warn`. The key itself is correct.

Happy to fix both in a follow-up.

## Conformance

- [x] Linked to the originating issue
- [x] Documentation-only change -- no code, no tests, no dependency changes
- [x] No secrets, tokens, or org identifiers committed
- [x] Facts verified against the live Mist API
- [x] Branched from `main`, not from another feature branch