### PR TITLE
fix(ops-platform): record the reason on every silent failure path

### DIFF
--- a/mist-ops-platform/src/api/routes/health.py
+++ b/mist-ops-platform/src/api/routes/health.py
@@ -39,19 +39,42 @@ async def readyz(request: Request) -> dict[str, str]:
     """Readiness probe — verifies database connectivity."""
     engine = getattr(request.app.state, "engine", None)
     if engine is None:
+        # WHY: an operator cannot diagnose a probe failure without a cause.
+        logger.warning("Readiness probe failed. The database engine is absent from app state.")
         return {"status": "unavailable"}
     try:
         async with engine.connect() as conn:
             await conn.execute(__import__("sqlalchemy").text("SELECT 1"))
         return {"status": "ready"}
     except Exception:
+        # WHY: log the exception so the traceback reaches the operator, not just the word.
+        logger.warning(
+            "Readiness probe failed. The database query raised an exception.",
+            exc_info=True,
+        )
         return {"status": "unavailable"}
 
 
 @router.get("/metrics")
-async def metrics() -> dict[str, str]:
-    """Placeholder for Prometheus metrics export."""
-    return {"status": "metrics_placeholder"}
+async def metrics() -> None:
+    """Reject Prometheus scrapes until real metrics are exported.
+
+    The route previously answered 200 with a fixed body. A Prometheus
+    scrape then recorded a healthy target with no series, so no alert
+    could fire. Answering 501 makes the gap visible to every scraper.
+    """
+    # WHY: warn on every call so the gap is visible in the application log.
+    logger.warning(
+        "The /metrics route is not implemented. Real Prometheus series are not exported yet."
+        " Returning 501 so the scrape fails loudly."
+    )
+    # WHY: raise HTTPException so FastAPI returns 501 with a JSON detail body.
+    from fastapi import HTTPException
+
+    raise HTTPException(
+        status_code=501,
+        detail="Prometheus metrics export is not implemented. No series are available.",
+    )
 
 
 # -- Notification channel schemas ----------------------------------------

--- a/mist-ops-platform/src/worker/checks/post_checks.py
+++ b/mist-ops-platform/src/worker/checks/post_checks.py
@@ -133,18 +133,31 @@ class PostCheckService:
         org_id: str,
         target_ids: list[str],
     ) -> list[CheckResult]:
-        """Verify client count is within expected range (placeholder).
+        """Return a skipped result for every target.
 
-        Future: compare pre-deploy client count with post-deploy
-        and flag if significant drop detected.
+        The check requires a pre-deployment client count to compare against
+        a post-deployment count. That count is not passed into this method
+        yet. Returning a non-passing result prevents the caller from
+        recording an unverified pass.
+
+        Future: when pre-deploy client counts are passed in, replace this
+        block with a real comparison and flag a significant drop.
         """
         results: list[CheckResult] = []
         for device_id in target_ids:
+            # WHY: warn once per device so the operator sees which check never ran.
+            logger.warning(
+                "Client connectivity check skipped for device %s in org %s."
+                " No pre-deployment client count is available to compare.",
+                device_id,
+                org_id,
+            )
+            # WHY: passed=False stops a caller from recording this as a verified pass.
             results.append(
                 CheckResult(
                     name=f"client_connectivity:{device_id}",
-                    passed=True,
-                    message="Client connectivity check passed (basic)",
+                    passed=False,
+                    message=("Client connectivity check skipped." " No pre-deployment client count is available."),
                 )
             )
         return results

--- a/mist-ops-platform/src/worker/checks/pre_checks.py
+++ b/mist-ops-platform/src/worker/checks/pre_checks.py
@@ -150,18 +150,31 @@ class PreCheckService:
         org_id: str,
         target_ids: list[str],
     ) -> list[CheckResult]:
-        """Verify firmware version compatibility (placeholder).
+        """Return a skipped result for every target.
 
-        Future: compare target config requirements against device
-        firmware version to catch incompatible settings.
+        The check requires a firmware version from the device record and a
+        target firmware string from the deployment job. Neither input is
+        available on this call path yet. Returning a non-passing result
+        prevents the caller from recording an unverified pass.
+
+        Future: when target firmware is passed into this method, replace
+        this block with a real version comparison.
         """
         results: list[CheckResult] = []
         for device_id in target_ids:
+            # WHY: warn once per device so the operator sees which check never ran.
+            logger.warning(
+                "Version compatibility check skipped for device %s in org %s."
+                " The target firmware version is not available on this call path.",
+                device_id,
+                org_id,
+            )
+            # WHY: passed=False stops a caller from recording this as a verified pass.
             results.append(
                 CheckResult(
                     name=f"version_compat:{device_id}",
-                    passed=True,
-                    message="Version compatibility check passed (basic)",
+                    passed=False,
+                    message=("Version compatibility check skipped." " The target firmware version is not available."),
                 )
             )
         return results

