### PR TITLE
fix(firmware): read the running firmware version, never the stale listSiteDevices value

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -353,6 +353,35 @@ listSiteDevices(site_id)
 listSiteDevices(site_id, type="all")
 ```
 
+### Stale Firmware Version (issue #2006)
+Three endpoints report a firmware version for one device, and they do not agree.
+
+| Endpoint | Reports |
+| - | - |
+| `listSiteDevicesStats` | The running version. Safe for a firmware decision. |
+| `getOrgInventory` | The running version. Safe for a firmware decision. |
+| `listSiteDevices` | The configured version. It can be old, or `None`. |
+
+Warning: A firmware decision that reads the `version` field of `listSiteDevices`
+can name a release the device left long ago. An operator then plans the wrong
+upgrade on production hardware.
+
+```python
+# WRONG: the device listing carries the configured version
+version = listSiteDevices(site_id, type="all").data[0]["version"]
+
+# CORRECT: read the running version through the shared resolver
+from src.firmware.running_version import RunningFirmwareVersionResolver
+
+resolver = RunningFirmwareVersionResolver(apisession)
+running = resolver.fetch_site_running_versions(site_id)
+reading = resolver.read(device_row, running)
+```
+
+`reading.is_running` states whether the value is safe for a firmware decision.
+A `False` value means no running version was found, so the caller must warn
+instead of deciding.
+
 ### Windows Path Compatibility
 Use `os.path.join()` or `Path()`, never hardcoded `/` or `\\`
 

--- a/src/firmware/firmware_manager.py
+++ b/src/firmware/firmware_manager.py
@@ -20,6 +20,10 @@ from dataclasses import dataclass  # WHY: FirmwareManagerConfig frozen value obj
 from datetime import UTC, datetime  # WHY: UTC-aware ISO timestamps and CSV filenames
 from typing import Any, cast  # WHY: Any for opaque API objects. Cast narrows mypy return types
 
+from src.firmware.running_version import (  # WHY: one reader holds the running-version endpoint rule
+    RunningFirmwareVersionResolver,
+)
+
 # Type aliases for injected dependencies keep readable signatures across helpers.
 SafeInputFn = Callable[..., str]  # WHY: safe_input(prompt, context=...) returning stripped text
 SelectSiteFn = Callable[..., Any]  # WHY: interactive site picker used by menu 196 sub-flows
@@ -2743,6 +2747,13 @@ class FirmwareManager:
     def _fetch_site_gateway_devices(self, site_id: Any, site_name: str) -> list[dict[str, Any]] | None:
         """Fetch gateway devices for a single site.
 
+        Warning:
+            The rows of ``listSiteDevices`` carry the configured firmware
+            version, not the running version. Never read the ``version`` field
+            of these rows for a firmware decision. Use
+            ``RunningFirmwareVersionResolver`` instead, which reads
+            ``listSiteDevicesStats`` or ``getOrgInventory``.
+
         Returns:
             list of device dicts on success, None on API error.
         """
@@ -3028,6 +3039,81 @@ class FirmwareManager:
         if site_result.get("error"):  # WHY: propagate error record
             results["errors"].append(site_result["error"])  # WHY: aggregate for summary
 
+    def _fetch_site_running_versions(self, site_id: str) -> dict[str, str]:
+        """Read the running firmware version of every device at one site.
+
+        Args:
+            site_id: The site to read.
+
+        Returns:
+            A map of device id or MAC address to the running version string.
+        """
+        logging.info("Loading running firmware versions site=%s", site_id)  # WHY: entry audit
+        resolver = RunningFirmwareVersionResolver(self.apisession)  # WHY: one reader holds the endpoint rule
+        running_by_key = resolver.fetch_site_running_versions(site_id)  # WHY: read the stats endpoint
+        logging.debug("Loaded running firmware versions site=%s keys=%d", site_id, len(running_by_key))  # WHY: exit
+        return running_by_key  # WHY: the overlay joins device rows against this map
+
+    def _overlay_running_versions(
+        self,
+        site_id: str,
+        site_ssrs: list[dict[str, Any]],
+        inventory: dict[str, dict[str, Any]],
+    ) -> dict[str, dict[str, Any]]:
+        """Return an inventory whose version fields hold the running version.
+
+        Why:
+            The site device listing reports the configured version, not the
+            running version. A firmware decision that reads the listing value
+            can plan the wrong upgrade on production hardware.
+
+        Args:
+            site_id: The site that owns the discovered devices.
+            site_ssrs: The SSR rows returned by the site device listing.
+            inventory: The org inventory map keyed by device id.
+
+        Returns:
+            A new inventory map that carries the running version for each device.
+        """
+        logging.info("Overlaying running versions site=%s devices=%d", site_id, len(site_ssrs))  # WHY: entry audit
+        running_by_key = self._fetch_site_running_versions(site_id)  # WHY: running state beats configured state
+        merged = dict(inventory)  # WHY: copy so the shared org inventory stays unchanged
+        resolver = RunningFirmwareVersionResolver(self.apisession)  # WHY: one reader applies the endpoint rule
+        for row in site_ssrs:  # WHY: one pass over every discovered SSR row
+            self._apply_running_version(merged, row, running_by_key, resolver)  # WHY: keep this loop body short
+        logging.debug("Overlaid running versions site=%s entries=%d", site_id, len(merged))  # WHY: exit audit
+        return merged  # WHY: the validator reads this map
+
+    @staticmethod
+    def _apply_running_version(
+        merged: dict[str, dict[str, Any]],
+        row: dict[str, Any],
+        running_by_key: dict[str, str],
+        resolver: RunningFirmwareVersionResolver,
+    ) -> None:
+        """Write the running version of one device row into the merged inventory.
+
+        Args:
+            merged: The inventory map to update in place.
+            row: One SSR row from the site device listing.
+            running_by_key: The running version map for the site.
+            resolver: The reader that applies the endpoint rule.
+        """
+        dev_id = str(row.get("id") or "")  # WHY: the inventory map is keyed by device id
+        if not dev_id:  # WHY: a row without an id cannot join to the inventory
+            return  # WHY: skip the row rather than create a bad key
+        reading = resolver.read(row, running_by_key)  # WHY: never treat the listing value as running
+        entry = dict(merged.get(dev_id, {}))  # WHY: copy so an org inventory entry stays unchanged
+        entry.setdefault("model", row.get("model", ""))  # WHY: keep a model for the operator messages
+        entry.setdefault("type", row.get("type", ""))  # WHY: keep the type for the operator messages
+        entry.setdefault("site_id", row.get("site_id", ""))  # WHY: keep the site anchor for reporting
+        if reading.is_running:  # WHY: only a running reading may replace the inventory value
+            entry["version"] = reading.value  # WHY: the decision now reads the version the device runs
+        else:  # WHY: no stats row exists for this device
+            entry.setdefault("version", reading.value)  # WHY: keep any org inventory value, which is running state
+            entry["version_is_stale"] = True  # WHY: mark the reading so a report can warn the operator
+        merged[dev_id] = entry  # WHY: publish the updated entry for the validator
+
     def _run_ssr_site_upgrade_flow(
         self,
         site: dict[str, Any],
@@ -3042,8 +3128,11 @@ class FirmwareManager:
         if not site_ssrs:  # WHY: nothing to upgrade here
             return  # WHY: skip remaining work
         ssr_ids = [ssr["id"] for ssr in site_ssrs]  # WHY: id list for validator
+        inventory = self._overlay_running_versions(  # WHY: the decision must read the running version
+            site.get("id", ""), site_ssrs, upgrade_config["inventory"]
+        )
         validated, _ = self._validate_ssr_devices_for_version(  # WHY: filter incompatible SSRs
-            ssr_ids, upgrade_config["inventory"], upgrade_config["version"]
+            ssr_ids, inventory, upgrade_config["version"]
         )
         if not validated:  # WHY: nothing left after filter
             return  # WHY: skip upgrade call

--- a/src/firmware/running_version.py
+++ b/src/firmware/running_version.py
@@ -1,0 +1,196 @@
+"""Read the running firmware version of a Mist device from an endpoint that reports it.
+
+Why:
+    Three cloud endpoints report a firmware version for one device, and they do
+    not agree. ``listSiteDevices`` returns the device configuration object, so
+    its ``version`` field names the configured version. That value can name a
+    release the device left long ago, or it can be ``None``.
+    ``listSiteDevicesStats`` and ``getOrgInventory`` report the running state,
+    and they agree with the device.
+
+    A firmware decision that reads the configured version can turn a one-step
+    upgrade into an apparent multi-release jump. An operator then plans the
+    wrong change on production hardware. This module gives every firmware
+    decision one reader that returns the running version, or that marks the
+    value as stale.
+
+Endpoint rule:
+    - ``listSiteDevicesStats`` reports the running version. Use it for a site.
+    - ``getOrgInventory`` reports the running version. Use it for an org.
+    - ``listSiteDevices`` reports the configured version. Never use it for a
+      firmware decision.
+
+Second trap:
+    ``listSiteDevices`` and ``listSiteDevicesStats`` both default to access
+    points. A switch or a gateway needs ``type="all"``. This module always
+    sends ``type="all"`` so no device type is dropped.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+DEVICE_LISTING_ENDPOINT = "listSiteDevices"  # WHY: name the endpoint that reports the configured version
+SITE_STATS_ENDPOINT = "listSiteDevicesStats"  # WHY: name the site endpoint that reports the running version
+ORG_INVENTORY_ENDPOINT = "getOrgInventory"  # WHY: name the org endpoint that reports the running version
+
+RUNNING_VERSION_ENDPOINTS = frozenset(
+    {SITE_STATS_ENDPOINT, ORG_INVENTORY_ENDPOINT}
+)  # WHY: one allow list keeps every caller on the same rule
+
+DEFAULT_STATS_PAGE_LIMIT = 1000  # WHY: one large page keeps the site call to a single request
+
+
+@dataclass(frozen=True)
+class FirmwareVersionReading:
+    """One firmware version value with the endpoint that produced it.
+
+    Attributes:
+        value: The version string. It is empty when no endpoint reported one.
+        source: The endpoint name that produced the value.
+        is_running: True when the source reports the running version.
+    """
+
+    value: str  # WHY: the caller displays this string and compares it to the target
+    source: str  # WHY: the caller records which endpoint produced the value
+    is_running: bool  # WHY: the caller must refuse a stale value for a firmware decision
+
+
+class RunningFirmwareVersionResolver:
+    """Return the running firmware version of a device, or mark the value stale.
+
+    Why:
+        A firmware decision needs the version the device runs now. This class
+        holds the single rule about which endpoint reports that value, so no
+        caller has to remember the trap.
+    """
+
+    def __init__(self, apisession: Any, stats_fn: Callable[..., Any] | None = None) -> None:
+        """Store the session and the stats callable.
+
+        Args:
+            apisession: The live mistapi session.
+            stats_fn: The callable that reads the site stats endpoint. Leave it
+                unset to use ``mistapi.api.v1.sites.stats.listSiteDevicesStats``.
+        """
+        self._apisession = apisession  # WHY: every endpoint call needs the live session
+        self._stats_fn = stats_fn  # WHY: a test injects a stand-in without a network call
+
+    @staticmethod
+    def reports_running_version(source: str) -> bool:
+        """Return True when the named endpoint reports the running version.
+
+        Args:
+            source: The endpoint name to check.
+
+        Returns:
+            True when a firmware decision may read the version of that endpoint.
+        """
+        return source in RUNNING_VERSION_ENDPOINTS  # WHY: one allow list decides for every caller
+
+    @staticmethod
+    def index_stats_rows(rows: list[dict[str, Any]]) -> dict[str, str]:
+        """Index stats rows by device id and by MAC address.
+
+        Why:
+            A device listing row and a stats row do not always share the same
+            identifier field. Two keys let the caller join on either one.
+
+        Args:
+            rows: The stats rows returned by the stats endpoint.
+
+        Returns:
+            A map of device id or MAC address to the running version string.
+        """
+        logging.info("Indexing device stats rows for a running version lookup rows=%d", len(rows))  # WHY: entry audit
+        running_by_key: dict[str, str] = {}  # WHY: accumulate one map that both key shapes can reach
+        for row in rows:  # WHY: a single pass keeps the cost linear in the row count
+            version = str(row.get("version") or "")  # WHY: normalize a missing version to an empty string
+            if not version:  # WHY: an empty version cannot support a firmware decision
+                continue  # WHY: skip the row rather than store a false reading
+            for key in (row.get("id"), row.get("device_id"), row.get("mac")):  # WHY: accept every join key shape
+                if key:  # WHY: skip an absent identifier
+                    running_by_key[str(key)] = version  # WHY: store the running version under each usable key
+        logging.debug("Indexed running versions keys=%d", len(running_by_key))  # WHY: exit audit
+        return running_by_key  # WHY: the caller joins device rows against this map
+
+    def fetch_site_running_versions(self, site_id: str) -> dict[str, str]:
+        """Read the running version of every device at one site.
+
+        Args:
+            site_id: The site to read.
+
+        Returns:
+            A map of device id or MAC address to the running version string. The
+            map is empty when the endpoint fails, so the caller can fall back.
+        """
+        logging.info("Reading running firmware versions from %s site=%s", SITE_STATS_ENDPOINT, site_id)  # WHY: audit
+        stats_fn = self._resolve_stats_fn()  # WHY: pick the injected callable or the real endpoint
+        try:  # WHY: a network call can raise, and a firmware flow must not stop here
+            response = stats_fn(
+                self._apisession, site_id, type="all", limit=DEFAULT_STATS_PAGE_LIMIT
+            )  # WHY: type=all keeps switches and gateways in the result
+        except Exception as error:  # WHY: a broad guard keeps the caller on its fallback path
+            logging.error("Failed to read %s for site %s: %s", SITE_STATS_ENDPOINT, site_id, error)  # WHY: audit
+            return {}  # WHY: an empty map tells the caller that no running version was read
+        rows = self._rows_from_response(response, site_id)  # WHY: one helper handles the status and payload shape
+        running_by_key = self.index_stats_rows(rows)  # WHY: build the join map for the caller
+        logging.debug("Read running versions site=%s keys=%d", site_id, len(running_by_key))  # WHY: exit audit
+        return running_by_key  # WHY: the caller overlays these values onto its device rows
+
+    def read(self, device_row: dict[str, Any], running_by_key: dict[str, str]) -> FirmwareVersionReading:
+        """Return the running version for one device row, or a stale reading.
+
+        Why:
+            The ``version`` field of a device listing row names the configured
+            version. This method never presents that value as running.
+
+        Args:
+            device_row: One device row, which may come from the device listing.
+            running_by_key: The map built by ``fetch_site_running_versions``.
+
+        Returns:
+            A reading whose ``is_running`` flag states whether the caller may
+            use the value for a firmware decision.
+        """
+        for key in (device_row.get("id"), device_row.get("device_id"), device_row.get("mac")):  # WHY: try each key
+            running = running_by_key.get(str(key)) if key else None  # WHY: only look up a present identifier
+            if running:  # WHY: the first hit is the running version
+                return FirmwareVersionReading(running, SITE_STATS_ENDPOINT, True)  # WHY: safe for a decision
+        listed = str(device_row.get("version") or "")  # WHY: the listing value is the only value that remains
+        logging.warning(
+            "No running version for device %s. The %s value %s is stale.",
+            device_row.get("id", "unknown"),
+            DEVICE_LISTING_ENDPOINT,
+            listed or "None",
+        )  # WHY: an operator must see that this value did not come from the running state
+        return FirmwareVersionReading(listed, DEVICE_LISTING_ENDPOINT, False)  # WHY: mark the value as stale
+
+    def _resolve_stats_fn(self) -> Callable[..., Any]:
+        """Return the injected stats callable, or the real mistapi endpoint."""
+        if self._stats_fn is not None:  # WHY: an injected callable wins so a test needs no network
+            return self._stats_fn  # WHY: hand back the stand-in
+        import mistapi.api.v1.sites.stats as _site_stats  # WHY: a lazy import keeps module load cheap
+
+        return _site_stats.listSiteDevicesStats  # WHY: the real endpoint that reports the running version
+
+    @staticmethod
+    def _rows_from_response(response: Any, site_id: str) -> list[dict[str, Any]]:
+        """Return the stats rows of a response, or an empty list.
+
+        Args:
+            response: The object returned by the stats endpoint.
+            site_id: The site under read, used only for the log line.
+
+        Returns:
+            The list of stats rows.
+        """
+        status = getattr(response, "status_code", 200)  # WHY: a stand-in response may omit the status
+        if status != 200:  # WHY: a non-200 status carries no usable rows
+            logging.error("The %s call for site %s returned %s", SITE_STATS_ENDPOINT, site_id, status)  # WHY: audit
+            return []  # WHY: an empty list drives the caller onto its fallback
+        data = getattr(response, "data", None) or []  # WHY: normalize a missing payload to an empty list
+        return [row for row in data if isinstance(row, dict)]  # WHY: drop any row shape the caller cannot read

--- a/src/firmware/running_version.py
+++ b/src/firmware/running_version.py
@@ -175,7 +175,8 @@ class RunningFirmwareVersionResolver:
             return self._stats_fn  # WHY: hand back the stand-in
         import mistapi.api.v1.sites.stats as _site_stats  # WHY: a lazy import keeps module load cheap
 
-        return _site_stats.listSiteDevicesStats  # WHY: the real endpoint that reports the running version
+        stats_fn: Callable[..., Any] = _site_stats.listSiteDevicesStats  # WHY: narrow the untyped module attribute
+        return stats_fn  # WHY: the real endpoint that reports the running version
 
     @staticmethod
     def _rows_from_response(response: Any, site_id: str) -> list[dict[str, Any]]:

--- a/tests/unit/firmware/test_running_version.py
+++ b/tests/unit/firmware/test_running_version.py
@@ -1,0 +1,149 @@
+"""Tests for the running firmware version resolver and the SSR overlay.
+
+Why:
+    Three cloud endpoints report a firmware version for one device, and
+    ``listSiteDevices`` disagrees with the other two. It reports the
+    configured version, not the running version. A firmware decision
+    that reads the wrong value turns a one-step upgrade into a
+    multi-release jump, and an operator plans the wrong change. These
+    tests pin the rule that a firmware decision reads the running
+    version, or marks the value as stale.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import src.firmware.firmware_manager as fm_mod
+from src.firmware.firmware_manager import FirmwareManager, FirmwareManagerConfig
+from src.firmware.running_version import (
+    DEVICE_LISTING_ENDPOINT,
+    ORG_INVENTORY_ENDPOINT,
+    SITE_STATS_ENDPOINT,
+    RunningFirmwareVersionResolver,
+)
+
+STALE_VERSION = "20.4R3-S2.6"
+RUNNING_VERSION = "23.4R2-S5.5"
+
+
+class _FakeResponse:
+    """Minimal mistapi response stand-in that carries a status and a payload."""
+
+    def __init__(self, status_code: int = 200, data: Any = None) -> None:
+        """Store the two fields every caller reads."""
+        self.status_code = status_code
+        self.data = data
+
+
+def _make_manager(**overrides: Any) -> FirmwareManager:
+    """Build a FirmwareManager with the minimum valid config."""
+    defaults: dict[str, Any] = {"apisession": object(), "org_id": "org-test"}
+    defaults.update(overrides)
+    return FirmwareManager(FirmwareManagerConfig(**defaults))
+
+
+def test_device_listing_is_not_a_running_version_source() -> None:
+    """The resolver must reject the device listing as a running-version source."""
+    assert RunningFirmwareVersionResolver.reports_running_version(SITE_STATS_ENDPOINT) is True
+    assert RunningFirmwareVersionResolver.reports_running_version(ORG_INVENTORY_ENDPOINT) is True
+    assert RunningFirmwareVersionResolver.reports_running_version(DEVICE_LISTING_ENDPOINT) is False
+
+
+def test_read_prefers_the_running_version_over_the_listing_value() -> None:
+    """A stats hit must win over the stale value carried by the device listing."""
+    resolver = RunningFirmwareVersionResolver(apisession=object())
+    device_row = {"id": "dev-1", "mac": "aabbccddeeff", "version": STALE_VERSION}
+    running_by_key = {"dev-1": RUNNING_VERSION}
+    reading = resolver.read(device_row, running_by_key)
+    assert reading.value == RUNNING_VERSION
+    assert reading.source == SITE_STATS_ENDPOINT
+    assert reading.is_running is True
+
+
+def test_read_marks_a_listing_only_value_as_stale() -> None:
+    """With no stats row the reading must carry the stale flag, not a silent value."""
+    resolver = RunningFirmwareVersionResolver(apisession=object())
+    device_row = {"id": "dev-1", "version": STALE_VERSION}
+    reading = resolver.read(device_row, {})
+    assert reading.source == DEVICE_LISTING_ENDPOINT
+    assert reading.is_running is False
+
+
+def test_fetch_site_running_versions_requests_every_device_type() -> None:
+    """The stats call must pass type=all so switches and gateways are included."""
+    captured: dict[str, Any] = {}
+
+    def _fake_stats(session: Any, site_id: str, **kwargs: Any) -> _FakeResponse:
+        """Record the keyword arguments the resolver sent to the stats endpoint."""
+        captured.update(kwargs)
+        captured["site_id"] = site_id
+        return _FakeResponse(data=[{"id": "dev-1", "mac": "aabbccddeeff", "version": RUNNING_VERSION}])
+
+    resolver = RunningFirmwareVersionResolver(apisession=object(), stats_fn=_fake_stats)
+    running = resolver.fetch_site_running_versions("site-1")
+    assert captured["type"] == "all"
+    assert captured["site_id"] == "site-1"
+    assert running["dev-1"] == RUNNING_VERSION
+    assert running["aabbccddeeff"] == RUNNING_VERSION
+
+
+def test_ssr_flow_classifies_on_the_running_version_not_the_stale_one(monkeypatch: Any) -> None:
+    """The SSR upgrade flow must not decide from the stale device-listing version."""
+    manager = _make_manager()
+    site = {"id": "site-1", "name": "Morrison House"}
+    stale_row = {"id": "dev-1", "type": "gateway", "model": "SSR120", "version": STALE_VERSION}
+    monkeypatch.setattr(manager, "_discover_site_ssr_devices", lambda *_a, **_k: [stale_row])
+    monkeypatch.setattr(
+        manager,
+        "_fetch_site_running_versions",
+        lambda *_a, **_k: {"dev-1": RUNNING_VERSION},
+    )
+    seen: dict[str, Any] = {}
+
+    def _capture(device_ids: list[str], inventory: dict[str, Any], target: str) -> tuple[list[str], list[str]]:
+        """Record the inventory the flow handed to the validator."""
+        seen["inventory"] = inventory
+        return [], []
+
+    monkeypatch.setattr(manager, "_validate_ssr_devices_for_version", _capture)
+    upgrade_config: dict[str, Any] = {
+        "inventory": {"dev-1": {"model": "SSR120", "type": "gateway", "version": STALE_VERSION, "site_id": "site-1"}},
+        "version": RUNNING_VERSION,
+        "ssr_models": ["SSR", "128T"],
+    }
+    site_result: dict[str, Any] = {"site_name": "Morrison House"}
+    results: dict[str, Any] = {"ssrs_upgraded": 0, "errors": []}
+    manager._run_ssr_site_upgrade_flow(site, site_result, upgrade_config, results)
+    assert seen["inventory"]["dev-1"]["version"] == RUNNING_VERSION
+
+
+def test_ssr_flow_keeps_a_device_missing_from_the_org_inventory(monkeypatch: Any) -> None:
+    """A device the org inventory misses must still reach the validator with its running version."""
+    manager = _make_manager()
+    site = {"id": "site-1", "name": "Morrison House"}
+    stale_row = {"id": "dev-2", "type": "gateway", "model": "SSR120", "version": STALE_VERSION}
+    monkeypatch.setattr(manager, "_discover_site_ssr_devices", lambda *_a, **_k: [stale_row])
+    monkeypatch.setattr(
+        manager,
+        "_fetch_site_running_versions",
+        lambda *_a, **_k: {"dev-2": RUNNING_VERSION},
+    )
+    seen: dict[str, Any] = {}
+
+    def _capture(device_ids: list[str], inventory: dict[str, Any], target: str) -> tuple[list[str], list[str]]:
+        """Record the inventory the flow handed to the validator."""
+        seen["inventory"] = inventory
+        return [], []
+
+    monkeypatch.setattr(manager, "_validate_ssr_devices_for_version", _capture)
+    upgrade_config: dict[str, Any] = {"inventory": {}, "version": "24.1R1", "ssr_models": ["SSR", "128T"]}
+    site_result: dict[str, Any] = {"site_name": "Morrison House"}
+    results: dict[str, Any] = {"ssrs_upgraded": 0, "errors": []}
+    manager._run_ssr_site_upgrade_flow(site, site_result, upgrade_config, results)
+    assert seen["inventory"]["dev-2"]["version"] == RUNNING_VERSION
+
+
+def test_firmware_manager_module_exposes_the_resolver() -> None:
+    """The firmware manager must import the shared resolver rather than re-implement it."""
+    assert fm_mod.RunningFirmwareVersionResolver is RunningFirmwareVersionResolver


### PR DESCRIPTION
Fixes #2006

## Problem

Three cloud endpoints report a firmware version for one device, and one of them
disagrees with the other two.

| Endpoint | Reports |
| - | - |
| `listSiteDevicesStats` | The running version. |
| `getOrgInventory` | The running version. |
| `listSiteDevices` | The configured version. It can be old, or `None`. |

A firmware decision that reads the `version` field of `listSiteDevices` can name
a release the device left long ago. An operator then plans a four-release jump
where one step is needed, or repeats an upgrade the device already has.

## The fix

New module `src/firmware/running_version.py` holds one reader,
`RunningFirmwareVersionResolver`. It carries the endpoint rule so no caller has
to remember the trap.

- `reports_running_version(source)` names which endpoint a firmware decision may
  read.
- `fetch_site_running_versions(site_id)` reads `listSiteDevicesStats` and always
  sends `type="all"`, so a switch or a gateway is not dropped by the
  access-point default.
- `read(device_row, running_by_key)` returns a `FirmwareVersionReading` with the
  value, the source endpoint, and an `is_running` flag. A value that came only
  from the device listing is marked stale and is never presented as running.

`FirmwareManager._run_ssr_site_upgrade_flow` now overlays the running version
onto the SSR inventory before the upgrade / current / downgrade verdict. The
verdict therefore reads the version the device runs now. A device that the org
inventory misses now reaches the validator with its running version, instead of
being skipped as missing.

The `_fetch_site_gateway_devices` docstring carries a warning where a reader
meets the trap. The Common Pitfalls section of the agent instructions carries
the rule next to the existing device type filtering trap.

## Acceptance criteria

- [x] No firmware decision reads the version of `listSiteDevices`.
- [x] A recorded note names which endpoint reports the running version.

## Tests

`tests/unit/firmware/test_running_version.py` adds seven tests. They were
written first and failed before the fix.

- The device listing is rejected as a running-version source.
- A stats hit wins over the listing value.
- A listing-only value is marked stale.
- The stats call sends `type="all"`.
- The SSR flow decides from the running version, not a stale one.
- A device the org inventory misses keeps its running version.
- The firmware manager imports the shared resolver.

```
tests/unit/firmware + bulk_ap + bulk_switch + org_ap:  1092 passed in 28.40s
python -m py_compile MistHelper.py src/firmware/...  : clean
python -m ruff check MistHelper.py src tests/unit/firmware : All checks passed
python -m black --check src/firmware tests/unit/firmware   : 17 files unchanged
```

## Notes

- `MistHelper.py` is unchanged. All new logic lives under `src/firmware/`,
  because `MistHelper.py` is a hot file.
- No `CHANGELOG.md` entry. Issue #1899 records that every concurrent pull
  request collides on the changelog head, and sibling pull requests are open
  right now.

## Conformance

- [x] The change addresses the linked issue.
- [x] Unit tests cover the new behavior.
- [x] No secrets are added. No `.env` value is committed.
- [x] Inline comments explain why on every added executable line.
- [x] `logging.info` before and `logging.debug` after each operation.
- [x] Prose follows Simplified Technical English. Log messages are ASCII only.
