### PR TITLE
fix(firmware): refuse an SSR verdict built on a stale firmware reading

### DIFF
--- a/src/firmware/firmware_manager.py
+++ b/src/firmware/firmware_manager.py
@@ -2828,14 +2828,19 @@ class FirmwareManager:
     ) -> str:
         """Return a single-word verdict for one candidate device.
 
-        Verdicts: 'missing' / 'current' / 'downgrade' / 'upgrade'.
+        Verdicts: 'missing' / 'stale' / 'current' / 'downgrade' / 'upgrade'.
+        'stale' means the only version available is the configured value from
+        the device listing. A stale reading must never produce a silent upgrade.
         """
         logging.info("Classifying SSR device id=%s target=%s", dev_id, target_version)  # WHY: entry audit
         if dev_id not in inventory:  # WHY: id must be present in inventory to proceed
             self._emit_ssr_verdict_missing(dev_id)  # WHY: uniform missing feedback
             return "missing"  # WHY: sentinel for orchestrator
-        info = inventory[dev_id]  # WHY: fetch model/version pair
-        current = info.get("version", "")  # WHY: currently-running firmware
+        info = inventory[dev_id]  # WHY: fetch model/version pair and staleness marker
+        if info.get("version_is_stale"):  # WHY: a stale reading cannot support a firmware decision
+            self._emit_ssr_verdict_stale(dev_id, info)  # WHY: warn the operator by name before skipping
+            return "stale"  # WHY: sentinel tells the orchestrator to keep this device out of the upgrade list
+        current = info.get("version", "")  # WHY: the running firmware version, confirmed as running state
         if current == target_version:  # WHY: already at target -> no-op
             self._emit_ssr_verdict_current(dev_id, target_version)  # WHY: uniform current feedback
             return "current"  # WHY: sentinel for orchestrator
@@ -2849,6 +2854,27 @@ class FirmwareManager:
         """Log + print the missing-inventory verdict."""
         logging.warning("Device %s not found in org SSR inventory - skipping", dev_id)  # WHY: audit miss
         print(f"    !? Device {dev_id} not in SSR inventory - skipping")  # WHY: operator feedback
+
+    def _emit_ssr_verdict_stale(self, dev_id: str, info: dict[str, Any]) -> None:
+        """Log + print the stale-reading verdict.
+
+        Warning: The only available version came from the device listing, not
+        from a running-version endpoint. Proceeding would risk an upgrade built
+        on a configured version that the device may have left long ago.
+        """
+        stale_value = info.get("version", "unknown")  # WHY: show the operator the value that was rejected
+        model = info.get("model", "unknown")  # WHY: the model helps the operator identify the device
+        logging.warning(  # WHY: write the staleness to the log for post-incident review
+            "Stale firmware reading for device %s (%s) value=%s - no running version found in any endpoint - skipping",
+            dev_id,
+            model,
+            stale_value,
+        )
+        print(  # WHY: the operator must see this warning during the maintenance window, not only in the log
+            f"    WARNING: Device {dev_id} ({model}) - firmware version {stale_value!r} is a stale"
+            f" reading. No running version was found in listSiteDevicesStats or getOrgInventory."
+            f" Skipping this device to prevent an upgrade decision on a stale reading."
+        )
 
     def _emit_ssr_verdict_current(self, dev_id: str, target_version: str) -> None:
         """Log + print the already-at-target verdict."""
@@ -3109,9 +3135,12 @@ class FirmwareManager:
         entry.setdefault("site_id", row.get("site_id", ""))  # WHY: keep the site anchor for reporting
         if reading.is_running:  # WHY: only a running reading may replace the inventory value
             entry["version"] = reading.value  # WHY: the decision now reads the version the device runs
+            entry.pop("version_is_stale", None)  # WHY: a running reading clears any stale marker from a prior pass
         else:  # WHY: no stats row exists for this device