--- a/mist-ops-platform/tests/unit/api/test_health.py
+++ b/mist-ops-platform/tests/unit/api/test_health.py
@@ -1,0 +1,126 @@
+"""Tests proving the health route silent failures now leave a record.
+
+Issue #2038, findings 1 and 2.
+Finding 1: /readyz logged nothing on both failure paths.
+Finding 2: /metrics answered 200 with a placeholder body.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+# WHY: import the router so we can mount a minimal FastAPI app for tests.
+from fastapi import FastAPI
+
+from src.api.routes.health import router
+
+
+def _build_app(engine: object | None = None) -> FastAPI:
+    """Build a minimal FastAPI app with the health router and optional engine."""
+    app = FastAPI()  # WHY: a real FastAPI instance keeps middleware wiring intact.
+    app.include_router(router)  # WHY: attach the health routes under test.
+    app.state.engine = engine  # WHY: the readyz handler reads this attribute.
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Finding 1: /readyz silent failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestReadyzLogsOnMissingEngine:
+    """Prove that /readyz logs a warning when the engine is absent."""
+
+    def test_missing_engine_emits_a_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        # WHY: build an app with no engine so the first failure path triggers.
+        app = _build_app(engine=None)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        with caplog.at_level(logging.WARNING, logger="src.api.routes.health"):
+            response = client.get("/readyz")  # WHY: call the probe directly.
+
+        # WHY: the response contract must not change.
+        assert response.status_code == 200
+        assert response.json() == {"status": "unavailable"}
+        # WHY: the bug was silence. The fix must produce at least one warning record.
+        assert any(r.levelno >= logging.WARNING for r in caplog.records), (
+            "Expected a WARNING on the missing-engine path but the log was empty."
+        )
+
+
+class TestReadyzLogsOnQueryFailure:
+    """Prove that /readyz logs the exception when the database query fails."""
+
+    def test_query_failure_emits_exception_info(self, caplog: pytest.LogCaptureFixture) -> None:
+        # WHY: supply a fake engine whose connect raises, so the except branch runs.
+        fake_conn = AsyncMock()
+        fake_conn.execute.side_effect = RuntimeError("connection refused")
+
+        # WHY: the async context manager must deliver the fake conn object.
+        fake_conn_ctx = AsyncMock()
+        fake_conn_ctx.__aenter__.return_value = fake_conn
+        fake_conn_ctx.__aexit__.return_value = False
+
+        fake_engine = MagicMock()
+        fake_engine.connect.return_value = fake_conn_ctx
+
+        app = _build_app(engine=fake_engine)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        with caplog.at_level(logging.WARNING, logger="src.api.routes.health"):
+            response = client.get("/readyz")  # WHY: call the probe with a broken engine.
+
+        # WHY: the response contract must not change.
+        assert response.status_code == 200
+        assert response.json() == {"status": "unavailable"}
+        # WHY: the fix must record the exception, not swallow it.
+        has_exc_info = any(
+            r.levelno >= logging.WARNING and r.exc_info for r in caplog.records
+        )
+        has_error_text = any(
+            "connection refused" in r.getMessage().lower() or "connection refused" in str(r.exc_info).lower()
+            for r in caplog.records
+            if r.exc_info
+        )
+        assert has_exc_info or has_error_text, (
+            "Expected the query exception to appear in the log, but it was absent."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Finding 2: /metrics must not answer 200 while delivering nothing
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsAnswers501:
+    """Prove that /metrics answers 501 instead of 200."""
+
+    def test_metrics_returns_501(self) -> None:
+        # WHY: an app with no engine is fine here because metrics does not use it.
+        app = _build_app()
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.get("/metrics")  # WHY: call the placeholder endpoint.
+
+        # WHY: 200 hides the gap from monitoring. The fix must return 501.
+        assert response.status_code == 501, (
+            f"Expected HTTP 501 from /metrics but received {response.status_code}."
+        )
+
+    def test_metrics_emits_a_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        # WHY: every scrape should announce the gap in the log.
+        app = _build_app()
+        client = TestClient(app, raise_server_exceptions=False)
+
+        with caplog.at_level(logging.WARNING, logger="src.api.routes.health"):
+            client.get("/metrics")  # WHY: call the route to trigger the log.
+
+        # WHY: a silent placeholder is the bug. The fix must produce a warning.
+        assert any(r.levelno >= logging.WARNING for r in caplog.records), (
+            "Expected a WARNING from /metrics but the log was empty."
+        )

--- a/mist-ops-platform/tests/unit/api/test_health.py
+++ b/mist-ops-platform/tests/unit/api/test_health.py
@@ -48,9 +48,9 @@ class TestReadyzLogsOnMissingEngine:
         assert response.status_code == 200
         assert response.json() == {"status": "unavailable"}
         # WHY: the bug was silence. The fix must produce at least one warning record.
-        assert any(r.levelno >= logging.WARNING for r in caplog.records), (
-            "Expected a WARNING on the missing-engine path but the log was empty."
-        )
+        assert any(
+            r.levelno >= logging.WARNING for r in caplog.records
+        ), "Expected a WARNING on the missing-engine path but the log was empty."
 
 
 class TestReadyzLogsOnQueryFailure:
@@ -79,17 +79,13 @@ class TestReadyzLogsOnQueryFailure:
         assert response.status_code == 200
         assert response.json() == {"status": "unavailable"}
         # WHY: the fix must record the exception, not swallow it.
-        has_exc_info = any(
-            r.levelno >= logging.WARNING and r.exc_info for r in caplog.records
-        )
+        has_exc_info = any(r.levelno >= logging.WARNING and r.exc_info for r in caplog.records)
         has_error_text = any(
             "connection refused" in r.getMessage().lower() or "connection refused" in str(r.exc_info).lower()
             for r in caplog.records
             if r.exc_info
         )
-        assert has_exc_info or has_error_text, (
-            "Expected the query exception to appear in the log, but it was absent."
-        )
+        assert has_exc_info or has_error_text, "Expected the query exception to appear in the log, but it was absent."
 
 
 # ---------------------------------------------------------------------------
@@ -108,9 +104,7 @@ class TestMetricsAnswers501:
         response = client.get("/metrics")  # WHY: call the placeholder endpoint.
 
         # WHY: 200 hides the gap from monitoring. The fix must return 501.
-        assert response.status_code == 501, (
-            f"Expected HTTP 501 from /metrics but received {response.status_code}."
-        )
+        assert response.status_code == 501, f"Expected HTTP 501 from /metrics but received {response.status_code}."
 
     def test_metrics_emits_a_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         # WHY: every scrape should announce the gap in the log.
@@ -121,6 +115,6 @@ class TestMetricsAnswers501:
             client.get("/metrics")  # WHY: call the route to trigger the log.
 
         # WHY: a silent placeholder is the bug. The fix must produce a warning.
-        assert any(r.levelno >= logging.WARNING for r in caplog.records), (
-            "Expected a WARNING from /metrics but the log was empty."
-        )
+        assert any(
+            r.levelno >= logging.WARNING for r in caplog.records
+        ), "Expected a WARNING from /metrics but the log was empty."

--- a/mist-ops-platform/tests/unit/worker/checks/test_post_checks.py
+++ b/mist-ops-platform/tests/unit/worker/checks/test_post_checks.py
@@ -160,9 +160,7 @@ class TestClientConnectivityDoesNotReportAnUnverifiedPass:
             "The check must not record an unverified pass."
         )
 
-    def test_client_connectivity_logs_the_missing_input(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_client_connectivity_logs_the_missing_input(self, caplog: pytest.LogCaptureFixture) -> None:
         # WHY: the fix must name the missing input so an operator can act.
         mist = MagicMock()
         mist.list_all_entities.return_value = SimpleNamespace(
@@ -175,6 +173,6 @@ class TestClientConnectivityDoesNotReportAnUnverifiedPass:
             service.run_all("org-1", ["dev-b"])  # WHY: run the pipeline to trigger the log.
 
         # WHY: a silent placeholder is the bug. The fix must warn that no real check ran.
-        assert any(r.levelno >= logging.WARNING for r in caplog.records), (
-            "Expected a WARNING from the client connectivity check, but none was emitted."
-        )
+        assert any(
+            r.levelno >= logging.WARNING for r in caplog.records
+        ), "Expected a WARNING from the client connectivity check, but none was emitted."

--- a/mist-ops-platform/tests/unit/worker/checks/test_post_checks.py
+++ b/mist-ops-platform/tests/unit/worker/checks/test_post_checks.py
@@ -8,8 +8,11 @@ depends on the number of target devices.
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 from src.worker.checks.post_checks import PostCheckService
 
@@ -121,3 +124,57 @@ class TestInventoryFetchFailureFailsEveryTarget:
         assert "Mist API unreachable" in by_name["health:dev-a"].message
         # WHY: the failure must still cost exactly one fetch attempt, not two.
         assert mist.list_all_entities.call_count == EXPECTED_INVENTORY_FETCHES_PER_RUN
+
+
+# ---------------------------------------------------------------------------
+# Issue #2038, finding 4: connectivity check must not report an unverified pass
+# ---------------------------------------------------------------------------
+
+
+class TestClientConnectivityDoesNotReportAnUnverifiedPass:
+    """Prove that client_connectivity results are not trivially passing.
+
+    The bug: _check_client_connectivity returned passed=True for every
+    device without reading a client count. A caller would record a
+    verified deployment even when no client data was read.
+    """
+
+    def test_client_connectivity_result_is_not_unconditionally_passing(self) -> None:
+        # WHY: supply a connected device so the health check passes.
+        mist = MagicMock()
+        mist.list_all_entities.return_value = SimpleNamespace(
+            status_code=200,
+            data=[{"id": "dev-a", "status": "connected"}],
+        )
+        service = PostCheckService(MagicMock(), mist)  # WHY: DB session unused here.
+
+        results = service.run_all("org-1", ["dev-a"])  # WHY: exercise the full pipeline.
+
+        by_name = {r.name: r for r in results}  # WHY: index for a readable assertion.
+        conn_result = by_name.get("client_connectivity:dev-a")
+        assert conn_result is not None, "Expected a client_connectivity result for dev-a."
+        # WHY: the bug was that passed=True with no evidence. The fix must set
+        # passed=False (or another non-passing value) when no comparison ran.
+        assert conn_result.passed is not True, (
+            "client_connectivity returned True without reading any client count. "
+            "The check must not record an unverified pass."
+        )
+
+    def test_client_connectivity_logs_the_missing_input(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # WHY: the fix must name the missing input so an operator can act.
+        mist = MagicMock()
+        mist.list_all_entities.return_value = SimpleNamespace(
+            status_code=200,
+            data=[{"id": "dev-b", "status": "connected"}],
+        )
+        service = PostCheckService(MagicMock(), mist)  # WHY: DB session unused here.
+
+        with caplog.at_level(logging.WARNING, logger="src.worker.checks.post_checks"):
+            service.run_all("org-1", ["dev-b"])  # WHY: run the pipeline to trigger the log.
+
+        # WHY: a silent placeholder is the bug. The fix must warn that no real check ran.
+        assert any(r.levelno >= logging.WARNING for r in caplog.records), (
+            "Expected a WARNING from the client connectivity check, but none was emitted."
+        )

--- a/mist-ops-platform/tests/unit/worker/checks/test_pre_checks.py
+++ b/mist-ops-platform/tests/unit/worker/checks/test_pre_checks.py
@@ -163,9 +163,7 @@ class TestVersionCompatDoesNotReportAnUnverifiedPass:
             "The check must not record an unverified pass."
         )
 
-    def test_version_compat_logs_the_missing_input(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_version_compat_logs_the_missing_input(self, caplog: pytest.LogCaptureFixture) -> None:
         # WHY: the fix must name the missing input so an operator can act.
         mist = MagicMock()
         mist.list_all_entities.return_value = SimpleNamespace(
@@ -178,6 +176,6 @@ class TestVersionCompatDoesNotReportAnUnverifiedPass:
             service.run_all("org-1", ["dev-b"])  # WHY: run the pipeline to trigger the log.
 
         # WHY: a silent placeholder is the bug. The fix must warn that no real check ran.
-        assert any(r.levelno >= logging.WARNING for r in caplog.records), (
-            "Expected a WARNING from the version compatibility check, but none was emitted."
-        )
+        assert any(
+            r.levelno >= logging.WARNING for r in caplog.records
+        ), "Expected a WARNING from the version compatibility check, but none was emitted."

--- a/mist-ops-platform/tests/unit/worker/checks/test_pre_checks.py
+++ b/mist-ops-platform/tests/unit/worker/checks/test_pre_checks.py
@@ -4,12 +4,18 @@ Issue #1886. Before this fix, PreCheckService called list_all_entities
 once for every target device, so a run over N devices paged the whole
 org inventory N times. These tests prove the fetch count no longer
 depends on the number of target devices.
+
+Issue #2038, finding 3: the version compatibility check always returned
+a passing result with no comparison. These tests prove the fix.
 """
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 from src.worker.checks.pre_checks import PreCheckService
 
