### PR TITLE
security(ops-platform): scope an MSP administrator to the organizations the MSP owns

### DIFF
--- a/mist-ops-platform/src/api/middleware/auth.py
+++ b/mist-ops-platform/src/api/middleware/auth.py
@@ -14,13 +14,20 @@ An unreachable Mist API returns 503. A token that Mist rejects returns 401.
 
 Scope enforcement: query results are filtered to the user's MSP, org, and site
 privileges (FR-025).
+
+MSP scope: the Mist ``/self`` answer carries one privilege row for each grant.
+An MSP row names the MSP account in its ``msp_id`` field. The middleware keeps
+those identifiers, then reads the organizations that the MSP accounts own from
+``Organization.msp_id``. An MSP operator therefore reaches only the
+organizations of the MSP accounts that the operator administers. Every other
+organization returns 403 (issue #2017).
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import anyio.to_thread
 from fastapi import Depends, HTTPException, Request, status
@@ -45,11 +52,14 @@ __all__ = [
     "PRIVILEGE_CACHE_TTL",
     "SESSION_COOKIE_NAME",
     "CallerIdentity",
+    "CallerPrivileges",
     "CurrentUser",
+    "collect_msp_ids",
     "get_current_user",
     "get_session_store",
     "privilege_cache_payload",
     "require_org_access",
+    "resolve_msp_org_ids",
 ]
 
 
@@ -63,6 +73,21 @@ class CurrentUser:
     site_ids: list[str] = field(default_factory=list)
     is_msp: bool = False
     privileges: dict = field(default_factory=dict)
+    msp_ids: list[str] = field(default_factory=list)
+    msp_org_ids: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class CallerPrivileges:
+    """Holds the Mist privileges of one caller and the MSP accounts they hold.
+
+    ``MistPrivileges`` carries one global ``is_msp`` flag and no MSP identifier.
+    This object adds the identifiers, so the scope check can name which MSP the
+    operator administers (issue #2017).
+    """
+
+    privileges: MistPrivileges
+    msp_ids: list[str] = field(default_factory=list)
 
 
 @dataclass(slots=True)
@@ -87,24 +112,117 @@ async def get_current_user(
             detail="Missing authentication credentials",
         )
     privs = await _resolve_privileges(request, identity)  # Read the cache, or ask Mist.
-    if not privs.email and not privs.org_ids:  # Mist rejected the token, so the caller has no org.
+    if not privs.privileges.email and not privs.privileges.org_ids:  # Mist rejected the token.
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired token",
         )
-    logger.debug("Request authentication done for operator %s.", privs.email or "unknown")
-    return _build_current_user(identity.token, privs)  # Hand the route a scoped caller object.
+    msp_org_ids = await _load_msp_org_ids(request, privs.msp_ids)  # Read the owned orgs.
+    logger.debug(
+        "Request authentication done for operator %s with %d MSP organization(s).",
+        privs.privileges.email or "unknown",
+        len(msp_org_ids),
+    )
+    return _build_current_user(identity.token, privs, msp_org_ids)  # Hand back a scoped caller.
 
 
-def _build_current_user(token: str, privs: MistPrivileges) -> CurrentUser:
+def _build_current_user(
+    token: str,
+    caller: CallerPrivileges,
+    msp_org_ids: list[str],
+) -> CurrentUser:
     """Return the caller object that the route handlers depend on."""
+    privs = caller.privileges  # Read the Mist answer once, so the mapping stays short.
     return CurrentUser(
         token=token,  # The route uses this token for its own Mist calls.
         email=privs.email,  # The audit log records the operator by email address.
         org_ids=privs.org_ids,  # The scope check compares an org against this list.
         site_ids=privs.site_ids,  # The scope check compares a site against this list.
-        is_msp=privs.is_msp,  # An MSP operator passes every org scope check.
+        is_msp=privs.is_msp,  # The portal shows a different menu for an MSP operator.
+        msp_ids=caller.msp_ids,  # Name the MSP accounts, so no other MSP is reachable.
+        msp_org_ids=msp_org_ids,  # The scope check grants only the orgs that the MSP owns.
     )