-            entry.setdefault("version", reading.value)  # WHY: keep any org inventory value, which is running state
-            entry["version_is_stale"] = True  # WHY: mark the reading so a report can warn the operator
+            had_version = bool(entry.get("version"))  # WHY: the org inventory version is running state; keep it
+            entry.setdefault("version", reading.value)  # WHY: fall back to the listing value only when nothing else
+            if not had_version:  # WHY: mark stale only when the org inventory also had no running version
+                entry["version_is_stale"] = True  # WHY: signal that both running-version endpoints missed this device
         merged[dev_id] = entry  # WHY: publish the updated entry for the validator
 
     def _run_ssr_site_upgrade_flow(

--- a/tests/unit/firmware/test_running_version.py
+++ b/tests/unit/firmware/test_running_version.py
@@ -147,3 +147,129 @@ def test_ssr_flow_keeps_a_device_missing_from_the_org_inventory(monkeypatch: Any
 def test_firmware_manager_module_exposes_the_resolver() -> None:
     """The firmware manager must import the shared resolver rather than re-implement it."""
     assert fm_mod.RunningFirmwareVersionResolver is RunningFirmwareVersionResolver
+
+
+# ---------------------------------------------------------------------------
+# Tests for issue #2040: stale reading must not produce a silent upgrade verdict
+# ---------------------------------------------------------------------------
+
+
+def test_classify_returns_stale_when_both_endpoints_miss_device(monkeypatch: Any) -> None:
+    """A device absent from both running-version endpoints must get a 'stale' verdict.
+
+    Why:
+        Commit 5ebbb30a fixed the main path but left a gap: when both
+        listSiteDevicesStats and getOrgInventory have no row for a device,
+        the inventory entry carries only the device-listing value and
+        version_is_stale=True. _classify_ssr_device_for_upgrade must refuse
+        to return 'upgrade' in that case.
+    """
+    manager = _make_manager()
+    # Build an inventory entry that _apply_running_version would create for
+    # a device absent from both running-version endpoints.
+    inventory = {
+        "dev-1": {
+            "model": "SSR120",
+            "type": "gateway",
+            "version": STALE_VERSION,  # WHY: the stale device-listing value
+            "version_is_stale": True,  # WHY: both running-version endpoints missed this device
+        }
+    }
+    verdict = manager._classify_ssr_device_for_upgrade("dev-1", inventory, "23.4R2-S5.5")
+    assert verdict == "stale", (
+        f"Expected 'stale' but got {verdict!r}. "
+        "A device absent from both running-version endpoints must not receive a silent upgrade verdict."
+    )
+
+
+def test_classify_returns_upgrade_when_org_inventory_holds_running_version() -> None:
+    """A device present in the org inventory must still reach an upgrade verdict.
+
+    Why:
+        The org inventory reports the running version. A device with an org
+        inventory entry must not be blocked by the stale check. version_is_stale
+        must be absent from the entry in that case.
+    """
+    manager = _make_manager()
+    # Build an inventory entry for a device whose org inventory version is running state.
+    inventory = {
+        "dev-2": {
+            "model": "SSR120",
+            "type": "gateway",
+            "version": STALE_VERSION,  # WHY: older running version that needs an upgrade
+            # WHY: version_is_stale is absent here because the org inventory had a value
+        }
+    }
+    verdict = manager._classify_ssr_device_for_upgrade("dev-2", inventory, "23.4R2-S5.5")
+    assert verdict == "upgrade", (
+        f"Expected 'upgrade' but got {verdict!r}. "
+        "A device with a running version from the org inventory must reach the upgrade verdict."
+    )
+
+
+def test_apply_running_version_does_not_mark_stale_when_org_inventory_held_version() -> None:
+    """version_is_stale must be absent when the org inventory supplied a version.
+
+    Why:
+        Before issue #2040 the code set version_is_stale=True on every entry
+        that had no stats row, including those whose org inventory version is
+        running state. That false alarm would mislead any reader of the flag.
+    """
+    manager = _make_manager()
+    # Simulate a device present in the org inventory (version is running state).
+    merged: dict[str, Any] = {"dev-3": {"model": "SSR120", "type": "gateway", "version": RUNNING_VERSION}}
+    row = {"id": "dev-3", "model": "SSR120", "type": "gateway", "version": STALE_VERSION}
+    # No stats row: the resolver will mark the reading as not running.
+    resolver = RunningFirmwareVersionResolver(apisession=object())
+    manager._apply_running_version(merged, row, {}, resolver)
+    assert (
+        "version_is_stale" not in merged["dev-3"]
+    ), "version_is_stale must not appear when the org inventory already held a running version."
+    # The org inventory version must be preserved by setdefault.
+    assert (
+        merged["dev-3"]["version"] == RUNNING_VERSION
+    ), "The org inventory version must be preserved when it already existed."
+
+
+def test_apply_running_version_marks_stale_only_when_both_endpoints_miss() -> None:
+    """version_is_stale must be True only when both running-version endpoints had no row.
+
+    Why:
+        A device absent from both listSiteDevicesStats and getOrgInventory has
+        no running version at all. The inventory entry must carry the stale flag
+        so _classify_ssr_device_for_upgrade can refuse to produce an upgrade verdict.
+    """
+    manager = _make_manager()
+    # Simulate a device absent from the org inventory and from the stats endpoint.
+    merged: dict[str, Any] = {}
+    row = {"id": "dev-4", "model": "SSR120", "type": "gateway", "version": STALE_VERSION}
+    resolver = RunningFirmwareVersionResolver(apisession=object())
+    manager._apply_running_version(merged, row, {}, resolver)
+    assert (
+        merged["dev-4"].get("version_is_stale") is True
+    ), "version_is_stale must be True when both running-version endpoints had no row."
+    assert (
+        merged["dev-4"]["version"] == STALE_VERSION
+    ), "The listing value must be stored so the operator can see which version was rejected."
+
+
+def test_validate_ssr_devices_skips_stale_devices() -> None:
+    """_validate_ssr_devices_for_version must not include a stale device in the validated list.
+
+    Why:
+        The validator calls _classify_ssr_device_for_upgrade and must treat the
+        'stale' verdict the same way it treats 'missing', 'current', and 'downgrade':
+        place the device in the skipped list, not the validated list.
+    """
+    manager = _make_manager()
+    inventory = {
+        "dev-5": {
+            "model": "SSR120",
+            "type": "gateway",
+            "version": STALE_VERSION,
+            "version_is_stale": True,  # WHY: both running-version endpoints missed this device
+        }
+    }
+    validated, skipped = manager._validate_ssr_devices_for_version(["dev-5"], inventory, "23.4R2-S5.5")
+    assert "dev-5" not in validated, "A stale device must not appear in the validated list."
+    assert "dev-5" in skipped, "A stale device must appear in the skipped list."


### PR DESCRIPTION
Fixes #2040

Summary:
- _apply_running_version sets version_is_stale only when both listSiteDevicesStats and getOrgInventory missed the device.
- _classify_ssr_device_for_upgrade returns 'stale' before comparing versions when version_is_stale is set.
- _emit_ssr_verdict_stale warns the operator by name on the console.
- 'stale' verdict moves the device to the skipped list.

Gate output:
py_compile: OK
ruff: All checks passed
black: 1 file reformatted
pytest -k firmware: 751 passed, 9893 deselected