@@ -121,3 +127,57 @@ class TestInventoryFetchFailureFailsEveryTarget:
         assert "Mist API unreachable" in by_name["reachability:dev-a"].message
         # WHY: the failure must still cost exactly one fetch attempt, not two.
         assert mist.list_all_entities.call_count == EXPECTED_INVENTORY_FETCHES_PER_RUN
+
+
+# ---------------------------------------------------------------------------
+# Issue #2038, finding 3: version compatibility check must not report a pass
+# ---------------------------------------------------------------------------
+
+
+class TestVersionCompatDoesNotReportAnUnverifiedPass:
+    """Prove that version_compat results are not trivially passing.
+
+    The bug: _check_version_compat returned passed=True for every device
+    without reading any data. A caller would record a verified deployment
+    even when no comparison ran.
+    """
+
+    def test_version_compat_result_is_not_unconditionally_passing(self) -> None:
+        # WHY: supply a connected device so the reachability check passes.
+        mist = MagicMock()
+        mist.list_all_entities.return_value = SimpleNamespace(
+            status_code=200,
+            data=[{"id": "dev-a", "status": "connected"}],
+        )
+        service = PreCheckService(MagicMock(), mist)  # WHY: DB session unused here.
+
+        results = service.run_all("org-1", ["dev-a"])  # WHY: exercise the full pipeline.
+
+        by_name = {r.name: r for r in results}  # WHY: index for a readable assertion.
+        compat_result = by_name.get("version_compat:dev-a")
+        assert compat_result is not None, "Expected a version_compat result for dev-a."
+        # WHY: the bug was that passed=True with no evidence. The fix must set
+        # passed=False (or another non-passing value) when no comparison ran.
+        assert compat_result.passed is not True, (
+            "version_compat returned True without comparing any version data. "
+            "The check must not record an unverified pass."
+        )
+
+    def test_version_compat_logs_the_missing_input(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # WHY: the fix must name the missing input so an operator can act.
+        mist = MagicMock()
+        mist.list_all_entities.return_value = SimpleNamespace(
+            status_code=200,
+            data=[{"id": "dev-b", "status": "connected"}],
+        )
+        service = PreCheckService(MagicMock(), mist)  # WHY: DB session unused here.
+
+        with caplog.at_level(logging.WARNING, logger="src.worker.checks.pre_checks"):
+            service.run_all("org-1", ["dev-b"])  # WHY: run the pipeline to trigger the log.
+
+        # WHY: a silent placeholder is the bug. The fix must warn that no real check ran.
+        assert any(r.levelno >= logging.WARNING for r in caplog.records), (
+            "Expected a WARNING from the version compatibility check, but none was emitted."
+        )


### PR DESCRIPTION
Refs #2038

## What this PR fixes

Findings 1 through 4 from issue #2038. Finding 5 (the web portal empty-list returns) is outside this agent's file scope and remains open.

### Finding 1 - /readyz states no reason (fixed)

Both failure paths returned `{"status": "unavailable"}` with no log record. Fix: log a warning on the missing-engine path naming the engine as absent. Log the exception with `exc_info=True` on the query-failure path. Response bodies and status codes are unchanged.

### Finding 2 - /metrics is a placeholder that reports success (fixed)

The route answered HTTP 200 with a fixed body. A Prometheus scrape succeeded and collected nothing, so no alert could fire. Fix: raise `HTTPException(status_code=501)` and log a warning on every call.

### Finding 3 - the pre-deployment version check always passes (fixed)

`_check_version_compat` returned `passed=True` for every device without reading any version data. The target firmware string is not passed into this method, so a real comparison is not possible. Fix: return `passed=False` with a message naming the missing input, and log a warning per device.

### Finding 4 - the post-deployment connectivity check always passes (fixed)

`_check_client_connectivity` returned `passed=True` for every device without reading a client count. No pre-deployment client count is passed into this method. Fix: same pattern as finding 3.

## Tests added

- `mist-ops-platform/tests/unit/api/test_health.py` (new, 4 tests) — proves warnings are logged and 501 is returned
- `mist-ops-platform/tests/unit/worker/checks/test_pre_checks.py` (extended, 2 tests) — proves version check does not return an unverified pass
- `mist-ops-platform/tests/unit/worker/checks/test_post_checks.py` (extended, 2 tests) — proves connectivity check does not return an unverified pass

All 8 new tests failed before the fixes and pass after.

## Gate results (Python 3.13.3)

| Gate | Result |
| - | - |
| `py_compile` | OK |
| `ruff check` (new code) | No new violations. Pre-existing violations were present before this change. |
| `black --check` | All 3 changed source files pass |
| `pytest tests` | 386 passed, 32 skipped |

## What remains open

Finding 5 — `web_portal/routes/operations.py` lines 301, 330, 369, 390 — outside this agent's file scope.