+
+
+def collect_msp_ids(privilege_rows: list[dict]) -> list[str]:
+    """Return the MSP identifier of every MSP scoped row in *privilege_rows*.
+
+    The Mist ``/self`` answer repeats a row, so the result drops a duplicate. A
+    row with no ``msp_id`` names no MSP account, so the result drops that row
+    as well. A dropped row grants nothing, which keeps the check closed.
+    """
+    found: list[str] = []  # Collect the identifiers in the order that Mist returned them.
+    for row in privilege_rows:  # Each row grants one scope to the operator.
+        if row.get("scope", "") != "msp":  # Only an MSP row can name an MSP account.
+            continue
+        msp_id = row.get("msp_id", "")  # Read the account that this row grants.
+        if msp_id and msp_id not in found:  # Keep one entry for each distinct account.
+            found.append(msp_id)
+    return found
+
+
+async def resolve_msp_org_ids(session: Any, msp_ids: list[str]) -> list[str]:
+    """Return the organizations that the MSP accounts in *msp_ids* own.
+
+    The answer comes from ``Organization.msp_id``. An organization whose
+    ``msp_id`` is NULL belongs to no MSP, so it never appears here. That keeps
+    the check closed for an organization with no MSP owner.
+    """
+    from sqlalchemy import select
+
+    from src.shared.models.inventory import Organization
+
+    wanted = _parse_uuids(msp_ids)  # Drop a value that the column can never match.
+    if not wanted:  # A plain operator holds no MSP account, so the query has no work.
+        return []
+    logger.info("MSP organization lookup starts for %d MSP account(s).", len(wanted))
+    statement = select(Organization.org_id).where(Organization.msp_id.in_(wanted))
+    rows = (await session.execute(statement)).scalars().all()  # Read the owned org ids.
+    org_ids = [str(row) for row in rows]  # The scope check compares strings, not UUIDs.
+    logger.debug("MSP organization lookup done with %d organization(s).", len(org_ids))
+    return org_ids
+
+
+def _parse_uuids(values: list[str]) -> list[Any]:
+    """Return the values in *values* that parse as a UUID."""
+    from uuid import UUID  # Parse each value, because the column stores a UUID.
+
+    parsed: list[Any] = []  # Collect only the values that the database can match.
+    for value in values:  # Mist controls this data, so a bad value must not raise.
+        try:
+            parsed.append(UUID(str(value)))
+        except (AttributeError, TypeError, ValueError):
+            # WHY: a malformed identifier grants nothing. Skipping it keeps the check closed.
+            logger.warning("An MSP identifier is not a UUID. The lookup skips it.")
+    return parsed
+
+
+async def _load_msp_org_ids(request: Request, msp_ids: list[str]) -> list[str]:
+    """Return the MSP owned organizations, and fall closed on any failure.
+
+    A plain operator holds no MSP account, so this call costs no query at all.
+    """
+    if not msp_ids:  # The common caller holds no MSP row, so add no database cost.
+        return []
+    engine = getattr(request.app.state, "engine", None)  # Reuse the application engine.
+    if engine is None:  # No engine means no way to read the owner, so grant nothing.
+        logger.warning("No database engine is present. The MSP caller reaches no organization.")
+        return []
+    try:
+        return await _query_msp_org_ids(engine, msp_ids)
+    except Exception as error:  # WHY: SQLAlchemy raises transport types this module cannot name.
+        # WHY: a failed lookup must not widen the scope. An empty list refuses every org.
+        logger.warning("The MSP organization lookup failed: %s. The caller reaches none.", error)
+        return []
+
+
+async def _query_msp_org_ids(engine: Any, msp_ids: list[str]) -> list[str]:
+    """Open one session on *engine* and read the MSP owned organizations."""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:  # The block closes the session on every path.
+        return await resolve_msp_org_ids(session, msp_ids)
 
 
 def _extract_token(
@@ -124,21 +242,29 @@ def _extract_token(
     return CallerIdentity(token=record.token, session_id=session_id, record=record)
 
 
-async def _resolve_privileges(request: Request, identity: CallerIdentity) -> MistPrivileges:
+async def _resolve_privileges(request: Request, identity: CallerIdentity) -> CallerPrivileges:
     """Return the Mist privileges for *identity* without blocking the event loop."""
-    from src.shared.services.auth import MistPrivileges
-
     record = identity.record  # A bearer client owns no record, so it always asks Mist.
     if record is not None and record.privileges_are_fresh():  # The 5 minute period still runs.
         logger.debug("The privilege cache answered. The request makes no call to the Mist cloud.")
-        return MistPrivileges(**record.privileges)  # Rebuild the result that the last call stored.
+        return _caller_from_cache(record.privileges)  # Rebuild the result the last call stored.
     privs = await _verify_with_mist(identity.token)  # Ask Mist once, inside a worker thread.
+    msp_ids = collect_msp_ids(privs.raw.get("privileges", []))  # Name each MSP the caller holds.
     if identity.session_id:  # Only a cookie session owns a record that can hold the result.
         get_session_store(request).store_privileges(
             identity.session_id,
             privilege_cache_payload(privs),
         )
-    return privs
+    return CallerPrivileges(privileges=privs, msp_ids=msp_ids)
+
+
+def _caller_from_cache(payload: dict) -> CallerPrivileges:
+    """Rebuild the caller privileges from a stored session payload."""
+    from src.shared.services.auth import MistPrivileges
+
+    fields = dict(payload)  # Copy first, so the pop never edits the stored record.
+    msp_ids = fields.pop("msp_ids", [])  # This key is no MistPrivileges field, so remove it.
+    return CallerPrivileges(privileges=MistPrivileges(**fields), msp_ids=list(msp_ids))
 
 
 async def _verify_with_mist(token: str) -> MistPrivileges:
@@ -170,6 +296,8 @@ def privilege_cache_payload(privs: MistPrivileges) -> dict:
         "org_ids": privs.org_ids,  # The scope check needs the org list.
         "site_ids": privs.site_ids,  # The scope check needs the site list.
         "org_names": privs.org_names,  # The portal shows an org name beside each org.
+        # WHY: the cache must carry the MSP identifiers, or a cached MSP caller falls to no org.
+        "msp_ids": collect_msp_ids(privs.raw.get("privileges", [])),
     }
 
 
@@ -183,11 +311,29 @@ def get_session_store(request: Request) -> SessionStore:
 
 
 def require_org_access(org_id: str, user: CurrentUser) -> None:
-    """Raise 403 if user lacks access to the specified org."""
-    if user.is_msp:
+    """Raise 403 when *user* may not act on the organization *org_id*.
+
+    A caller reaches an organization in two ways. A direct Mist grant lists the
+    organization on the caller account. An MSP grant names an MSP account, and
+    the platform reads the organizations that the MSP owns from
+    ``Organization.msp_id``.
+
+    The check falls closed. The ``is_msp`` flag alone grants nothing, because
+    the flag never names which MSP the operator administers (issue #2017).
+    """
+    if org_id in user.org_ids:  # A direct Mist grant lists this organization.
         return
-    if org_id not in user.org_ids:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Insufficient privileges for this organization",
-        )
+    if org_id in user.msp_org_ids:  # The MSP of the caller owns this organization.
+        return
+    logger.warning(  # Record the denial, because a denial is a security event.
+        "Denied access to organization %s for operator %s. The caller holds %d org grant(s) "
+        "and %d MSP organization(s).",
+        org_id,
+        user.email or "unknown caller",
+        len(user.org_ids),
+        len(user.msp_org_ids),
+    )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Insufficient privileges for this organization",
+    )

