### PR TITLE
security(ops-platform): scope every sync and audit route to the caller org

### DIFF
--- a/mist-ops-platform/src/api/routes/audit.py
+++ b/mist-ops-platform/src/api/routes/audit.py
@@ -12,7 +12,6 @@ Covers:
 from __future__ import annotations
 
 import logging
-from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -24,7 +23,7 @@ from src.api.deps import (
     get_db_session,
     get_scoped_org_id,
 )
-from src.api.middleware.auth import CurrentUser
+from src.api.middleware.auth import CurrentUser, require_org_access
 from src.api.schemas.audit import (
     AuditRecordResponse,
     CompliancePackRequest,
@@ -109,9 +108,11 @@ async def get_audit_record(
 async def export_records(
     body: ExportRequest,
     db: AsyncSession = Depends(get_db_session),
-    _user: CurrentUser = Depends(get_authenticated_user),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[ExportStatusResponse]:
-    """Trigger async audit record export (SC-012 <30s)."""
+    """Trigger async audit record export (SC-012 <30s), scoped to the caller's org."""
+    logger.info("export_records called for org_id=%s by user=%s", body.org_id, user.email)
+    require_org_access(str(body.org_id), user)  # Refuse a caller outside the target org
     from src.worker.tasks.audit_tasks import export_audit_records
 
     filters = body.filters.model_dump(by_alias=True)
@@ -124,6 +125,7 @@ async def export_records(
 
     export_id = _uuid.uuid4()
     total = await _estimate_records(db, body.org_id)
+    logger.debug("export_records: export_id=%s estimated_records=%s", export_id, total)
     return ResponseEnvelope(
         data=ExportStatusResponse(
             export_id=export_id,
@@ -171,7 +173,9 @@ async def create_compliance_pack(
     db: AsyncSession = Depends(get_db_session),
     user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[CompliancePackResponse]:
-    """Generate a compliance audit evidence package."""
+    """Generate a compliance audit evidence package, scoped to the caller's org."""
+    logger.info("create_compliance_pack called for org_id=%s by user=%s", body.org_id, user.email)
+    require_org_access(str(body.org_id), user)  # Refuse a caller outside the target org
     from src.worker.tasks.audit_tasks import generate_compliance_pack
 
     generate_compliance_pack.delay(
@@ -184,9 +188,11 @@ async def create_compliance_pack(
     )
     import uuid as _uuid
 
+    pack_id = _uuid.uuid4()
+    logger.debug("create_compliance_pack: pack_id=%s queued for org_id=%s", pack_id, body.org_id)
     return ResponseEnvelope(
         data=CompliancePackResponse(
-            pack_id=_uuid.uuid4(),
+            pack_id=pack_id,
             status="generating",
             framework=body.framework,
         ),
@@ -197,17 +203,19 @@ async def create_compliance_pack(
 async def get_compliance_pack(
     pack_id: UUID,
     db: AsyncSession = Depends(get_db_session),
-    _user: CurrentUser = Depends(get_authenticated_user),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[CompliancePackResponse]:
-    """Poll compliance pack generation status."""
+    """Poll compliance pack generation status, scoped to the caller's org."""
+    logger.info("get_compliance_pack called for pack_id=%s by user=%s", pack_id, user.email)
     stmt = select(ComplianceAuditPack).where(
         ComplianceAuditPack.pack_id == pack_id,
     )
     row = (await db.execute(stmt)).scalar_one_or_none()
     if row is None:
         raise HTTPException(status_code=404, detail="Pack not found")
-
+    require_org_access(str(row.org_id), user)  # Refuse a caller outside the org of this pack
     included = row.included_records or {}
+    logger.debug("get_compliance_pack: pack_id=%s returned to user=%s", pack_id, user.email)
     return ResponseEnvelope(
         data=CompliancePackResponse(
             pack_id=row.pack_id,

--- a/mist-ops-platform/src/api/routes/sync.py
+++ b/mist-ops-platform/src/api/routes/sync.py
@@ -290,13 +290,22 @@ async def list_devices(
 async def get_device(
     device_id: UUID,
     db: AsyncSession = Depends(get_db_session),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[DeviceResponse]:
-    """Get a single device by ID."""
-    stmt = select(Device).where(Device.device_id == device_id)  # Single-row lookup
+    """Get a single device by ID, scoped to the caller's organizations."""
+    logger.info("get_device called for device_id=%s by user=%s", device_id, user.email)
+    stmt = select(Device).where(Device.device_id == device_id)  # Single-row lookup by device UUID
     row = (await db.execute(stmt)).scalar_one_or_none()  # 0 or 1 result
-    if not row:  # 404 path
+    if not row:  # 404 path — device does not exist
         raise HTTPException(status_code=404, detail="Device not found")
-    return ResponseEnvelope(data=_device_to_response(row))  # 200 path
+    require_org_access(str(row.org_id), user)  # Refuse a caller outside the org of this device
+    logger.debug(
+        "get_device: device_id=%s org_id=%s returned to user=%s",
+        device_id,
+        row.org_id,
+        user.email,
+    )  # Log device returned to confirm the scope check passed
+    return ResponseEnvelope(data=_device_to_response(row))  # 200 path — caller is in scope
 
 
 # ===================================================================
@@ -368,13 +377,16 @@ async def list_drift_alerts(
 async def get_drift_alert(
     alert_id: UUID,
     db: AsyncSession = Depends(get_db_session),
-    _user: CurrentUser = Depends(get_authenticated_user),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[DriftAlertDetail]:
-    """Get drift alert detail with full diff payload."""
+    """Get drift alert detail with full diff payload, scoped to the caller's org."""
+    logger.info("get_drift_alert called for alert_id=%s by user=%s", alert_id, user.email)
     stmt = select(DriftAlert).where(DriftAlert.alert_id == alert_id)  # Single-row lookup
     alert = (await db.execute(stmt)).scalar_one_or_none()  # 0 or 1
     if alert is None:  # 404 path
         raise HTTPException(status_code=404, detail="Alert not found")
+    require_org_access(str(alert.org_id), user)  # Refuse a caller outside the org of this alert
+    logger.debug("get_drift_alert: alert_id=%s returned to user=%s", alert_id, user.email)
     return ResponseEnvelope(data=DriftAlertDetail.model_validate(alert))
 
 
@@ -385,15 +397,22 @@ async def acknowledge_drift_alert(
     db: AsyncSession = Depends(get_db_session),
     user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[DriftAlertDetail]:
-    """Acknowledge a drift alert."""
+    """Acknowledge a drift alert, scoped to the caller's org."""
+    logger.info("acknowledge_drift_alert called for alert_id=%s by user=%s", alert_id, user.email)
     stmt = select(DriftAlert).where(DriftAlert.alert_id == alert_id)  # Look up alert
     alert = (await db.execute(stmt)).scalar_one_or_none()  # 0 or 1
     if alert is None:  # 404 path
         raise HTTPException(status_code=404, detail="Alert not found")
+    require_org_access(str(alert.org_id), user)  # Refuse a caller outside the org of this alert
     alert.status = "acknowledged"  # Flip state to acknowledged
     alert.resolved_by = user.email  # Track who acknowledged
     alert.resolved_at = datetime.now(UTC)  # Track when (UTC)
     await db.flush()  # Push changes to DB without committing the transaction
+    logger.debug(
+        "acknowledge_drift_alert: alert_id=%s acknowledged by user=%s",
+        alert_id,
+        user.email,
+    )  # Log acknowledgment to confirm the write completed
     return ResponseEnvelope(data=DriftAlertDetail.model_validate(alert))
 
 
@@ -456,9 +475,11 @@ async def list_policies(
 async def create_policy(
     body: PolicyCreate,
     db: AsyncSession = Depends(get_db_session),
-    _user: CurrentUser = Depends(get_authenticated_user),
+    user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[PolicyResponse]:
-    """Create a network policy."""
+    """Create a network policy, scoped to the caller's org."""
+    logger.info("create_policy called for org_id=%s by user=%s", body.org_id, user.email)
+    require_org_access(str(body.org_id), user)  # Refuse a caller outside the target org
     policy = NetworkPolicy(
         org_id=body.org_id,
         mist_entity_id=body.mist_entity_id,
@@ -471,6 +492,11 @@ async def create_policy(
     )  # Hydrate ORM object from request body
     db.add(policy)  # Stage insert
     await db.flush()  # Push to DB to populate generated columns
+    logger.debug(
+        "create_policy: policy_id=%s created for org_id=%s",
+        policy.policy_id,
+        body.org_id,
+    )  # Log creation to confirm the flush completed
     return ResponseEnvelope(data=PolicyResponse.model_validate(policy))
 
 
@@ -481,15 +507,23 @@ async def recertify_policy(
     db: AsyncSession = Depends(get_db_session),
     user: CurrentUser = Depends(get_authenticated_user),
 ) -> ResponseEnvelope[PolicyResponse]:
-    """Recertify a policy before expiration."""
+    """Recertify a policy before expiration, scoped to the caller's org."""
+    logger.info("recertify_policy called for policy_id=%s by user=%s", policy_id, user.email)
     if not body.confirm:  # Reject unconfirmed recertify
         raise HTTPException(status_code=400, detail="confirm required")
     stmt = select(NetworkPolicy).where(NetworkPolicy.policy_id == policy_id)  # Look up policy
     policy = (await db.execute(stmt)).scalar_one_or_none()  # 0 or 1
     if policy is None:  # 404 path
         raise HTTPException(status_code=404, detail="Policy not found")
+    require_org_access(str(policy.org_id), user)  # Refuse a caller outside the org of this policy
     policy.last_reviewed_at = datetime.now(UTC)  # Stamp review time
     policy.reviewed_by = user.email  # Track who reviewed
     policy.version = policy.version + 1  # Bump version
     await db.flush()  # Push update
+    logger.debug(
+        "recertify_policy: policy_id=%s version=%s by user=%s",
+        policy_id,
+        policy.version,
+        user.email,
+    )  # Log recertification to confirm the bump completed
     return ResponseEnvelope(data=PolicyResponse.model_validate(policy))

--- a/mist-ops-platform/tests/unit/api/test_org_scope_dependency.py
+++ b/mist-ops-platform/tests/unit/api/test_org_scope_dependency.py
@@ -77,6 +77,132 @@ def _calls_a_scope_check(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
     return False
 
 
+def _has_auth_dependency(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Return True when the function declares an authentication dependency.
+
+    A route without this dependency is fully anonymous. The platform accepts
+    both get_authenticated_user and get_scoped_org_id as valid auth dependencies.
+    get_scoped_org_id calls get_authenticated_user internally, so either form
+    satisfies the authentication requirement.
+    """
+    auth_deps = {"get_authenticated_user", "get_scoped_org_id"}  # Both forms satisfy auth
+    all_args = node.args.args + node.args.kwonlyargs  # Every named parameter
+    all_defaults = (
+        ([None] * (len(node.args.args) - len(node.args.defaults)))
+        + list(node.args.defaults)
+        + list(node.args.kw_defaults)
+    )  # Align defaults with arguments
+    for arg, default in zip(all_args, all_defaults):  # Walk each arg-default pair
+        if default is None:  # No default means no Depends
+            continue
+        if not (isinstance(default, ast.Call) and getattr(default.func, "id", "") == "Depends"):
+            continue  # Not a Depends() call
+        dep_args = default.args  # The argument passed to Depends(...)
+        if not dep_args:  # Depends called with no positional arg
+            continue
+        dep_name = getattr(dep_args[0], "id", "")  # Simple name, e.g. get_authenticated_user
+        if dep_name in auth_deps:  # Found an accepted authentication dependency
+            return True
+    return False
+
+
+def _is_route_handler(node: ast.FunctionDef | ast.AsyncFunctionDef, tree: ast.Module) -> bool:
+    """Return True when the function is decorated with a router method decorator."""
+    router_methods = {"get", "post", "put", "patch", "delete"}  # HTTP method decorator names
+    for decorator in node.decorator_list:  # Walk all decorators on this function
+        if not isinstance(decorator, ast.Call):  # Only decorated calls count
+            continue
+        func = decorator.func  # The decorator itself
+        method = getattr(func, "attr", None)  # e.g. router.get -> "get"
+        if method in router_methods:  # Matches an HTTP method
+            return True
+    return False
+
+
+def _get_route_handlers_without_auth(path: pathlib.Path) -> list[str]:
+    """Return function names that are route handlers with no auth dependency."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))  # Parse the source without importing it
+    offenders: list[str] = []  # Collect handlers that lack authentication
+    for node in ast.walk(tree):  # Visit every AST node
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue  # Only functions can be route handlers
+        if not _is_route_handler(node, tree):  # Skip non-route functions
+            continue
+        if not _has_auth_dependency(node):  # Route has no authentication dependency
+            offenders.append(node.name)  # Record the offender
+    return offenders
+
+
+def _default_is_depends(default: ast.expr | None) -> bool:
+    """Return True when the default value is a Depends() call.
+
+    FastAPI dependency parameters use Depends(func) as their default value.
+    Body parameters have no default or use a Body() literal. Only body
+    parameters need the require_org_access check.
+    """
+    if default is None:  # No default value
+        return False
+    if not isinstance(default, ast.Call):  # Not a function call
+        return False
+    func_name = getattr(default.func, "id", None)  # Simple function name
+    return func_name == "Depends"  # True only for Depends(...)
+
+
+def _body_org_id_without_scope_check(path: pathlib.Path) -> list[str]:
+    """Return handler names that accept a body model with org_id but skip the scope check.
+
+    A handler that reads org_id from a body parameter passes the guard only
+    when its body calls require_org_access or _resolve_org_ids. Without that
+    call, any authenticated caller supplies any org_id and writes into that org.
+
+    Parameters with a Depends(...) default are FastAPI dependencies, not body
+    parameters. Those are excluded because the dependency performs its own
+    scope check through get_scoped_org_id or require_org_access.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))  # Parse without importing
+    body_org_id_models: set[str] = set()  # Names of models that carry org_id
+    for node in ast.walk(tree):  # Collect class definitions first
+        if not isinstance(node, ast.ClassDef):
+            continue  # Only classes can be models
+        ann_names = {
+            stmt.target.id
+            for stmt in node.body
+            if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
+        }  # Collect annotated assignments (e.g. org_id: UUID)
+        assign_names = {
+            stmt.targets[0].id
+            for stmt in node.body
+            if isinstance(stmt, ast.Assign) and isinstance(stmt.targets[0], ast.Name)
+        }  # Collect plain assignments too
+        if "org_id" in (ann_names | assign_names):  # This model carries org_id
+            body_org_id_models.add(node.name)
+    offenders: list[str] = []  # Handlers that accept a body org_id without the check
+    for node in ast.walk(tree):  # Walk only route handlers
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue  # Only handlers matter
+        if not _is_route_handler(node, tree):  # Skip helper functions
+            continue
+        if _calls_a_scope_check(node):  # Handler already performs its own check
+            continue
+        all_args = node.args.args + node.args.kwonlyargs  # Every named parameter
+        all_defaults = (
+            ([None] * (len(node.args.args) - len(node.args.defaults)))
+            + list(node.args.defaults)
+            + list(node.args.kw_defaults)
+        )  # Align defaults with argument positions
+        for arg, default in zip(all_args, all_defaults):  # Walk arg-default pairs
+            if _default_is_depends(default):  # Depends() params are FastAPI dependencies
+                continue
+            annotation = arg.annotation  # The type annotation of this parameter
+            if annotation is None:  # No type annotation
+                continue
+            ann_name = getattr(annotation, "id", None)  # Simple name, e.g. ExportRequest
+            if ann_name in body_org_id_models:  # Parameter type carries org_id
+                offenders.append(node.name)
+                break  # One match per handler is enough
+    return offenders
+
+
 def test_no_route_reads_org_id_from_query() -> None:
     """Assert that every route reads ``org_id`` through the scope dependency.
 
@@ -92,6 +218,48 @@ def test_no_route_reads_org_id_from_query() -> None:
     assert offenders == {}, (  # Report every offender at once, so one run shows all the work
         "These routes read org_id straight from Query and skip the membership "
         f"check. Use Depends(get_scoped_org_id) instead: {offenders}"
+    )
+
+
+# Health and webhook routes do not expose tenant data, so they are exempt from authentication.
+_AUTH_EXEMPT_MODULES = {"health.py", "webhooks.py", "__init__.py"}  # Modules that may omit auth
+
+
+def test_no_route_handler_is_anonymous() -> None:
+    """Assert that every data route handler declares get_authenticated_user.
+
+    A handler without an authentication dependency is fully anonymous. Any
+    caller who reaches the port can read or write data without a token. This
+    test catches the pattern before it reaches the branch.
+    """
+    offenders: dict[str, list[str]] = {}  # Map a module name to its offending handlers
+    for module in sorted(ROUTES_DIR.glob("*.py")):  # Read every route module
+        if module.name in _AUTH_EXEMPT_MODULES:  # Skip exempt modules
+            continue
+        found = _get_route_handlers_without_auth(module)  # Collect handlers with no auth
+        if found:  # Only record a module that holds an offender
+            offenders[module.name] = found
+    assert offenders == {}, (
+        "These route handlers have no authentication dependency and are fully anonymous. "
+        f"Add user: CurrentUser = Depends(get_authenticated_user): {offenders}"
+    )
+
+
+def test_no_handler_accepts_body_org_id_without_scope_check() -> None:
+    """Assert that every handler that accepts a body org_id calls require_org_access.
+
+    A handler that reads org_id from a request body and never calls
+    require_org_access lets any authenticated caller write data into any
+    organization. This test catches the pattern before it reaches the branch.
+    """
+    offenders: dict[str, list[str]] = {}  # Map a module name to its offending handlers
+    for module in sorted(ROUTES_DIR.glob("*.py")):  # Read every route module
+        found = _body_org_id_without_scope_check(module)  # Collect the offenders
+        if found:  # Only record a module that holds an offender
+            offenders[module.name] = found
+    assert offenders == {}, (
+        "These handlers accept a body with org_id but never call require_org_access. "
+        f"Add require_org_access(str(body.org_id), user) before writing data: {offenders}"
     )
 
 


### PR DESCRIPTION
Fixes #2018
Fixes #2019
Fixes #2020

Eight routes loaded or wrote records without an org membership check. This PR adds require_org_access to all eight and extends the AST guards to prevent regression.

## Routes fixed
- GET /inventory/devices/{id}: added get_authenticated_user + require_org_access
- POST /policies: added require_org_access(body.org_id)
- GET /drift/alerts/{id}: added require_org_access(alert.org_id)
- POST /drift/alerts/{id}/acknowledge: added require_org_access(alert.org_id)
- POST /policies/{id}/recertify: added require_org_access(policy.org_id)
- POST /audit/export: added require_org_access(body.org_id)
- POST /audit/compliance-packs: added require_org_access(body.org_id)
- GET /audit/compliance-packs/{id}: added require_org_access(row.org_id)

## AST guards added (issue #2020)
test_no_route_handler_is_anonymous and test_no_handler_accepts_body_org_id_without_scope_check

## Gate results: ruff 60 errors (baseline 61), black clean, pytest 338 passed 0 failed