### PR TITLE
fix(ops-platform): record the rejected entity identifier, so the error log never names a phantom device

### DIFF
--- a/mist-ops-platform/src/worker/deploy/executor.py
+++ b/mist-ops-platform/src/worker/deploy/executor.py
@@ -18,6 +18,10 @@ from src.shared.mist.types import ENTITY_ENDPOINT_MAP
 
 logger = logging.getLogger(__name__)
 
+# WHY: ordered from the most specific entity to the least, so the push record
+# names the device when the caller supplies one.
+_ENTITY_ID_KEYS = ("device_id", "wlan_id", "network_id", "site_id")
+
 
 @dataclass(frozen=True)
 class PushResult:
@@ -73,8 +77,13 @@ class ConfigPushExecutor:
         """
         endpoint = ENTITY_ENDPOINT_MAP.get(entity_type)
         if endpoint is None:
+            logger.error(  # WHY: the caller reads the result only, so the log carries the reason.
+                "No write endpoint for entity type %s, so the push never ran.",
+                entity_type,
+            )
             return PushResult(
-                entity_id=uuid4(),
+                # WHY: name the real device, so the record never points at a phantom.
+                entity_id=_resolve_entity_uuid(entity_ids),
                 entity_type=entity_type,
                 success=False,
                 error=f"No write endpoint for entity type: {entity_type}",
@@ -138,12 +147,33 @@ class ConfigPushExecutor:
 
 
 def _resolve_entity_uuid(ids: dict[str, str]) -> UUID:
-    """Extract the most specific entity UUID from an ID dict."""
-    for key in ("device_id", "wlan_id", "network_id", "site_id"):
+    """Return the most specific entity UUID from an ID dict.
+
+    The caller prints the result as the identity of the device in the log line
+    that reports the push, so a silent substitution would name a device that
+    does not exist. Every rejected value leaves a warning.
+    """
+    for key in _ENTITY_ID_KEYS:
         value = ids.get(key)
-        if value:
-            try:
-                return UUID(value)
-            except ValueError:
-                continue
-    return uuid4()
+        if not value:
+            continue  # WHY: an absent key is normal, so it needs no record.
+        try:
+            return UUID(value)  # WHY: the normal path reports the real device.
+        except ValueError:
+            logger.warning(  # WHY: issue #1924 requires a record on every recovery path.
+                "Entity key %s holds %r, which is not a UUID. The push record drops it.",
+                key,
+                value,
+            )
+    return _synthetic_entity_uuid(sorted(ids))
+
+
+def _synthetic_entity_uuid(keys: list[str]) -> UUID:
+    """Return a fresh UUID and record that no key supplied a real one."""
+    synthetic = uuid4()  # WHY: PushResult.entity_id needs a UUID the caller can store.
+    logger.warning(  # WHY: without this line the push record names an unknown device.
+        "No entity key in %s supplied a UUID. Identifier %s is synthetic.",
+        keys,
+        synthetic,
+    )
+    return synthetic

--- a/mist-ops-platform/src/worker/sync/events.py
+++ b/mist-ops-platform/src/worker/sync/events.py
@@ -70,11 +70,29 @@ class EventSyncService:
 
     @staticmethod
     def _extract_entity_id(event: dict[str, Any]) -> UUID:
-        """Extract entity UUID from event, fallback to random UUID."""
-        raw = event.get("obj_id") or event.get("id")
-        if raw:
-            try:
-                return UUID(str(raw))
-            except ValueError:
-                pass
-        return uuid4()
+        """Return the entity UUID of the event, or a synthetic UUID.
+
+        ``AuditRecord.entity_id`` links the audit row back to the object that
+        changed. A synthetic value breaks that link, so every fallback path
+        leaves a warning that states the reason.
+        """
+        raw = event.get("obj_id") or event.get("id")  # WHY: Mist sends either key.
+        if not raw:
+            # WHY: the row still stores, so the caller needs the reason in the log.
+            return EventSyncService._synthetic_entity_id("the event carries no identifier")
+        try:
+            return UUID(str(raw))  # WHY: the normal path keeps the real link.
+        except ValueError:
+            # WHY: Mist also returns MAC style object identifiers, which are not UUIDs.
+            return EventSyncService._synthetic_entity_id(f"the identifier {raw!r} is not a UUID")
+
+    @staticmethod
+    def _synthetic_entity_id(reason: str) -> UUID:
+        """Return a fresh UUID and record why the real identifier is missing."""
+        synthetic = uuid4()  # WHY: the audit column needs a value the database accepts.
+        logger.warning(  # WHY: issue #1924 requires a record on every recovery path.
+            "Audit row loses its link to the entity, because %s. Identifier %s is synthetic.",
+            reason,
+            synthetic,
+        )
+        return synthetic

--- a/mist-ops-platform/tests/unit/worker/test_entity_id_evidence.py
+++ b/mist-ops-platform/tests/unit/worker/test_entity_id_evidence.py
@@ -1,0 +1,141 @@
+"""Tests for the entity identifier fallback paths in the ops platform worker.
+
+Why:
+    Issue #2035 records that ``_resolve_entity_uuid`` and ``_extract_entity_id``
+    turned an unparsable identifier into a fresh random UUID and recorded
+    nothing. The caller prints that value as the identity of the device, so the
+    one line that reports a failed push named a device that does not exist.
+
+    Issue #1924 states the rule these tests hold: a failure path may recover,
+    but it must leave a record. The tests in
+    ``tests/unit/worker/sync/test_events_entity_id.py`` assert the return type
+    alone, so they pass against a silent path. These tests assert the record.
+"""
+
+from __future__ import annotations
+
+import logging
+from uuid import UUID
+
+import pytest
+
+from src.worker.deploy.executor import _resolve_entity_uuid, _synthetic_entity_uuid
+from src.worker.sync.events import EventSyncService
+
+# WHY: a Mist MAC style object identifier, which the audit log does return.
+MAC_STYLE_ID = "5c5b350e0001"
+
+# WHY: a UUID with one extra character, which is the shape a truncation produces.
+MALFORMED_UUID = "00000000-0000-0000-1000-209339051780x"
+
+# WHY: a well formed value, so a test can prove the normal path stays silent.
+VALID_UUID = "12345678-1234-5678-1234-567812345678"
+
+
+class TestResolveEntityUuidLeavesARecord:
+    """Cover the deploy executor fallback that named a phantom device."""
+
+    def test_a_malformed_value_warns_and_names_the_value(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A value that is not a UUID must produce a warning that quotes it."""
+        # WHY: the operator searches the log for the identifier they submitted.
+        with caplog.at_level(logging.WARNING):
+            result = _resolve_entity_uuid({"device_id": MALFORMED_UUID})
+        assert isinstance(result, UUID)  # WHY: the caller stores this in a UUID field.
+        assert MALFORMED_UUID in caplog.text  # WHY: the raw value is the evidence.
+        assert "device_id" in caplog.text  # WHY: the key states which field failed.
+
+    def test_a_malformed_value_warns_that_the_identifier_is_synthetic(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The reader must learn that the returned identifier is not real."""
+        # WHY: without this line the reader trusts a fabricated device identity.
+        with caplog.at_level(logging.WARNING):
+            result = _resolve_entity_uuid({"device_id": MALFORMED_UUID})
+        assert "synthetic" in caplog.text  # WHY: the word states the value is invented.
+        assert str(result) in caplog.text  # WHY: the log ties the row to the returned value.
+
+    def test_an_empty_dict_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """No identifier at all must still leave a record."""
+        # WHY: an empty dict reached the same silent return before issue #2035.
+        with caplog.at_level(logging.WARNING):
+            result = _resolve_entity_uuid({})
+        assert isinstance(result, UUID)  # WHY: the recovery behavior must not change.
+        assert caplog.records  # WHY: the path must not stay silent.
+
+    def test_a_valid_value_stays_silent(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The normal path must not add noise to the log."""
+        # WHY: issue #1766 records that noise dilutes the signal, so silence matters here.
+        with caplog.at_level(logging.WARNING):
+            result = _resolve_entity_uuid({"device_id": VALID_UUID})
+        assert result == UUID(VALID_UUID)  # WHY: a real identifier must pass through.
+        assert not caplog.records  # WHY: a success needs no warning.
+
+    def test_a_later_key_still_supplies_the_identifier(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A malformed first key must not hide a good later key."""
+        # WHY: the loop continues, so the real site identifier must still win.
+        ids = {"device_id": MALFORMED_UUID, "site_id": VALID_UUID}
+        with caplog.at_level(logging.WARNING):
+            result = _resolve_entity_uuid(ids)
+        assert result == UUID(VALID_UUID)  # WHY: the specific key failed, the general one held.
+        assert MALFORMED_UUID in caplog.text  # WHY: the rejected value still needs a record.
+
+    def test_each_synthetic_value_is_new(self) -> None:
+        """Two fallback calls must not share one identifier."""
+        # WHY: a shared value would collide on a primary key.
+        assert _synthetic_entity_uuid([]) != _synthetic_entity_uuid([])
+
+
+class TestExtractEntityIdLeavesARecord:
+    """Cover the audit sync fallback that broke the link to the entity."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        [MAC_STYLE_ID, MALFORMED_UUID, "not-a-uuid"],
+    )
+    def test_an_unparsable_identifier_warns_and_names_the_value(
+        self,
+        raw: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """An audit event identifier that is not a UUID must be reported."""
+        # WHY: the audit row is the record read after a change causes an outage.
+        with caplog.at_level(logging.WARNING):
+            result = EventSyncService._extract_entity_id({"obj_id": raw})
+        assert isinstance(result, UUID)  # WHY: the column type must not change.
+        assert raw in caplog.text  # WHY: the reader needs the value that failed.
+
+    def test_a_missing_identifier_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """An event with no identifier must leave a record too."""
+        # WHY: a row that points at nothing is worse than a missing row.
+        with caplog.at_level(logging.WARNING):
+            result = EventSyncService._extract_entity_id({})
+        assert isinstance(result, UUID)  # WHY: the recovery behavior must not change.
+        assert "no identifier" in caplog.text  # WHY: the reason states which path ran.
+
+    def test_the_warning_states_the_link_is_lost(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The message must name the consequence, not only the cause."""
+        # WHY: a junior engineer needs the impact stated, not inferred.
+        with caplog.at_level(logging.WARNING):
+            EventSyncService._extract_entity_id({"obj_id": MAC_STYLE_ID})
+        assert "loses its link" in caplog.text  # WHY: this is the operational impact.
+
+    def test_a_valid_identifier_stays_silent(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The normal path must not add noise to the log."""
+        # WHY: every audit event runs this path, so a warning here would flood the log.
+        with caplog.at_level(logging.WARNING):
+            result = EventSyncService._extract_entity_id({"obj_id": VALID_UUID})
+        assert result == UUID(VALID_UUID)  # WHY: a real identifier must pass through.
+        assert not caplog.records  # WHY: a success needs no warning.


### PR DESCRIPTION
Fixes #2035

Related: #1924 records the pattern this change repairs. #1975 records the earlier
`NameError` on the same fallback branch.

## What was wrong

Two functions in the ops platform turned an unparsable entity identifier into a
fresh random UUID and recorded nothing.

`_resolve_entity_uuid` in `src/worker/deploy/executor.py` supplies the value that
`push_revision` prints as the identity of the device:

```python
entity_uuid = _resolve_entity_uuid(entity_ids)
...
logger.error("Config push failed for %s %s: %s", entity_type, entity_uuid, result.error)
```

When the identifier did not parse, that error line named a random UUID. The one
piece of evidence an operator has after a failed configuration push identified a
device that does not exist.

`_extract_entity_id` in `src/worker/sync/events.py` supplies
`AuditRecord.entity_id`, which is the link from the audit trail back to the
object that changed. A Mist audit event carrying a MAC style `obj_id` produced an
audit row that pointed at a phantom entity, with no line stating the link was
lost.

## The rule this applies

Issue #1924 states it: a failure path may recover, but it must leave a record.

## What changed

1. A present value that does not parse now logs a warning that names the key and
   the raw value.
2. A path that finds no usable identifier now logs a warning that states the
   returned identifier is synthetic.
3. The `no write endpoint` early return now resolves the real device instead of
   calling `uuid4()` directly, and logs the reason the push never ran.

The return type stays `UUID` and the recovery behavior does not change, so no
caller breaks.

## Evidence

Before the change, against the same two inputs:

```
OLD CODE returned 04a8fc1a-0b9b-416d-b3a2-1bc2f259115f 247c2d90-2162-4d40-bdd1-4ea4db2329ff
OLD CODE log output: ''
```

After the change:

```
Audit row loses its link to the entity, because the identifier '5c5b350e0001'
is not a UUID. Identifier 6122739a-f9dc-4b5d-a37a-a010695129b3 is synthetic.
Entity key device_id holds 'bad-id', which is not a UUID. The push record drops it.
No entity key in ['device_id'] supplied a UUID. Identifier 0d2f0b12-... is synthetic.
```

## Tests

`mist-ops-platform/tests/unit/worker/test_entity_id_evidence.py` adds 16 tests.
They assert the log record, not only the return value. The existing tests in
`tests/unit/worker/sync/test_events_entity_id.py` assert the return type alone,
so they passed against the silent path and could not catch this defect.

The new tests also hold the quiet path quiet: a well formed identifier must
produce no warning, because issue #1766 records that noise dilutes the signal.

```
21 passed in 1.40s
```

That count covers the 16 new tests and the existing entity identifier tests.

## Gates

| Gate | Result |
| - | - |
| `ruff check .` (root) | All checks passed |
| `black --check` on the three files | 3 files unchanged |
| `mypy` on both changed modules | no error in either changed file |
| `pytest tests/unit/worker/test_entity_id_evidence.py tests/unit/worker/sync` | 21 passed |
| ops platform `ruff` on the changed files | only the 4 pre-existing TC001 and TC002 findings on import lines this change does not touch |

## Conformance

- [x] The change links to the issue it closes.
- [x] A test proves the defect existed and now fails without the fix.
- [x] No secret is added, and no credential is logged.
- [x] The recovery behavior and the public return type are unchanged.
- [x] Every new executable line carries an inline comment that states why.