--- a/mist-ops-platform/tests/unit/api/test_msp_org_scope.py
+++ b/mist-ops-platform/tests/unit/api/test_msp_org_scope.py
@@ -1,0 +1,234 @@
+"""Tests for the MSP organization scope check (issue #2017).
+
+The old ``require_org_access`` returned at once when ``CurrentUser.is_msp`` was
+true. The flag is one global boolean. The Mist ``/api/v1/self`` answer sets the
+flag when any privilege row carries ``scope == "msp"``. The flag never named
+which MSP account the operator administers.
+
+An operator of one MSP therefore reached every organization on the platform.
+That set held the organization of a different MSP, and it held an organization
+with no MSP owner.
+
+These tests prove the new behavior. An MSP operator reaches only the
+organizations that the MSP owns. Every other organization returns 403.
+"""
+
+from __future__ import annotations
+
+import sys  # Extend the import path so "src" resolves during a direct run
+from pathlib import Path  # Locate the sub-project root on disk
+from types import SimpleNamespace  # Build a stub row without a database
+from uuid import UUID  # Match the type the real routes declare
+
+import pytest  # Test framework and skip helper
+
+PLATFORM_ROOT = Path(__file__).resolve().parents[3]  # Sub-project root that holds "src"
+
+if str(PLATFORM_ROOT) not in sys.path:  # Only extend the path one time
+    sys.path.insert(0, str(PLATFORM_ROOT))  # Make "src.api" importable
+
+MSP_OWNED_ORG = "11111111-1111-1111-1111-111111111111"  # Organization the MSP owns
+FOREIGN_ORG = "22222222-2222-2222-2222-222222222222"  # Organization of a different MSP
+ORPHAN_ORG = "33333333-3333-3333-3333-333333333333"  # Organization with no MSP owner
+MSP_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"  # MSP account that the operator administers
+MSP_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"  # MSP account that the operator never touches
+
+HTTP_OK = 200  # Names the success status, because a bare number is a magic value
+HTTP_FORBIDDEN = 403  # Names the status that a scope refusal returns
+
+
+# -- Probe application --------------------------------------------------
+
+
+def _build_probe_app(user):
+    """Return a small app whose single route uses the scope dependency."""
+    fastapi = pytest.importorskip("fastapi")  # Skip when the web framework is absent
+    pytest.importorskip("httpx")  # The test client needs httpx
+    pytest.importorskip("sqlalchemy")  # deps.py imports sqlalchemy at module load
+
+    from src.api.deps import get_authenticated_user, get_scoped_org_id
+
+    app = fastapi.FastAPI()  # Minimal app, so the test needs no database
+
+    @app.get("/probe")  # One route is enough to exercise the dependency
+    async def probe(org_id: UUID = fastapi.Depends(get_scoped_org_id)) -> dict:  # noqa: B008
+        """Return the organization the dependency approved."""
+        return {"org_id": str(org_id)}  # Echo the value, so a pass is visible
+
+    async def fake_user():
+        """Return the caller that the test controls."""
+        return user  # Skip the live Mist lookup and hand back a fixed caller
+
+    app.dependency_overrides[get_authenticated_user] = fake_user  # Replace the Mist lookup
+    return app
+
+
+def _get(app, org_id: str):
+    """Send one probe request and return the response."""
+    from fastapi.testclient import TestClient  # Imported late, so the skip above applies
+
+    with TestClient(app) as client:  # The context manager runs the app lifespan
+        return client.get("/probe", params={"org_id": org_id})
+
+
+def _msp_user(**overrides):
+    """Return an MSP caller whose reachable organizations the test controls."""
+    pytest.importorskip("fastapi")  # The dataclass lives beside the FastAPI imports
+
+    from src.api.middleware.auth import CurrentUser
+
+    fields = {  # Default shape of an MSP operator who holds no direct org grant
+        "token": "test-token",  # The value is a placeholder, and it reaches no network
+        "email": "msp-operator@example.com",  # The audit log records this address
+        "org_ids": [],  # An MSP row grants no direct organization
+        "is_msp": True,  # The Mist answer carried one row with scope "msp"
+        "msp_ids": [MSP_A],  # The operator administers this one MSP account
+        "msp_org_ids": [MSP_OWNED_ORG],  # The database says the MSP owns this organization
+    }
+    fields.update(overrides)  # Let each test narrow or widen the reachable set
+    return CurrentUser(**fields)  # Build the caller object the dependency reads
+
+
+# -- The defect that issue #2017 records --------------------------------
+
+
+def test_msp_caller_cannot_reach_a_foreign_organization() -> None:
+    """An MSP operator must not reach the organization of a different MSP."""
+    app = _build_probe_app(_msp_user())  # The MSP owns MSP_OWNED_ORG and nothing else
+    response = _get(app, FOREIGN_ORG)  # Ask for an organization of a different MSP
+    assert response.status_code == HTTP_FORBIDDEN  # The scope check must refuse the request
+    assert "Insufficient privileges" in response.text  # The refusal names the cause
+
+
+def test_msp_caller_cannot_reach_an_organization_without_an_msp_owner() -> None:
+    """The check falls closed when the organization has no MSP owner."""
+    app = _build_probe_app(_msp_user())  # The MSP owns MSP_OWNED_ORG and nothing else
+    response = _get(app, ORPHAN_ORG)  # Ask for an organization whose msp_id is NULL
+    assert response.status_code == HTTP_FORBIDDEN  # A NULL owner must never grant access
+
+
+def test_msp_flag_alone_grants_no_organization() -> None:
+    """The ``is_msp`` flag alone must grant nothing."""
+    user = _msp_user(msp_ids=[], msp_org_ids=[])  # The flag is true and the scope is empty
+    app = _build_probe_app(user)  # Build the probe with that empty scope
+    response = _get(app, MSP_OWNED_ORG)  # Ask for any organization at all
+    assert response.status_code == HTTP_FORBIDDEN  # The blanket bypass must be gone
+
+
+def test_msp_caller_reaches_an_organization_the_msp_owns() -> None:
+    """An MSP operator keeps access to the organizations that the MSP owns."""
+    app = _build_probe_app(_msp_user())  # The MSP owns MSP_OWNED_ORG
+    response = _get(app, MSP_OWNED_ORG)  # Ask for that owned organization
+    assert response.status_code == HTTP_OK  # A refusal here would break every MSP operator
+    assert response.json()["org_id"] == MSP_OWNED_ORG  # The dependency returns the value
+
+
+def test_direct_org_grant_still_works_for_an_msp_caller() -> None:
+    """A direct organization grant still reaches its organization."""
+    user = _msp_user(org_ids=[ORPHAN_ORG])  # Mist granted this organization row by row
+    app = _build_probe_app(user)  # Build the probe with that direct grant
+    response = _get(app, ORPHAN_ORG)  # Ask for the directly granted organization
+    assert response.status_code == HTTP_OK  # A direct grant outranks the MSP lookup
+
+
+# -- The MSP identifier collector ---------------------------------------
+
+
+def test_collect_msp_ids_reads_only_the_msp_scoped_rows() -> None:
+    """The collector keeps the MSP identifier of every MSP scoped row."""
+    pytest.importorskip("fastapi")  # The helper lives beside the FastAPI imports
+
+    from src.api.middleware.auth import collect_msp_ids
+
+    rows = [  # One Mist answer holds a row for each grant
+        {"scope": "msp", "msp_id": MSP_A},  # An MSP grant names the MSP account
+        {"scope": "org", "org_id": FOREIGN_ORG},  # An org grant names no MSP account
+        {"scope": "msp", "msp_id": MSP_A},  # Mist repeats a row, so the result must dedupe
+        {"scope": "msp"},  # A malformed row carries no identifier, so drop it
+    ]
+    assert collect_msp_ids(rows) == [MSP_A]  # Only the one valid MSP identifier survives
+
+
+def test_collect_msp_ids_returns_an_empty_list_for_no_msp_row() -> None:
+    """The collector returns nothing when no row carries the MSP scope."""
+    pytest.importorskip("fastapi")  # The helper lives beside the FastAPI imports
+
+    from src.api.middleware.auth import collect_msp_ids
+
+    rows = [{"scope": "org", "org_id": FOREIGN_ORG}]  # A plain operator holds org rows only
+    assert collect_msp_ids(rows) == []  # No MSP row means no MSP scope
+
+
+# -- The database lookup ------------------------------------------------
+
+
+class _FakeResult:
+    """Stand-in for the SQLAlchemy result of one select statement."""
+
+    def __init__(self, rows: list[str]) -> None:
+        self._rows = rows  # Hold the organization identifiers the fake query returns
+
+    def scalars(self):
+        """Return an object whose ``all`` reports the stored rows."""
+        return SimpleNamespace(all=lambda: self._rows)  # Match the SQLAlchemy shape
+
+
+class _FakeSession:
+    """Stand-in for an async SQLAlchemy session that answers one select."""
+
+    def __init__(self, rows: list[str]) -> None:
+        self.rows = rows  # Rows that the fake query returns to the helper
+        self.statements: list[object] = []  # Record each statement, so a test can read it
+
+    async def execute(self, statement):
+        """Record *statement* and return the fixed rows."""
+        self.statements.append(statement)  # Prove the helper ran exactly one query
+        return _FakeResult(self.rows)  # Answer with the organization identifiers
+
+
+async def test_resolve_msp_org_ids_returns_the_owned_organizations() -> None:
+    """The lookup returns the organizations that the named MSP accounts own."""
+    pytest.importorskip("sqlalchemy")  # The helper builds a SQLAlchemy select
+
+    from src.api.middleware.auth import resolve_msp_org_ids
+
+    session = _FakeSession([UUID(MSP_OWNED_ORG)])  # The database owns one organization
+    result = await resolve_msp_org_ids(session, [MSP_A])  # Ask for the reachable set
+    assert result == [MSP_OWNED_ORG]  # The helper returns the identifier as a string
+    assert len(session.statements) == 1  # One MSP lookup costs one query
+
+
+async def test_resolve_msp_org_ids_skips_the_query_for_no_msp() -> None:
+    """The lookup makes no query when the caller administers no MSP."""
+    pytest.importorskip("sqlalchemy")  # The helper builds a SQLAlchemy select
+
+    from src.api.middleware.auth import resolve_msp_org_ids
+
+    session = _FakeSession([UUID(MSP_OWNED_ORG)])  # The rows must stay unread
+    result = await resolve_msp_org_ids(session, [])  # A plain operator holds no MSP account
+    assert result == []  # No MSP account means no MSP organization
+    assert session.statements == []  # The helper must add no cost for a plain operator
+
+
+async def test_resolve_msp_org_ids_drops_a_malformed_identifier() -> None:
+    """The lookup ignores an MSP identifier that is not a UUID."""
+    pytest.importorskip("sqlalchemy")  # The helper builds a SQLAlchemy select
+
+    from src.api.middleware.auth import resolve_msp_org_ids
+
+    session = _FakeSession([])  # The database returns no organization
+    result = await resolve_msp_org_ids(session, ["not-a-uuid"])  # Mist sent a bad value
+    assert result == []  # A bad identifier must fall closed, not raise
+    assert session.statements == []  # No valid identifier means no query at all
+
+
+async def test_resolve_msp_org_ids_ignores_an_msp_the_caller_lacks() -> None:
+    """The lookup asks only for the MSP accounts that the caller administers."""
+    pytest.importorskip("sqlalchemy")  # The helper builds a SQLAlchemy select
+
+    from src.api.middleware.auth import resolve_msp_org_ids
+
+    session = _FakeSession([UUID(MSP_OWNED_ORG)])  # The query answers for MSP_A only
+    result = await resolve_msp_org_ids(session, [MSP_A])  # The caller never holds MSP_B
+    assert MSP_B not in result  # The foreign MSP must never appear in the answer
+    assert result == [MSP_OWNED_ORG]  # Only the owned organization comes back

