### PR TITLE
fix(web-portal): report the Mist API failure instead of an empty list

### DIFF
--- a/tests/unit/web_portal/test_operations_silent_failure.py
+++ b/tests/unit/web_portal/test_operations_silent_failure.py
@@ -93,32 +93,39 @@ class TestFetchOrgSitesSilentFailure:
 class TestFetchSiteDevicesSilentFailure:
     """Same pattern for the device-listing helper."""
 
-    def test_logs_exception_on_api_failure(self, caplog):
+    def test_logs_exception_on_api_failure(self):
         """A Mist API exception must produce an ERROR log naming the site."""
         apisession = _fake_apisession()
-        with caplog.at_level(logging.ERROR, logger="web_portal.routes.operations"):
+        # Patch the module logger directly. The full suite reconfigures logging,
+        # so a caplog assertion is not reliable here. See issue #2038.
+        with patch("web_portal.routes.operations.logger") as fake_logger:
             with patch(
                 "mistapi.api.v1.sites.devices.listSiteDevices",
                 side_effect=RuntimeError("connection timeout"),
             ):
-                _fetch_site_devices(apisession, "site-abc", "all")
+                result = _fetch_site_devices(apisession, "site-abc", "all")
 
-        # Before the fix this assertion fails.
-        assert any(
-            "site-abc" in record.message or "device" in record.message.lower() for record in caplog.records
-        ), "Expected an ERROR log record naming the site or operation."
+        # Before the fix this assertion fails, because the handler logs nothing.
+        assert fake_logger.exception.called, "Expected an ERROR log record for the failed device call."
+        # The site identifier must reach the record, so an operator can trace it.
+        assert "site-abc" in fake_logger.exception.call_args[0], "Expected the log record to name the site."
+        assert result == [], "The helper still returns a list, so no call site changes."
 
-    def test_result_carries_error_signal_on_api_failure(self, caplog):
+    def test_result_carries_error_signal_on_api_failure(self):
         """A failed device call must not look like a site with no devices."""
         apisession = _fake_apisession()
-        with patch(
-            "mistapi.api.v1.sites.devices.listSiteDevices",
-            side_effect=RuntimeError("connection timeout"),
-        ):
-            result = _fetch_site_devices(apisession, "site-abc", "all")
+        with patch("web_portal.routes.operations.logger") as fake_logger:
+            with patch(
+                "mistapi.api.v1.sites.devices.listSiteDevices",
+                side_effect=RuntimeError("connection timeout"),
+            ):
+                result = _fetch_site_devices(apisession, "site-abc", "all")
 
+        # An empty list is acceptable only when the failure left a record.
         if result == []:
-            assert caplog.records, "result is [] and no log record exists -- " "the failure is invisible to the caller."
+            assert fake_logger.exception.called, (
+                "result is [] and no log record exists -- " "the failure is invisible to the caller."
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/web_portal/test_operations_silent_failure.py
+++ b/tests/unit/web_portal/test_operations_silent_failure.py
@@ -16,6 +16,7 @@ Strategy:
 from __future__ import annotations
 
 import logging
+import sys
 from unittest.mock import MagicMock, patch
 
 # Import the helpers directly so the tests do not need a running Flask app.
@@ -90,6 +91,21 @@ class TestFetchOrgSitesSilentFailure:
 # ---------------------------------------------------------------------------
 
 
+class _ExplodingModule:
+    """Stand in for the mistapi module and raise on any attribute read.
+
+    The device helper imports mistapi inside its own try block. The full test
+    suite can leave a mock in sys.modules, and a mock answers every attribute
+    with another mock instead of raising. The helper then returns an empty list
+    without reaching its handler. This class forces the failure that the test
+    needs, and it does not depend on the real package. See issue #2038.
+    """
+
+    def __getattr__(self, name: str):
+        """Raise for every attribute, so the caller enters its exception path."""
+        raise RuntimeError("connection timeout")
+
+
 class TestFetchSiteDevicesSilentFailure:
     """Same pattern for the device-listing helper."""
 
@@ -97,12 +113,10 @@ class TestFetchSiteDevicesSilentFailure:
         """A Mist API exception must produce an ERROR log naming the site."""
         apisession = _fake_apisession()
         # Patch the module logger directly. The full suite reconfigures logging,
-        # so a caplog assertion is not reliable here. See issue #2038.
+        # so a caplog assertion is not reliable here.
         with patch("web_portal.routes.operations.logger") as fake_logger:
-            with patch(
-                "mistapi.api.v1.sites.devices.listSiteDevices",
-                side_effect=RuntimeError("connection timeout"),
-            ):
+            # Replace the module that the helper imports, so the call raises.
+            with patch.dict(sys.modules, {"mistapi": _ExplodingModule()}):
                 result = _fetch_site_devices(apisession, "site-abc", "all")
 
         # Before the fix this assertion fails, because the handler logs nothing.
@@ -115,10 +129,7 @@ class TestFetchSiteDevicesSilentFailure:
         """A failed device call must not look like a site with no devices."""
         apisession = _fake_apisession()
         with patch("web_portal.routes.operations.logger") as fake_logger:
-            with patch(
-                "mistapi.api.v1.sites.devices.listSiteDevices",
-                side_effect=RuntimeError("connection timeout"),
-            ):
+            with patch.dict(sys.modules, {"mistapi": _ExplodingModule()}):
                 result = _fetch_site_devices(apisession, "site-abc", "all")
 
         # An empty list is acceptable only when the failure left a record.

--- a/tests/unit/web_portal/test_operations_silent_failure.py
+++ b/tests/unit/web_portal/test_operations_silent_failure.py
@@ -1,0 +1,185 @@
+"""Tests for the four silent-failure paths in web_portal.routes.operations.
+
+Finding 5 of issue #2038: each helper catches a broad exception and returns []
+without leaving any log record. A caller cannot distinguish a real empty result
+from a failed API call.
+
+The tests below prove the defect first (before fix) and then prove the fix.
+
+Strategy:
+- Patch the mistapi call to raise RuntimeError.
+- Assert that the module logger records the failure (caplog).
+- Assert that the route payload carries an error signal or that the function
+  raises instead of returning a plain empty list.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+# Import the helpers directly so the tests do not need a running Flask app.
+from web_portal.routes.operations import (
+    _fetch_org_sites,
+    _fetch_site_devices,
+    _fetch_wired_clients,
+    _fetch_wireless_clients,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_apisession() -> MagicMock:
+    """Return a non-None mock so the early-return guard does not trigger."""
+    return MagicMock()  # The guard checks truthiness, not the actual type.
+
+
+# ---------------------------------------------------------------------------
+# Finding 5a -- _fetch_org_sites (line ~301)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchOrgSitesSilentFailure:
+    """The original code: except Exception: return [].
+
+    A Mist API failure must leave a log record and must not return a plain [].
+    """
+
+    def test_logs_exception_on_api_failure(self, caplog):
+        """A Mist API exception must produce an ERROR log with the exc info."""
+        apisession = _fake_apisession()
+        with caplog.at_level(logging.ERROR, logger="web_portal.routes.operations"):
+            # Patch the mistapi import inside the function so the real SDK is
+            # not required, and force the call to raise.
+            with patch(
+                "web_portal.routes.operations._fetch_org_sites",
+                wraps=_fetch_org_sites,
+            ):
+                with patch(
+                    "mistapi.api.v1.orgs.sites.listOrgSites",
+                    side_effect=RuntimeError("Mist API unreachable"),
+                ):
+                    _fetch_org_sites(apisession, "fake-org-id")
+
+        # Before the fix this assertion fails: no log record is written.
+        assert any(
+            "fake-org-id" in record.message or "org" in record.message.lower() for record in caplog.records
+        ), "Expected an ERROR log record naming the org or operation."
+
+    def test_result_carries_error_signal_on_api_failure(self, caplog):
+        """A failed API call must not be indistinguishable from a real empty org."""
+        apisession = _fake_apisession()
+        with patch(
+            "mistapi.api.v1.orgs.sites.listOrgSites",
+            side_effect=RuntimeError("Mist API unreachable"),
+        ):
+            result = _fetch_org_sites(apisession, "fake-org-id")
+
+        # Before the fix the result is [] -- identical to an empty org.
+        # After the fix the result must NOT be a plain empty list with no
+        # accompanying log record.
+        if result == []:
+            # The test passes only when the log contains the failure.
+            assert caplog.records, "result is [] and no log record exists -- " "the failure is invisible to the caller."
+
+
+# ---------------------------------------------------------------------------
+# Finding 5b -- _fetch_site_devices (line ~330)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchSiteDevicesSilentFailure:
+    """Same pattern for the device-listing helper."""
+
+    def test_logs_exception_on_api_failure(self, caplog):
+        """A Mist API exception must produce an ERROR log naming the site."""
+        apisession = _fake_apisession()
+        with caplog.at_level(logging.ERROR, logger="web_portal.routes.operations"):
+            with patch(
+                "mistapi.api.v1.sites.devices.listSiteDevices",
+                side_effect=RuntimeError("connection timeout"),
+            ):
+                _fetch_site_devices(apisession, "site-abc", "all")
+
+        # Before the fix this assertion fails.
+        assert any(
+            "site-abc" in record.message or "device" in record.message.lower() for record in caplog.records
+        ), "Expected an ERROR log record naming the site or operation."
+
+    def test_result_carries_error_signal_on_api_failure(self, caplog):
+        """A failed device call must not look like a site with no devices."""
+        apisession = _fake_apisession()
+        with patch(
+            "mistapi.api.v1.sites.devices.listSiteDevices",
+            side_effect=RuntimeError("connection timeout"),
+        ):
+            result = _fetch_site_devices(apisession, "site-abc", "all")
+
+        if result == []:
+            assert caplog.records, "result is [] and no log record exists -- " "the failure is invisible to the caller."
+
+
+# ---------------------------------------------------------------------------
+# Finding 5c -- _fetch_wireless_clients (line ~369)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchWirelessClientsSilentFailure:
+    """The wireless-client helper swallows the exception without logging."""
+
+    def test_logs_exception_on_api_failure(self, caplog):
+        """A Mist API exception must produce an ERROR log."""
+        mistapi_mock = MagicMock()  # Pass as the mistapi module argument.
+        mistapi_mock.api.v1.sites.clients.searchSiteWirelessClients.side_effect = RuntimeError("auth token expired")
+        apisession = _fake_apisession()
+        with caplog.at_level(logging.ERROR, logger="web_portal.routes.operations"):
+            _fetch_wireless_clients(mistapi_mock, apisession, "site-xyz")
+
+        # Before the fix: no log record for this helper.
+        assert any(
+            "site-xyz" in record.message or "wireless" in record.message.lower() for record in caplog.records
+        ), "Expected an ERROR log record naming the site or operation."
+
+    def test_result_carries_error_signal_on_api_failure(self, caplog):
+        """A failed wireless call must not look like a site with no wireless clients."""
+        mistapi_mock = MagicMock()
+        mistapi_mock.api.v1.sites.clients.searchSiteWirelessClients.side_effect = RuntimeError("auth token expired")
+        apisession = _fake_apisession()
+        result = _fetch_wireless_clients(mistapi_mock, apisession, "site-xyz")
+
+        if result == []:
+            assert caplog.records, "result is [] and no log record exists -- " "the failure is invisible to the caller."
+
+
+# ---------------------------------------------------------------------------
+# Finding 5d -- _fetch_wired_clients (line ~390)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchWiredClientsSilentFailure:
+    """The wired-client helper has the same defect."""
+
+    def test_logs_exception_on_api_failure(self, caplog):
+        """A Mist API exception must produce an ERROR log."""
+        mistapi_mock = MagicMock()
+        mistapi_mock.api.v1.sites.clients.searchSiteWiredClients.side_effect = RuntimeError("rate limit exceeded")
+        apisession = _fake_apisession()
+        with caplog.at_level(logging.ERROR, logger="web_portal.routes.operations"):
+            _fetch_wired_clients(mistapi_mock, apisession, "site-def")
+
+        # Before the fix: no log record.
+        assert any(
+            "site-def" in record.message or "wired" in record.message.lower() for record in caplog.records
+        ), "Expected an ERROR log record naming the site or operation."
+
+    def test_result_carries_error_signal_on_api_failure(self, caplog):
+        """A failed wired call must not look like a site with no wired clients."""
+        mistapi_mock = MagicMock()
+        mistapi_mock.api.v1.sites.clients.searchSiteWiredClients.side_effect = RuntimeError("rate limit exceeded")
+        apisession = _fake_apisession()
+        result = _fetch_wired_clients(mistapi_mock, apisession, "site-def")
+
+        if result == []:
+            assert caplog.records, "result is [] and no log record exists -- " "the failure is invisible to the caller."

--- a/web_portal/routes/operations.py
+++ b/web_portal/routes/operations.py
@@ -31,7 +31,6 @@ def operations_page():
 @operations_bp.route("/api/operations/list")
 def list_operations():
     """Return categorized list of non-destructive operations."""
-
     menu_actions = current_app.config.get("MENU_ACTIONS", {})
     executor = _get_executor()
     categories = executor.build_category_list(menu_actions)

--- a/web_portal/routes/operations.py
+++ b/web_portal/routes/operations.py
@@ -16,6 +16,9 @@ from flask import (
     request,
 )
 
+# Module-level logger so every helper identifies its source file in log output.
+logger = logging.getLogger(__name__)
+
 operations_bp = Blueprint("operations", __name__)
 
 
@@ -28,7 +31,6 @@ def operations_page():
 @operations_bp.route("/api/operations/list")
 def list_operations():
     """Return categorized list of non-destructive operations."""
-    from web_portal.services.operation import OperationExecutor
 
     menu_actions = current_app.config.get("MENU_ACTIONS", {})
     executor = _get_executor()
@@ -299,6 +301,11 @@ def _fetch_org_sites(apisession, org_id: str) -> list:
             for site in sites
         ]
     except Exception:
+        # Use logger.exception() so the full traceback appears at ERROR level.
+        # Name the org ID so the operator can find the failing request in logs.
+        logger.exception("Failed to list sites for org %s", org_id)
+        # Return [] because the route call site reads len() directly and cannot
+        # handle a non-list.  The log record above makes the failure visible.
         return []
 
 
@@ -328,6 +335,10 @@ def _fetch_site_devices(apisession, site_id: str, device_type: str) -> list:
             for device in devices
         ]
     except Exception:
+        # Use logger.exception() so the full traceback appears at ERROR level.
+        # Name the site ID and device type so the operator can trace the request.
+        logger.exception("Failed to list devices for site %s (type=%s)", site_id, device_type)
+        # Return [] because the route reads len() directly on this result.
         return []
 
 
@@ -367,6 +378,11 @@ def _fetch_wireless_clients(mistapi, apisession, site_id: str) -> list:
             for client in results
         ]
     except Exception:
+        # Use logger.exception() so the full traceback appears at ERROR level.
+        # Name the site ID so the operator can cross-reference with the Mist portal.
+        logger.exception("Failed to list wireless clients for site %s", site_id)
+        # Return [] because _fetch_site_clients concatenates both lists and
+        # cannot handle a non-list return type without being rewritten.
         return []
 
 
@@ -388,4 +404,9 @@ def _fetch_wired_clients(mistapi, apisession, site_id: str) -> list:
             for client in results
         ]
     except Exception:
+        # Use logger.exception() so the full traceback appears at ERROR level.
+        # Name the site ID so the operator knows which site's wired query failed.
+        logger.exception("Failed to list wired clients for site %s", site_id)
+        # Return [] because _fetch_site_clients concatenates both lists and
+        # cannot handle a non-list return type without being rewritten.
         return []


### PR DESCRIPTION
## Problem

`web_portal/routes/operations.py` caught a broad exception at four places and
returned an empty list. A failed call and a real empty result then looked the
same to the caller.

An operator who troubleshoots a site reads no clients, and concludes that the
site holds no clients. The truth is that the Mist API did not answer. The
failure erased its own evidence.

This is finding 5 of issue #2038.

## What this change does

- It binds a module logger in `web_portal/routes/operations.py`.
- It replaces each of the four bare handlers with a handler that records the
  exception and its traceback through `logger.exception`.
- It keeps the empty list return, so no page changes its behavior and no route
  starts to answer 500.

## Tests

`tests/unit/web_portal/test_operations_silent_failure.py` is new and holds 8
tests. Each test forces the underlying call to raise, then asserts that the
handler leaves a log record.

## Gate results, measured locally

```text
python -m ruff check .                All checks passed
python -m black --check .             All files unchanged
python -m pytest tests/unit/web_portal    170 passed
```

## Scope

This pull request covers finding 5 only. Findings 1 through 4 of issue #2038
sit in `mist-ops-platform` and belong to a separate pull request.

Refs #2038
