### PR TITLE
security(ops-platform): authenticate the token refresh route

### DIFF
--- a/mist-ops-platform/src/api/routes/health.py
+++ b/mist-ops-platform/src/api/routes/health.py
@@ -329,14 +329,27 @@ def _login_response(
 
 
 @auth_router.post("/token")
-async def refresh_token() -> ResponseEnvelope[TokenRefreshResponse]:
-    """Refresh an existing session token (placeholder)."""
-    import secrets
+async def refresh_token(request: Request) -> ResponseEnvelope[TokenRefreshResponse]:
+    """Extend the current session and return the identifier that the store holds.
 
+    The route reads the session cookie and renews the record behind it. A caller
+    with no valid session receives 401, because no session exists to refresh.
+    """
+    from fastapi import HTTPException
+
+    from src.api.middleware.auth import SESSION_COOKIE_NAME, get_session_store
+
+    logger.info("Session refresh starts.")  # Announce the refresh before the store read.
+    session_id = request.cookies.get(SESSION_COOKIE_NAME, "")  # The cookie carries the identifier.
+    lifetime = get_session_store(request).renew(session_id)  # Renew only a record that exists.
+    if lifetime is None:  # An anonymous or expired caller holds no session to extend.
+        logger.warning("Session refresh refused. No record matched the session cookie.")
+        raise HTTPException(status_code=401, detail="No active session to refresh")
+    logger.debug("Session refresh done. The record lives for %d more seconds.", lifetime)
     return ResponseEnvelope(
         data=TokenRefreshResponse(
-            session_id=secrets.token_urlsafe(32),
-            expires_in=3600,
+            session_id=session_id,  # Return the identifier the store knows, never a new random one.
+            expires_in=lifetime,  # Report the true lifetime that the renewal set.
         ),
     )
 

--- a/mist-ops-platform/src/shared/services/session_store.py
+++ b/mist-ops-platform/src/shared/services/session_store.py
@@ -96,6 +96,24 @@ class SessionStore:
         self._write(record)  # Persist the updated record under the same identifier.
         logger.debug("Session privilege cache write done for key %s.", session_key(session_id))
 
+    def renew(self, session_id: str) -> int | None:
+        """Extend the lifetime of the record for *session_id* and return that lifetime.
+
+        The method returns None when no record matches. A renewal must never
+        create a record, because that would let an anonymous caller mint a
+        session.
+        """
+        if not session_id:  # An empty cookie value addresses no record, so report no renewal.
+            return None
+        logger.info("Session record renewal starts.")  # Announce the write before the work.
+        record = self.resolve(session_id)  # Read the record, so a renewal never creates one.
+        if record is None:  # An unknown or expired identifier must not gain a new lifetime.
+            logger.debug("Session record renewal found no record.")
+            return None
+        self._write(record)  # Re-write the record, so the store restarts the session lifetime.
+        logger.debug("Session record renewal done. The key is %s.", session_key(session_id))
+        return SESSION_TTL_SECONDS  # The caller reports this lifetime to the operator.
+
     def delete(self, session_id: str) -> bool:
         """Delete the record for *session_id* and report whether a record existed."""
         if not session_id:  # An empty cookie value addresses no record, so report no deletion.

--- a/mist-ops-platform/tests/unit/api/test_token_refresh_route.py
+++ b/mist-ops-platform/tests/unit/api/test_token_refresh_route.py
@@ -1,0 +1,126 @@
+"""Tests that the token refresh route renews a real session and refuses an anonymous caller.
+
+The route used to answer any caller with ``secrets.token_urlsafe(32)``. That
+value looked like a session identifier, but the session store never issued it.
+Three faults followed. An anonymous caller received a credential-shaped string.
+A client that followed the refresh contract replaced a working identifier with
+an unknown one. The real record never gained a longer lifetime.
+
+The static guard in ``test_write_route_authentication.py`` did not catch this,
+because the allowlist entry stated a cookie check that the code never made.
+These tests hold the corrected behavior in place.
+"""
+
+from __future__ import annotations
+
+import pathlib  # Locate the sub-project root, so "src" resolves during a direct run
+import sys  # Extend the import path before the first "src" import
+
+import pytest  # Test framework and skip helper
+
+PLATFORM_ROOT = pathlib.Path(__file__).resolve().parents[3]  # Sub-project root directory
+
+if str(PLATFORM_ROOT) not in sys.path:  # Only extend the path one time
+    sys.path.insert(0, str(PLATFORM_ROOT))  # Make "src.shared" and "src.api" importable
+
+from src.shared.services.session_store import (  # noqa: E402
+    SESSION_TTL_SECONDS,
+    SessionStore,
+)
+
+HTTP_UNAUTHORIZED = 401  # Status code that a refresh with no session must get
+HTTP_OK = 200  # Status code that a refresh with a valid session must get
+
+
+# -- The store refuses to mint a session -------------------------------
+
+
+def test_renew_refuses_an_empty_identifier() -> None:
+    """An empty cookie value addresses no record, so the renewal reports None."""
+    store = SessionStore()  # A None client selects the process-local fallback map.
+    assert store.renew("") is None  # An empty value must never gain a lifetime.
+
+
+def test_renew_refuses_an_unknown_identifier() -> None:
+    """An identifier that the store never issued must not gain a lifetime.
+
+    This is the defect the route carried. A random string used to reach the
+    caller as a session identifier. The store must refuse it.
+    """
+    store = SessionStore()  # Use the fallback map, so the test needs no Redis.
+    unknown = "this-identifier-was-never-issued"  # A value that the store did not create.
+    assert store.renew(unknown) is None  # The store must not create a record on a renewal.
+
+
+def test_renew_extends_a_real_record_and_keeps_its_identifier() -> None:
+    """A renewal returns the true lifetime and leaves the identifier unchanged."""
+    store = SessionStore()  # Use the fallback map, so the test needs no Redis.
+    session_id = store.create("mist-token-value")  # Create the record the login route would write.
+
+    lifetime = store.renew(session_id)  # Renew the record that the cookie addresses.
+
+    assert lifetime == SESSION_TTL_SECONDS  # The route reports the real lifetime, not 3600.
+    record = store.resolve(session_id)  # Read the record back under the same identifier.
+    assert record is not None  # The renewal must keep the record reachable.
+    assert record.token == "mist-token-value"  # The renewal must not disturb the credential.
+
+
+def test_renew_does_not_create_a_record_for_the_identifier_it_refused() -> None:
+    """A refused renewal leaves no record behind, so a retry stays refused."""
+    store = SessionStore()  # Use the fallback map, so the test needs no Redis.
+    unknown = "a-second-identifier-the-store-never-issued"  # A value the store did not create.
+
+    store.renew(unknown)  # Attempt the renewal that the store must refuse.
+
+    assert store.resolve(unknown) is None  # No record may exist after the refusal.
+
+
+# -- The route refuses an anonymous caller ------------------------------
+
+
+def _build_client() -> object:
+    """Return a test client for the auth router, or skip when FastAPI is absent."""
+    fastapi = pytest.importorskip("fastapi")  # Skip when the web framework is not installed.
+    testclient = pytest.importorskip("fastapi.testclient")  # The client needs httpx as well.
+
+    from src.api.routes.health import auth_router  # Import here, so a missing dependency skips.
+
+    app = fastapi.FastAPI()  # A bare application isolates the route from the real middleware.
+    app.include_router(auth_router)  # Mount the router that holds POST /auth/token.
+    app.state.session_store = SessionStore()  # Give the route the fallback store to read.
+    return testclient.TestClient(app)  # The client drives a real request through the route.
+
+
+def test_an_anonymous_refresh_is_refused() -> None:
+    """A refresh with no session cookie must answer 401, never 200 with a value."""
+    client = _build_client()  # Build the client, or skip when a dependency is missing.
+
+    response = client.post("/auth/token")  # Send the refresh with no cookie at all.
+
+    assert response.status_code == HTTP_UNAUTHORIZED  # An anonymous caller gains no session.
+    assert "session_id" not in response.text  # The body must carry no credential-shaped value.
+
+
+def test_a_refresh_with_an_unknown_cookie_is_refused() -> None:
+    """A cookie that names no record must answer 401, so a guess gains nothing."""
+    client = _build_client()  # Build the client, or skip when a dependency is missing.
+    client.cookies.set("mist_session", "an-identifier-the-store-never-issued")  # Guess a value.
+
+    response = client.post("/auth/token")  # Send the refresh with the guessed cookie.
+
+    assert response.status_code == HTTP_UNAUTHORIZED  # A guessed identifier must not refresh.
+
+
+def test_a_refresh_with_a_valid_cookie_returns_the_stored_identifier() -> None:
+    """A valid session receives its own identifier back, and the true lifetime."""
+    client = _build_client()  # Build the client, or skip when a dependency is missing.
+    store = client.app.state.session_store  # Reuse the store the route reads.
+    session_id = store.create("mist-token-value")  # Create the record the login route would write.
+    client.cookies.set("mist_session", session_id)  # Present the cookie that the browser holds.
+
+    response = client.post("/auth/token")  # Send the refresh with the valid cookie.
+
+    assert response.status_code == HTTP_OK  # A valid session refreshes without an error.
+    body = response.json()["data"]  # The route wraps the payload in a response envelope.
+    assert body["session_id"] == session_id  # The route returns the identifier the store knows.
+    assert body["expires_in"] == SESSION_TTL_SECONDS  # The route reports the real lifetime.

--- a/mist-ops-platform/tests/unit/api/test_write_route_authentication.py
+++ b/mist-ops-platform/tests/unit/api/test_write_route_authentication.py
@@ -45,7 +45,9 @@ PUBLIC_WRITE_ROUTES = {  # Write routes that answer an anonymous caller on purpo
     "receive_mist_webhook",
     # The login route creates the session, so no session can exist before it.
     "login",
-    # The refresh route reads the session cookie and issues a token from it.
+    # The refresh route reads the session cookie and renews the record behind
+    # it. It answers 401 when no record matches, so it authenticates the caller
+    # through the cookie instead of a dependency.
     "refresh_token",
     # The logout route deletes the session cookie. A logout must always work.
     "logout",


### PR DESCRIPTION
Fixes #2043

## Problem

`POST /auth/token` took no parameters, so it could not read a cookie and could not authenticate anybody. It returned `secrets.token_urlsafe(32)` as a `session_id`. The session store never issued that value.

The static guard from #1979 did not catch this. Its allowlist entry said *"The refresh route reads the session cookie and issues a token from it"*, which described a check the code never made.

## The change

- `refresh_token` now takes a `Request`, reads `SESSION_COOKIE_NAME`, and renews the record through `get_session_store(request)`, the same store that `login` writes and `logout` deletes.
- The route answers `401` when the cookie is absent or names no record.
- The route returns the identifier the store already holds, so a client never replaces a working session with an unknown one.
- `expires_in` reports the real record lifetime instead of a fixed `3600`.
- New `SessionStore.renew` extends a record and returns its lifetime. It returns `None` for an absent or unknown identifier, so a renewal can never create a session.
- The `PUBLIC_WRITE_ROUTES` comment now states the check the code performs.

## Tests

`mist-ops-platform/tests/unit/api/test_token_refresh_route.py`, seven tests:

- The store refuses an empty identifier.
- The store refuses an unknown identifier.
- The store extends a real record, keeps its identifier, and preserves the token.
- A refused renewal leaves no record behind.
- An anonymous refresh answers 401 and carries no `session_id` in the body.
- A guessed cookie answers 401.
- A valid cookie returns the stored identifier and the true lifetime.

## Gate output

```
py_compile ......... compile ok
ruff check ......... All checks passed!
black --check ...... 4 files would be left unchanged
pytest ............. 4 passed, 3 skipped in 0.45s
```

The three skips are the route-level tests. They call `pytest.importorskip` on `fastapi`, which the root worktree venv does not install. CI installs the ops-platform dependency set, so those three run there. The dependency split is issue #2034.

## Note for the reviewer

`ruff` reports 11 pre-existing findings in `health.py` under the **root** config. They come from the config gap that issue #1974 records, and this branch leaves them untouched.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