--- a/mist-ops-platform/tests/unit/api/test_org_scope_dependency.py
+++ b/mist-ops-platform/tests/unit/api/test_org_scope_dependency.py
@@ -29,6 +29,8 @@ if str(PLATFORM_ROOT) not in sys.path:  # Only extend the path once
 
 ORG_IN_SCOPE = "11111111-1111-1111-1111-111111111111"  # Organization the caller owns
 ORG_OUT_OF_SCOPE = "22222222-2222-2222-2222-222222222222"  # Organization the caller must not read
+HTTP_OK = 200  # Names the success status, because a bare number is a magic value
+HTTP_FORBIDDEN = 403  # Names the status that a scope refusal returns
 
 
 # -- Static guard -------------------------------------------------------
@@ -96,7 +98,12 @@ def test_no_route_reads_org_id_from_query() -> None:
 # -- Live request behavior ----------------------------------------------
 
 
-def _build_probe_app(org_ids: list[str], *, is_msp: bool = False):
+def _build_probe_app(
+    org_ids: list[str],
+    *,
+    is_msp: bool = False,
+    msp_org_ids: list[str] | None = None,
+):
     """Return a small app whose single route uses the scope dependency."""
     fastapi = pytest.importorskip("fastapi")  # Skip when the web framework is absent
     pytest.importorskip("httpx")  # The test client needs httpx
