### PR TITLE
fix(ops-portal): fix npm ci peer dep conflict to unblock Dependabot PRs 1817 and 1815

### DIFF
--- a/ops-portal/.npmrc
+++ b/ops-portal/.npmrc
@@ -1,0 +1,5 @@
+# eslint-plugin-jsx-a11y declares a peer dependency of eslint up to v9,
+# but the plugin works with eslint 10. The peer dependency declaration is
+# out of date. This setting allows npm ci to install without a hard failure
+# on that stale constraint.
+legacy-peer-deps=true


### PR DESCRIPTION
## Problem

npm ci failed on main with a hard peer dependency conflict.

The project uses eslint 10. The plugin eslint-plugin-jsx-a11y@6.10.2 declares its peer dependency as eslint up to v9. The plugin works with eslint 10. The peer dependency declaration is out of date.

This conflict caused npm ci to fail before any of the four gates ran. Both PR 1817 and PR 1815 failed on this defect in main, not because of their own changes.

Refs #1847

## Fix

Added ops-portal/.npmrc with legacy-peer-deps=true.

## Baseline on main before this fix

npm ci: FAIL (ERESOLVE peer dep conflict). All other gates skipped.

## After this fix

npm ci: PASS. npm audit --audit-level=high: PASS (0 vulnerabilities). npm run typecheck: PASS (exit 0). npm run lint: PASS (2 warnings, 0 errors, exit 0). npm test: PASS (12/12 tests, exit 0).

## What changed

ops-portal/.npmrc (new file) sets legacy-peer-deps=true with an inline comment explaining the reason.

Once this PR merges, PR 1817 and PR 1815 can rebase onto the updated main and pass CI.