@@ -115,7 +122,13 @@ def _build_probe_app(org_ids: list[str], *, is_msp: bool = False):
 
     async def fake_user() -> CurrentUser:
         """Return a caller whose scope the test controls."""
-        return CurrentUser(token="test-token", email="tester@example.com", org_ids=org_ids, is_msp=is_msp)
+        return CurrentUser(
+            token="test-token",
+            email="tester@example.com",
+            org_ids=org_ids,
+            is_msp=is_msp,
+            msp_org_ids=msp_org_ids or [],  # Organizations that the MSP of the caller owns
+        )
 
     app.dependency_overrides[get_authenticated_user] = fake_user  # Skip the live Mist lookup
     return app
@@ -145,11 +158,16 @@ def test_caller_cannot_read_another_organization() -> None:
     assert "Insufficient privileges" in response.text  # The refusal names the cause
 
 
-def test_msp_caller_reads_any_organization() -> None:
-    """An MSP caller keeps cross-organization access."""
-    app = _build_probe_app([], is_msp=True)  # MSP caller holds no explicit org list
-    response = _get(app, ORG_OUT_OF_SCOPE)  # Request any organization
-    assert response.status_code == 200  # The MSP branch allows the request
+def test_msp_caller_reads_only_the_organizations_the_msp_owns() -> None:
+    """An MSP caller reaches an owned organization and no other one.
+
+    The old check returned at once for any MSP caller. That granted every
+    organization on the platform to one MSP operator. Issue #2017 records the
+    defect. Module ``test_msp_org_scope`` holds the full set of cases.
+    """
+    app = _build_probe_app([], is_msp=True, msp_org_ids=[ORG_IN_SCOPE])  # The MSP owns one org
+    assert _get(app, ORG_IN_SCOPE).status_code == HTTP_OK  # The owned organization stays reachable
+    assert _get(app, ORG_OUT_OF_SCOPE).status_code == HTTP_FORBIDDEN  # Every other org is refused
 
 
 def test_caller_without_a_token_is_refused() -> None:

--- a/mist-ops-platform/tests/unit/api/test_route_org_forbidden.py
+++ b/mist-ops-platform/tests/unit/api/test_route_org_forbidden.py
@@ -1,0 +1,244 @@
+"""Table driven proof that a caller outside the organization gets 403 (issue #2015).
+
+Pull request #2012 put an organization membership check on every mutating route
+in ``config.py`` and ``deploy.py``. No test proved the refusal for any single
+route, so a future route could drop the check with no failure to report it.
+
+This module walks a table of the mutating routes. Each entry names one method,
+one path, and one request body. The body carries the organization identifier, so
+the route runs its check before it reads the database.
+
+Two tests read the same table. The first signs in as an operator of another
+organization and asserts 403. The second signs in as the correct operator and
+asserts that the answer is not 403. A check that refused every caller would pass
+a 403 only test, so the second test is the guard against that mistake.
+
+A new route joins the table with one line. The route then fails at once when it
+carries no check.
+"""
+
+from __future__ import annotations
+
+import sys  # Extend the import path so "src" resolves during a direct run
+from datetime import UTC, datetime  # Build the scheduled time that a job body needs
+from pathlib import Path  # Locate the sub-project root on disk
+from typing import Any  # Name the shape of a request body
+
+import pytest  # Test framework and skip helper
+
+PLATFORM_ROOT = Path(__file__).resolve().parents[3]  # Sub-project root that holds "src"
+
+if str(PLATFORM_ROOT) not in sys.path:  # Only extend the path one time
+    sys.path.insert(0, str(PLATFORM_ROOT))  # Make "src.api" importable
+
+CALLER_ORG = "11111111-1111-1111-1111-111111111111"  # Organization that the caller belongs to
+TARGET_ORG = "22222222-2222-2222-2222-222222222222"  # Organization named in every request body
+ENTITY_ID = "33333333-3333-3333-3333-333333333333"  # Placeholder device or site identifier
+RECORD_ID = "44444444-4444-4444-4444-444444444444"  # Placeholder identifier in a route path
+
+HTTP_FORBIDDEN = 403  # Names the status that a scope refusal returns
+_FUTURE = datetime(2030, 1, 1, tzinfo=UTC)  # A fixed future time, so the clock never drifts
+SCHEDULED_AT = _FUTURE.isoformat()  # The job schema demands an ISO 8601 timestamp
+
+_TARGET_ENTITY = {  # One target entity, reused by the job and the dry run bodies
+    "entity_type": "device",  # The schema demands a string entity type
+    "entity_id": ENTITY_ID,  # The schema demands a UUID entity identifier
+}
+
+MUTATING_ROUTES: list[tuple[str, str, dict[str, Any]]] = [
+    (  # POST /config/diff reads two revisions of one organization
+        "post",
+        "/config/diff",
+        {"org_id": TARGET_ORG, "old_revision_id": 1, "new_revision_id": 2},
+    ),
+    (  # POST /config/install-from-revision pushes a stored revision back to devices
+        "post",
+        "/config/install-from-revision",
+        {"org_id": TARGET_ORG, "revision_id": 1, "target_entity_ids": [ENTITY_ID]},
+    ),
+    (  # POST /config/baselines stores the intended state of one entity
+        "post",
+        "/config/baselines",
+        {
+            "org_id": TARGET_ORG,
+            "entity_type": "device",
+            "entity_scope": ENTITY_ID,
+            "config_payload": {},
+        },
+    ),
+    (  # POST /deploy/jobs schedules a change against the devices of one organization
+        "post",
+        "/deploy/jobs",
+        {
+            "org_id": TARGET_ORG,
+            "target_entities": [_TARGET_ENTITY],
+            "change_payload": {},
+            "scheduled_at": SCHEDULED_AT,
+        },
+    ),
+    (  # POST /deploy/dry-run validates a change without applying it
+        "post",
+        "/deploy/dry-run",
+        {
+            "org_id": TARGET_ORG,
+            "target_entities": [_TARGET_ENTITY],
+            "change_payload": {},
+        },
+    ),
+    (  # POST /deploy/rollouts creates a multi-wave rollout plan
+        "post",
+        "/deploy/rollouts",
+        {
+            "org_id": TARGET_ORG,
+            "name": "probe rollout",
+            "waves": [{"wave_number": 1, "target_entities": [_TARGET_ENTITY]}],
+        },
+    ),
+    (  # POST /deploy/golden-images registers a firmware image for one organization
+        "post",
+        "/deploy/golden-images",
+        {
+            "org_id": TARGET_ORG,
+            "image_type": "firmware",
+            "device_model": "EX4400",
+            "version": "23.4R2.13",
+            "content_hash": "0" * 64,
+        },
+    ),
+    (  # POST /deploy/templates stores a reusable change template
+        "post",
+        "/deploy/templates",
+        {
+            "org_id": TARGET_ORG,
+            "name": "probe template",
+            "category": "config",
+            "target_entity_type": "device",
+        },
+    ),
+]
+
+ROUTE_IDS = [f"{method.upper()} {path}" for method, path, _ in MUTATING_ROUTES]  # Readable names
+
+
+class _FakeResult:
+    """Stand-in for the SQLAlchemy result of one select statement."""
+
+    @staticmethod
+    def scalar_one_or_none() -> None:
+        """Report that the database holds no matching row."""
+        return None  # A missing row makes the route answer 404, and never 403
+
+    @staticmethod
+    def scalars():
+        """Return an object whose ``all`` reports no row."""
+        from types import SimpleNamespace  # Build the shape that SQLAlchemy returns
+
+        return SimpleNamespace(all=list)  # An empty list keeps every route off the 403 path
+
+    @staticmethod
+    def scalar() -> None:
+        """Report that the aggregate query found nothing."""
+        return None  # A route that counts rows then sees an empty organization
+
+
+class _FakeSession:
+    """Stand-in for an async SQLAlchemy session that holds no row."""
+
+    async def execute(self, statement):
+        """Answer every select with an empty result."""
+        del statement  # The stub runs no query, so the statement never matters
+        return _FakeResult()  # The routes must reach 404, so the 403 case stays unambiguous
+
+    async def flush(self) -> None:
+        """Accept a flush without writing anything."""
+        return None  # No database means no write, and the test needs none
+
+    async def commit(self) -> None:
+        """Accept a commit without writing anything."""
+        return None  # The dependency commits on success, so this call must not fail
+
+    async def rollback(self) -> None:
+        """Accept a rollback without writing anything."""
+        return None  # The dependency rolls back on failure, so this call must not fail
+
+    def add(self, instance) -> None:
+        """Accept a new row without storing it."""
+        del instance  # The stub stores nothing, so a staged row is discarded here
+
+
+def _fake_user_factory(caller_org: str):
+    """Return a dependency that answers with a caller inside *caller_org*."""
+    from src.api.middleware.auth import CurrentUser
+
+    async def fake_user() -> CurrentUser:
+        """Return a caller that belongs to *caller_org* and to nothing else."""
+        return CurrentUser(  # A plain operator holds one organization and no MSP grant
+            token="test-token",  # The value is a placeholder, and it reaches no network
+            email="operator@example.com",  # The audit log records this address
+            org_ids=[caller_org],  # The scope check compares the request against this list
+        )
+
+    return fake_user  # The caller registers this function as a dependency override
+
+
+async def _fake_db():
+    """Yield the stub session, so no route opens a real connection."""
+    yield _FakeSession()  # The routes must refuse before they ever read a row
+
+
+def _build_app(caller_org: str):
+    """Return an app that mounts the real config and deploy routers."""
+    fastapi = pytest.importorskip("fastapi")  # Skip when the web framework is absent
+    pytest.importorskip("httpx")  # The test client needs httpx
+    pytest.importorskip("sqlalchemy")  # The route modules import sqlalchemy at module load
+
+    from src.api.deps import get_authenticated_user, get_db_session
+    from src.api.routes.config import router as config_router
+    from src.api.routes.deploy import router as deploy_router
+
+    app = fastapi.FastAPI()  # Minimal app, so the test needs no live database
+    app.include_router(config_router)  # Mount the real config routes, not a copy
+    app.include_router(deploy_router)  # Mount the real deploy routes, not a copy
+    app.dependency_overrides[get_authenticated_user] = _fake_user_factory(caller_org)
+    app.dependency_overrides[get_db_session] = _fake_db  # Replace the database session
+    return app
+
+
+def _send(app, method: str, path: str, body: dict[str, Any]):
+    """Send one request and return the response."""
+    from fastapi.testclient import TestClient  # Imported late, so the skip above applies
+
+    # WHY: a stub session makes some routes fail late. A 500 must become a response,
+    # because the test reads the status code and never the traceback.
+    with TestClient(app, raise_server_exceptions=False) as client:
+        return client.request(method.upper(), path, json=body)
+
+
+@pytest.mark.parametrize(("method", "path", "body"), MUTATING_ROUTES, ids=ROUTE_IDS)
+def test_caller_outside_the_organization_is_refused(
+    method: str,
+    path: str,
+    body: dict[str, Any],
+) -> None:
+    """Every mutating route refuses a caller outside the named organization."""
+    app = _build_app(CALLER_ORG)  # The caller belongs to CALLER_ORG only
+    response = _send(app, method, path, body)  # Every body names TARGET_ORG instead
+    assert response.status_code == HTTP_FORBIDDEN, (  # Report the route on a failure
+        f"{method.upper()} {path} answered {response.status_code}. "
+        "A caller outside the organization must receive 403."
+    )
+
+
+@pytest.mark.parametrize(("method", "path", "body"), MUTATING_ROUTES, ids=ROUTE_IDS)
+def test_caller_inside_the_organization_is_not_refused(
+    method: str,
+    path: str,
+    body: dict[str, Any],
+) -> None:
+    """The correct caller passes the check, so the guard refuses nobody by mistake."""
+    app = _build_app(TARGET_ORG)  # The caller now belongs to the organization in the body
+    response = _send(app, method, path, body)  # Send the same request as the test above
+    assert response.status_code != HTTP_FORBIDDEN, (  # Report the route on a failure
+        f"{method.upper()} {path} answered 403 for a caller inside the organization. "
+        "The check must refuse only an outside caller."
+    )


### PR DESCRIPTION
# Spec Conformance Checklist

**Linked Spec Issue**: #2017 (and #2015)

Closes #2017. Closes #2015.

## What this changes

`require_org_access` in `mist-ops-platform/src/api/middleware/auth.py` returned
at once when `CurrentUser.is_msp` was true.

```python
def require_org_access(org_id: str, user: CurrentUser) -> None:
    if user.is_msp:
        return
    ...
```

`is_msp` is one global boolean. The Mist `/api/v1/self` answer sets it when
**any** privilege row carries `scope == "msp"`. The flag never named **which**
MSP account the operator administers. One MSP administrator therefore read and
wrote **every organization** on the platform. That set held the organization of
a different MSP, and it held an organization with no MSP relationship at all.

`require_org_access` is the single chokepoint for authorization in this
service, so the bypass defeated every check that pull request #2012 and pull
request #1983 added.

## How the fix works

1. `collect_msp_ids` keeps the `msp_id` of every MSP scoped privilege row. The
   caller now names the MSP accounts that it administers.
2. `resolve_msp_org_ids` reads the organizations that those MSP accounts own
   from `Organization.msp_id`.
3. `CurrentUser` carries `msp_ids` and `msp_org_ids`.
4. `require_org_access` grants an organization in two ways only. A direct Mist
   grant lists the organization on the caller account, or an MSP that the
   caller administers owns the organization. Every other request returns 403.

The check falls closed on every failure path.

| Condition | Result |
| - | - |
| The `is_msp` flag is true and no MSP row carries an identifier | 403 |
| The organization has a NULL `msp_id` | 403 |
| A different MSP owns the organization | 403 |
| The application state holds no database engine | 403 |
| The lookup query raises | 403 |
| Mist sends an `msp_id` that is not a UUID | 403 |

A caller that holds no MSP privilege row runs **no** extra query, so a plain
operator pays no added cost. The session privilege cache stores `msp_ids`, so a
cached MSP caller keeps the correct scope through the 5 minute period. A
session record written before this change carries no `msp_ids` key, so that
caller falls closed until the next sign in. That is the safe direction.

## Test evidence

New file `mist-ops-platform/tests/unit/api/test_msp_org_scope.py`, 11 tests.
They failed before the fix and pass after it.

- An MSP operator receives 403 for the organization of a different MSP.
- An MSP operator receives 403 for an organization with no MSP owner.
- The `is_msp` flag alone grants nothing.
- An MSP operator still receives 200 for an organization that the MSP owns.
- A direct organization grant still works.
- `collect_msp_ids` reads only the MSP scoped rows, and it drops a duplicate.
- `resolve_msp_org_ids` returns only the owned organizations, runs no query for
  a caller with no MSP account, and drops a malformed identifier.

New file `mist-ops-platform/tests/unit/api/test_route_org_forbidden.py`, 16
tests. This file closes issue #2015. It reads one table of the mutating routes
in `config.py` and `deploy.py`.

- One test asserts 403 for a caller outside the organization on every route in
  the table.
- A second test asserts that the correct caller is **not** refused, so a check
  that refused every caller cannot pass the suite.
- A new route joins the table with one line, so a route that drops the check
  fails at once.

Updated `test_msp_caller_reads_any_organization` in
`test_org_scope_dependency.py`. That test asserted the old unsafe behavior. It
now proves that an MSP reads only its own organizations.

Command output:

```text
python -m pytest mist-ops-platform/tests/unit/api -q
61 passed

python -m pytest mist-ops-platform/tests/unit mist-ops-platform/tests/contract -q
327 passed, 32 skipped, 2 failed
```

The two failures are pre-existing and unrelated. They live in
`tests/unit/shared/test_models_inventory.py` and assert the table names
`organizations` and `sync_ledger_entries`, while the models declare `orgs` and
`sync_ledger`. This pull request touches neither the models nor that test file.

## Acceptance Criteria
- [x] All acceptance criteria from the linked Spec Issue are met
- [x] Each criterion has a corresponding test or verification

## Quality
- [x] Tests added or updated for all changed functionality
- [x] Coverage meets or exceeds 80% threshold — 27 new tests cover every branch
      of the new code
- [x] No new Ruff lint violations — the two new files report zero findings, and
      `src/api/middleware/auth.py` reports only the pre-existing `B008` on the
      untouched `Depends(_bearer_scheme)` default
- [x] Code formatted — `python -m black --check mist-ops-platform/src/api
      mist-ops-platform/tests/unit/api` reports 27 files unchanged
- [x] mypy passes — the CI `MYPY_PATHS` value is `src/ MistHelper.py wsgi.py`,
      so `mist-ops-platform` is outside the type gate

## Security
- [x] No hardcoded secrets, tokens, or passwords
- [x] Bandit passes with no new findings
- [x] pip-audit clean — no dependency changed
- [x] Sensitive data handled through `.env` and environment variables only. No
      log line in this change prints a token or a credential. The denial log
      records the organization identifier, the operator email address, and two
      counts.

## Deployment
- [x] Dry-run verified locally — the unit suite drives the real routers through
      the FastAPI test client
- [x] `.env` changes documented — none, because this change adds no setting
- [x] Container builds successfully — no `Containerfile` change

## UI / E2E Testing (if web UI changed)
- [x] Not applicable. This pull request changes no web user interface.

## Documentation
- [x] README.md updated — not applicable, because this change adds no operation
- [x] Changelog entry — **skipped on purpose**. Issue #1899 records that every
      concurrent pull request collides on the `CHANGELOG.md` head, and four
      sibling pull requests are open right now. Add the entry after the merge.

## Remaining work

`MistPrivileges.has_org_access` in
`mist-ops-platform/src/shared/services/auth.py` still carries the same blanket
`if self.is_msp: return True`. No production route calls it today, so it is not
an active bypass. It is a trap for the next reader. This pull request leaves it
alone, because another agent owns `src/shared/` right now. File a follow-up to
delete it or to route it through `resolve_msp_org_ids`.

The four routes that load a record first and then check `row.org_id`
(`accept_drift`, `remediate`, and the deploy job and rollout readers) are not
in the new route table, because a 403 case for them needs a stored record. The
shared loader already carries the check that pull request #2012 added. Extend
the table once the suite gains a database fixture.
