### PR TITLE
feat(export): add menu 238 for listMspLicenses (spec 752)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Export the MSP licenses through menu 238 (issue #1260)
+
+- **Gap (Closed)**: the Mist endpoint `listMspLicenses`
+  (`GET /api/v1/msps/{msp_id}/licenses`) had no menu entry. An operator who
+  manages an MSP had to write custom code to read the license entitlement, the
+  usage counters, and the subscription records.
+- **Menu (Added)**: menu 238 runs the export. The registry classifies it
+  `interactive_safe`, because it reads only and it prompts for an MSP ID. The
+  `--testinteractive` run therefore includes it, and the `--test` run skips it.
+- **Class (Added)**: `src/export/msp_license_exporter.py` holds
+  `MSPLicenseExporter`. It prompts through `InputUtils.safe_input`, calls the
+  SDK once, and writes through `DataExporter.write_with_format_selection`, so
+  the CSV, SQLite, and ArangoDB backends all work.
+- **Response shape (Explained)**: the endpoint returns one aggregate object, not
+  a list. The object holds four counter maps, one `licenses` array, and one
+  `amendments` array. The endpoint is not paginated, so the exporter reads
+  `response.data` instead of running `mistapi.get_all`.
+- **Two files (Chosen)**: the exporter writes `MSPLicenses_<msp>_summary.csv`
+  and `MSPLicenses_<msp>_details.csv`. One wide row would hold one column for
+  each subscription field, so the column count would change every time the MSP
+  buys or retires a subscription. Two files keep both schemas stable. The
+  detail file carries a `record_type` column, because a subscription record and
+  an amendment record share the same field names.
+- **Primary keys (Added)**: `ENDPOINT_PRIMARY_KEY_STRATEGIES` gains
+  `listMspLicenses` as a `natural_pk` on `msp_id` and `listMspLicensesDetails`
+  as a `natural_pk` on `id`. Both are natural keys, so a repeat run upserts and
+  writes no duplicate row.
+- **Shared prompt (Extracted)**: `InputUtils.prompt_msp_id` now holds the MSP
+  identifier prompt. Menu 237 carried its own copy inside `CountExporter`, and a
+  second copy in the new exporter made Pylint report duplicate code. One method
+  keeps the prompt text, the trim, and the abort rule identical across both MSP
+  menus. `CountExporter._prompt_msp_id` is deleted, not delegated, because the
+  project forbids a wrapper.
+- **Tests (Added)**: `tests/unit/export/test_msp_license_exporter.py` holds 22
+  tests. They cover the abort path, the non-dict body, both row builders, the
+  malformed-array guards, the empty result, the error handler, both primary-key
+  entries, and the menu wiring. `tests/unit/utils/test_input_utils_wave9.py`
+  gains 4 tests for the shared prompt, including the EOF path. Every Mist call
+  is mocked, so no test reaches the live cloud.
+- **Documentation (Updated)**: `documentation/menu_reference.md` and
+  `documentation/wiki/Menu-Reference.md` were regenerated. The README operation
+  counts were stale at menu 234, because menus 235 to 237 reached `main` without
+  a README update. The counts now read 238 entries plus Exit, and the menu table
+  lists 235 through 238.
+
 ### Run the quality gates on every pull request (issue #1952)
 
 - **Defect (Fixed)**: `.github/workflows/ci.yml` started on a pull request that

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -407,6 +407,9 @@ from src.export.license_export_utils import (
 from src.export.msp_inventory_exporter import (
     MSPInventoryExporter,  # Cat B (1013 SC-001 position 8) -- re-export for menu tuple + static call rewire
 )
+from src.export.msp_license_exporter import (
+    MSPLicenseExporter,  # Issue #1260 -- the MSP license export, menu 238
+)
 from src.export.org_admin_exporter import (
     OrgAdminExporter,  # Cat B (1013 SC-001 position 20) -- re-export for MistHelper.OrgAdminExporter callers
 )
@@ -3734,6 +3737,10 @@ menu_actions: dict[str, tuple[Callable[..., Any], str]] = {
     "237": (
         CountExporter.msp_counts,
         "Run any MSP-scoped Mist count endpoint (3 operations, issue #1802)",
+    ),
+    "238": (
+        MSPLicenseExporter.licenses,
+        "Export the license entitlement, usage, and subscriptions for an MSP (listMspLicenses)",
     ),
     "44": (OrgConfigExporter.psks, "Export PSK (Pre-Shared Key) information for the organization"),
     "45": (OrgConfigExporter.webhooks, "Export webhook configuration for the organization"),

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Network Operations & Data Export Tool for Juniper Mist Cloud
 [![Quality Gates](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/ci.yml/badge.svg)](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/ci.yml)
 [![Container Build](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/container-build.yml/badge.svg)](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/container-build.yml)
 
-**Operation Count:** The code defines 234 actionable menu entries, numbered 1 to
-234 with no gaps. Exit is menu 0, so the registry holds 235 entries in total.
+**Operation Count:** The code defines 238 actionable menu entries, numbered 1 to
+238 with no gaps. Exit is menu 0, so the registry holds 239 entries in total.
 The [Menu Reference](#menu-reference) section lists every category and range.
 
 MistHelper is a production-focused Python application that streamlines large-scale Juniper Mist Cloud data extraction, enrichment, transformation, and limited lifecycle operations. It supports both interactive (menu) and fully automated CLI execution, with flexible output to CSV files, a local SQLite database, or a polyglot backend (ArangoDB for documents, Redis for time-series and JSON caching) using natural/composite business keys (no artificial surrogate IDs for core entities). The codebase emphasizes safety, transparency, and predictable behavior-aligned with the included internal Agents Guide and NASA/JPL style defensive programming practices.
@@ -146,8 +146,8 @@ flowchart LR
   'fontFamily': 'ui-monospace, monospace'
 }}}%%
 mindmap
-   root((MistHelper<br/>235 Operations))
-    Safe Org Exports (66)
+   root((MistHelper<br/>239 Operations))
+    Safe Org Exports (64)
       Sites and Analysis 1-7
       Device Inventory 8-13
       Device Stats 15-17
@@ -162,7 +162,7 @@ mindmap
       Address and License 195-196
       JSI and Mist Edge 204-205
       Org Searches 230-234
-    Interactive Safe (67)
+    Interactive Safe (71)
       Site Devices 60-72
       Site Insights 73-79
       Site Stats 80-91
@@ -172,6 +172,7 @@ mindmap
       Site Event Searches 214-220
       Site Client and Device Searches 221-224
       Site Stats and Zones 225-229
+      Counts and MSP Licenses 235-238
     Resource Intensive (10)
       Heavy Inventory 14, 18-19
       Bulk Exports 59
@@ -541,13 +542,13 @@ fails closed, so `--test` skips any option that the registry does not name
 | Category | Count | Menu numbers | Behavior under `--test` |
 |----------|-------|--------------|-------------------------|
 | `safe` | 64 | 1-13, 15-17, 20-58, 188, 193, 204-205, 230-234 | Runs |
-| `interactive_safe` | 67 | 60-96, 195-203, 209-229 | Runs under `--testinteractive` |
+| `interactive_safe` | 71 | 60-96, 195-203, 209-229, 235-238 | Runs under `--testinteractive` |
 | `destructive` | 41 | 154-187, 189-191, 194, 206-208 | Never runs |
 | `interactive` | 29 | 0, 124-150, 192 | Never runs |
 | `websocket` | 22 | 102-123 | Never runs |
 | `resource_intensive` | 10 | 14, 18-19, 59, 97-101, 153 | Never runs |
 | `continuous_loop` | 2 | 151-152 | Never runs |
-| **Total** | **235** | 0-234, no gaps | Menu 0 is Exit |
+| **Total** | **239** | 0-238, no gaps | Menu 0 is Exit |
 
 Warning: A destructive operation changes the Mist cloud configuration. Read
 `documentation/menu_reference.md` before you run one.
@@ -596,6 +597,10 @@ Warning: A destructive operation changes the Mist cloud configuration. Read
 | 232 | Search organization WAN clients (`searchOrgWanClients`) | `safe` |
 | 233 | Search organization WAN client events (`searchOrgWanClientEvents`) | `safe` |
 | 234 | Search organization system events (`searchOrgSystemEvents`) | `safe` |
+| 235 | Run any org-scoped Mist count endpoint (35 operations) | `interactive_safe` |
+| 236 | Run any site-scoped Mist count endpoint (32 operations) | `interactive_safe` |
+| 237 | Run any MSP-scoped Mist count endpoint (3 operations) | `interactive_safe` |
+| 238 | Export the MSP license entitlement, usage, and subscriptions (`listMspLicenses`) | `interactive_safe` |
 
 Menu 197 writes to `data/packet_captures/<mac>/vlan_<id>/`. Every other
 operation in the table writes through `DataExporter`, so it honors the CSV,

--- a/documentation/menu_reference.md
+++ b/documentation/menu_reference.md
@@ -3,9 +3,9 @@
 This page is generated. Run `python scripts/generate_menu_wiki.py` after any
 change to `menu_actions` in `MistHelper.py` or to `src/utils/operation_registry.py`.
 
-MistHelper defines **237 actionable menu entries**, numbered
-1 to 237 with no gaps.
-Menu 0 is Exit, so the registry holds 238 entries in total.
+MistHelper defines **238 actionable menu entries**, numbered
+1 to 238 with no gaps.
+Menu 0 is Exit, so the registry holds 239 entries in total.
 
 The Safety column reads from `src/utils/operation_registry.py`, which is the
 single source of truth. The classifier fails closed, so an unregistered option
@@ -22,7 +22,7 @@ never runs in an automated test pass.
 
 | Menu numbers | Category | Summary |
 |---|---|---|
-| 60-96, 195-203, 209-229, 235-237 | Interactive safe | 70 operations. Read-only, but they prompt for a site or a device. The --testinteractive run includes them. |
+| 60-96, 195-203, 209-229, 235-238 | Interactive safe | 71 operations. Read-only, but they prompt for a site or a device. The --testinteractive run includes them. |
 | 1-13, 15-17, 20-58, 188, 193, 204-205, 230-234 | Safe org exports | 64 operations. Read-only org exports. The --test run includes them. |
 | 154-187, 189-191, 194, 206-208 | Destructive | 41 operations. They change the Mist cloud configuration. Each one needs a typed confirmation. |
 | 0, 124-150, 192 | Interactive | 29 operations. They prompt the operator, so no automated run includes them. |
@@ -272,6 +272,7 @@ never runs in an automated test pass.
 | 235 | Run any org-scoped Mist count endpoint (35 operations, issue #1802) | Interactive safe | `CountExporter.org_counts` |
 | 236 | Run any site-scoped Mist count endpoint (32 operations, issue #1802) | Interactive safe | `CountExporter.site_counts` |
 | 237 | Run any MSP-scoped Mist count endpoint (3 operations, issue #1802) | Interactive safe | `CountExporter.msp_counts` |
+| 238 | Export the license entitlement, usage, and subscriptions for an MSP (listMspLicenses) | Interactive safe | `MSPLicenseExporter.licenses` |
 
 This page should be regenerated whenever `menu_actions` or the operation registry
 changes, so the wiki stays aligned with the code.

--- a/documentation/wiki/Menu-Reference.md
+++ b/documentation/wiki/Menu-Reference.md
@@ -3,9 +3,9 @@
 This page is generated. Run `python scripts/generate_menu_wiki.py` after any
 change to `menu_actions` in `MistHelper.py` or to `src/utils/operation_registry.py`.
 
-MistHelper defines **237 actionable menu entries**, numbered
-1 to 237 with no gaps.
-Menu 0 is Exit, so the registry holds 238 entries in total.
+MistHelper defines **238 actionable menu entries**, numbered
+1 to 238 with no gaps.
+Menu 0 is Exit, so the registry holds 239 entries in total.
 
 The Safety column reads from `src/utils/operation_registry.py`, which is the
 single source of truth. The classifier fails closed, so an unregistered option
@@ -22,7 +22,7 @@ never runs in an automated test pass.
 
 | Menu numbers | Category | Summary |
 |---|---|---|
-| 60-96, 195-203, 209-229, 235-237 | Interactive safe | 70 operations. Read-only, but they prompt for a site or a device. The --testinteractive run includes them. |
+| 60-96, 195-203, 209-229, 235-238 | Interactive safe | 71 operations. Read-only, but they prompt for a site or a device. The --testinteractive run includes them. |
 | 1-13, 15-17, 20-58, 188, 193, 204-205, 230-234 | Safe org exports | 64 operations. Read-only org exports. The --test run includes them. |
 | 154-187, 189-191, 194, 206-208 | Destructive | 41 operations. They change the Mist cloud configuration. Each one needs a typed confirmation. |
 | 0, 124-150, 192 | Interactive | 29 operations. They prompt the operator, so no automated run includes them. |
@@ -272,6 +272,7 @@ never runs in an automated test pass.
 | 235 | Run any org-scoped Mist count endpoint (35 operations, issue #1802) | Interactive safe | `CountExporter.org_counts` |
 | 236 | Run any site-scoped Mist count endpoint (32 operations, issue #1802) | Interactive safe | `CountExporter.site_counts` |
 | 237 | Run any MSP-scoped Mist count endpoint (3 operations, issue #1802) | Interactive safe | `CountExporter.msp_counts` |
+| 238 | Export the license entitlement, usage, and subscriptions for an MSP (listMspLicenses) | Interactive safe | `MSPLicenseExporter.licenses` |
 
 This page should be regenerated whenever `menu_actions` or the operation registry
 changes, so the wiki stays aligned with the code.

--- a/specs/752-mist-list-msp-licenses/tasks.md
+++ b/specs/752-mist-list-msp-licenses/tasks.md
@@ -1,0 +1,66 @@
+# Tasks: listMspLicenses
+
+**Spec**: `specs/752-mist-list-msp-licenses/spec.md`
+**Issue**: #1260
+
+## Phase 1: Discovery
+
+- [X] T001 Resolve `listMspLicenses` against the installed SDK, not the spec text.
+      The module `mistapi.api.v1.msps.licenses` exists and the signature is
+      `(mist_session, msp_id)`.
+- [X] T002 Read the response schema in `documentation/mist-api-openapi31json.json`.
+      The endpoint returns one aggregate object, not a list, so the exporter
+      cannot run `mistapi.get_all`.
+- [X] T003 Confirm `listMspLicenses` has no call site in first-party code and no
+      entry in `ENDPOINT_PRIMARY_KEY_STRATEGIES`.
+
+## Phase 2: Design
+
+- [X] T004 Choose two output files over one wide row. One row would hold one
+      column for each subscription field, so the column count would change every
+      time the MSP buys or retires a subscription.
+- [X] T005 Choose a natural primary key for each file, so a repeat run upserts.
+      The summary keys on `msp_id`. The detail keys on the record `id`.
+- [X] T006 Choose one detail file for both record arrays. A subscription record
+      and an amendment record share their field names, so a `record_type` column
+      separates them.
+
+## Phase 3: Implementation
+
+- [X] T007 Add `src/export/msp_license_exporter.py` with `MSPLicenseExporter`.
+- [X] T008 Add `InputUtils.prompt_msp_id`, the shared prompt. It calls
+      `safe_input` and rejects an empty answer, so the menu survives an EOF in an
+      SSH or a container session. `CountExporter` held the only copy, and a
+      second copy made Pylint report duplicate code, so menu 237 now calls the
+      shared method and `CountExporter._prompt_msp_id` is deleted.
+- [X] T009 Add `_fetch`, which reads `response.data` and returns an empty dict
+      for a non-dict body.
+- [X] T010 Add `_build_summary_row`, which keeps the counter maps and drops the
+      record arrays.
+- [X] T011 Add `_build_detail_rows`, which skips a non-list field and a non-dict
+      entry instead of raising.
+- [X] T012 Add `_persist`, which routes each write through
+      `DataExporter.write_with_format_selection`.
+- [X] T013 Add `licenses`, the menu entry point that holds the error handler.
+
+## Phase 4: Wiring
+
+- [X] T014 Import `MSPLicenseExporter` in `MistHelper.py`.
+- [X] T015 Register menu 238 in `menu_actions`.
+- [X] T016 Mark menu 238 `interactive_safe` in the operation registry.
+- [X] T017 Add the `listMspLicenses` and `listMspLicensesDetails` primary key
+      strategies.
+
+## Phase 5: Verification
+
+- [X] T018 Add 22 unit tests in `tests/unit/export/test_msp_license_exporter.py`
+      and 4 more in `tests/unit/utils/test_input_utils_wave9.py`.
+- [X] T019 Run menu 238 end to end with a stubbed SDK. Read both output files,
+      confirm the EOF path makes no API call, and confirm an SDK error writes no
+      file and raises nothing into the menu loop.
+- [X] T020 Run py_compile, ruff, black, mypy, pydocstyle, interrogate, radon,
+      vulture, bandit, and pylint.
+- [X] T021 Run the export suite and the guardrail suite. 1215 tests pass.
+- [X] T022 Regenerate the menu reference documentation.
+- [X] T023 Correct the README operation counts, which were stale at menu 234.
+- [X] T024 Add the CHANGELOG entry.

--- a/src/export/count_exporter.py
+++ b/src/export/count_exporter.py
@@ -29,6 +29,7 @@ import mistapi  # WHY: direct SDK access for every count operation.
 from src.data.data_processing_utils import (
     DataProcessingUtils,
 )  # WHY: canonical flatten and escape helpers keep CSV output consistent with peers.
+from src.utils.input_utils import InputUtils  # WHY: the shared, EOF-safe MSP identifier prompt.
 
 
 @dataclass(frozen=True)
@@ -265,30 +266,7 @@ class CountExporter:
         operation = CountExporter._choose(_MSP_OPS, "msp")  # Ask which count to run.
         if operation is None:  # The chooser already logged the cancellation.
             return
-        msp_id = CountExporter._prompt_msp_id()  # MSP identifiers have no shared resolver yet.
+        msp_id = InputUtils.prompt_msp_id()  # MSP identifiers have no cached resolver.
         if msp_id is None:  # The prompt helper already logged the cancellation.
             return
         CountExporter._run(operation, msp_id, msp_id)  # Execute and persist.
-
-    @staticmethod
-    def _prompt_msp_id() -> str | None:
-        """Prompt for the MSP identifier, which has no cached resolver.
-
-        Why:
-            The org and site paths reuse existing resolvers. No MSP equivalent
-            exists, so this asks directly and rejects an empty answer.
-        """
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of InputUtils.
-        logging.info("Prompting the operator for the MSP identifier")  # Action log before the prompt.
-        value = str(  # WHY: the lazy module attribute is untyped, so pin the declared str return.
-            mh.InputUtils.safe_input(
-                "Enter MSP ID: ",
-                allow_empty=False,  # An empty identifier is invalid for the API path.
-                context="count_exporter.msp_id",
-            )
-        ).strip()
-        logging.debug("Completed the MSP prompt with value_present=%s", bool(value))  # Result trace.
-        if not value:  # A blank answer, an EOF, or an interrupt must abort before any API call.
-            logging.info("! No MSP ID supplied. Returning to the menu.")  # User-facing cancel line.
-            return None
-        return value

--- a/src/export/msp_license_exporter.py
+++ b/src/export/msp_license_exporter.py
@@ -1,0 +1,184 @@
+"""MSPLicenseExporter -- MSP license export for the ``listMspLicenses`` endpoint.
+
+Added for spec 752 / issue #1260. The class wraps the Mist API
+``listMspLicenses`` (``GET /api/v1/msps/{msp_id}/licenses``) so an operator can
+read the licenses an MSP holds through the standard MistHelper menu and the
+DataExporter pipeline (CSV, SQLite, or ArangoDB).
+
+Why:
+    The endpoint was absent from the menu. An operator who manages an MSP had to
+    write custom code to read the MSP license entitlement and the usage counters.
+
+Shape of the response:
+    The endpoint returns one aggregate object, not a list of records. The object
+    holds four counter maps (``entitled``, ``fully_loaded``, ``summary``, and
+    ``usages``), one ``licenses`` array of subscription records, and one
+    ``amendments`` array of subscription changes.
+
+Why two files:
+    The exporter writes a summary file and a detail file. This follows the
+    pattern that ``LicenseExportUtils`` established for the org async-claim
+    export. One wide row would hold one column for each subscription field, so
+    the column count would change every time the MSP buys or retires a
+    subscription. Two files keep both schemas stable, and both files upsert
+    cleanly on a repeat run.
+
+    - The summary file holds one row for each MSP, keyed by ``msp_id``.
+    - The detail file holds one row for each subscription and for each
+      amendment, keyed by the record ``id``. A ``record_type`` column separates
+      the two kinds, because both kinds carry the same field names.
+"""
+
+from __future__ import annotations  # WHY: enable PEP 604 unions on the project toolchain.
+
+import importlib  # WHY: lazy MistHelper import avoids a circular load at module init.
+import logging  # WHY: structured trace for export lifecycle events.
+from typing import Any  # WHY: raw license rows are duck-typed dicts from mistapi.
+
+import mistapi  # WHY: direct SDK access for listMspLicenses.
+
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: canonical flatten and escape helpers keep CSV output consistent with peers.
+from src.utils.input_utils import InputUtils  # WHY: the shared, EOF-safe MSP identifier prompt.
+
+# The two response keys that hold record arrays rather than counters. The
+# summary row drops them, and the detail rows read them.
+_RECORD_KEYS: tuple[tuple[str, str], ...] = (
+    ("licenses", "license"),  # Subscription records the MSP owns.
+    ("amendments", "amendment"),  # Recorded changes to those subscriptions.
+)
+
+
+class MSPLicenseExporter:
+    """MSP license exporter for the ``listMspLicenses`` operationId.
+
+    Why:
+        Provides the only MistHelper entry point for the MSP license endpoint.
+        Static methods only, with no per-instance state, matching the peer
+        exporters such as ``SiteApplicationListExporter``.
+    """
+
+    @staticmethod
+    def _fetch(msp_id: str) -> dict[str, Any]:
+        """Call ``listMspLicenses`` for one MSP and return the aggregate payload.
+
+        Why:
+            The endpoint is not paginated, so the caller reads ``response.data``
+            instead of running ``mistapi.get_all``.
+
+        Args:
+            msp_id: The MSP identifier the operator supplied.
+
+        Returns:
+            The response body as a dict, or an empty dict when the body is absent.
+        """
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession.
+        logging.info("Calling listMspLicenses for msp_id=%s", msp_id)  # Pre-call log.
+        response = mistapi.api.v1.msps.licenses.listMspLicenses(mh.apisession, msp_id)  # SDK call.
+        payload = getattr(response, "data", None)  # The SDK exposes the body on .data.
+        logging.debug("listMspLicenses returned payload_type=%s", type(payload).__name__)  # Post-call trace.
+        if not isinstance(payload, dict):  # A list body or a None body means the MSP has no license record.
+            logging.debug("listMspLicenses returned no dict body for msp_id=%s", msp_id)  # Explain the empty result.
+            return {}
+        return payload
+
+    @staticmethod
+    def _build_summary_row(msp_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """Build the one counter row for an MSP, dropping the record arrays.
+
+        Why:
+            The counter maps answer the question an operator asks first: how many
+            licenses of each type does this MSP hold, and how many are in use.
+
+        Args:
+            msp_id: The MSP identifier, which becomes the primary key.
+            payload: The aggregate body ``listMspLicenses`` returned.
+
+        Returns:
+            One flattened row that always carries ``msp_id``.
+        """
+        record_keys = {key for key, _ in _RECORD_KEYS}  # The array keys the detail file owns.
+        counters = {key: value for key, value in payload.items() if key not in record_keys}  # Keep the maps only.
+        logging.debug("Built the MSP summary from %d counter keys", len(counters))  # Post-build trace.
+        flattened = DataProcessingUtils.flatten_nested_fields([counters])  # Expand each counter map into columns.
+        row: dict[str, Any] = {"msp_id": msp_id}  # Lead with the primary key so the CSV reads left to right.
+        row.update(flattened[0] if flattened else {})  # Merge the counters behind the identifier.
+        return row
+
+    @staticmethod
+    def _build_detail_rows(msp_id: str, payload: dict[str, Any]) -> list[dict[str, Any]]:
+        """Build one row for each subscription and for each amendment.
+
+        Why:
+            Both arrays carry the same field names and a stable ``id``, so one
+            file with a ``record_type`` column holds both without a name clash.
+
+        Args:
+            msp_id: The MSP identifier, added to every row for attribution.
+            payload: The aggregate body ``listMspLicenses`` returned.
+
+        Returns:
+            The detail rows, in subscription order and then amendment order.
+        """
+        rows: list[dict[str, Any]] = []  # Accumulate the rows of both arrays.
+        for key, record_type in _RECORD_KEYS:  # Walk the subscription array, then the amendment array.
+            records = payload.get(key) or []  # A missing key and a null value both mean no record.
+            if not isinstance(records, list):  # A malformed body must not stop the export.
+                logging.warning("listMspLicenses returned a non-list %s field; skipping it", key)  # Name the gap.
+                continue
+            for record in records:  # Each record becomes one row.
+                if not isinstance(record, dict):  # Skip a malformed entry rather than write a broken row.
+                    logging.warning("Skipping a non-dict entry in the %s field", key)  # Name the skipped entry.
+                    continue
+                rows.append({"msp_id": msp_id, "record_type": record_type, **record})  # Tag, then copy the record.
+        logging.debug("Built %d MSP license detail rows", len(rows))  # Post-build count trace.
+        return DataProcessingUtils.flatten_nested_fields(rows)  # Flatten any nested field before the write.
+
+    @staticmethod
+    def _persist(rows: list[dict[str, Any]], filename: str, api_function_name: str, noun: str) -> None:
+        """Escape and persist one set of rows, or report that there are none.
+
+        Why:
+            An MSP with no license record is legitimate, so the exporter reports
+            the empty result plainly instead of failing.
+
+        Args:
+            rows: The flattened rows to write. May be empty.
+            filename: The output filename, used as the CSV name or the table name.
+            api_function_name: The key that selects the primary-key strategy.
+            noun: The word shown to the operator, for example ``license summary``.
+        """
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of the DataExporter helper.
+        if not rows:  # No rows, so inform the operator and return.
+            logging.info("! No MSP %s data found", noun)  # ASCII-only user notice.
+            return
+        sanitized_data = DataProcessingUtils.escape_multiline(rows)  # Make multiline values CSV-safe.
+        mh.DataExporter.write_with_format_selection(  # Persist through the CSV, SQLite, or Arango selector.
+            sanitized_data, filename, api_function_name=api_function_name
+        )
+        logging.debug("%s persisted %d rows to %s", api_function_name, len(rows), filename)  # Post-call count.
+        logging.info("! %d MSP %s records exported to %s", len(rows), noun, filename)  # User notice with count.
+
+    @staticmethod
+    def licenses() -> None:
+        """Export the license summary and the license details for an MSP (menu 238).
+
+        Why:
+            Interactive menu entry point. The method owns the prompt, the API
+            call, and the two writes, and it keeps every failure inside the menu.
+        """
+        logging.info("MSP Licenses:")  # Menu header echoed to the operator.
+        msp_id = InputUtils.prompt_msp_id()  # Ask which MSP to read.
+        if msp_id is None:  # The prompt helper already logged the cancellation.
+            return
+        try:
+            payload = MSPLicenseExporter._fetch(msp_id)  # Read the aggregate body once.
+            summary_rows = [MSPLicenseExporter._build_summary_row(msp_id, payload)] if payload else []  # One row.
+            detail_rows = MSPLicenseExporter._build_detail_rows(msp_id, payload)  # One row for each record.
+            stem = f"MSPLicenses_{msp_id.replace(' ', '_')}"  # Per-MSP filename stem shared by both files.
+            MSPLicenseExporter._persist(summary_rows, f"{stem}_summary.csv", "listMspLicenses", "license summary")
+            MSPLicenseExporter._persist(detail_rows, f"{stem}_details.csv", "listMspLicensesDetails", "license detail")
+        except Exception as e:  # noqa: BLE001 -- surface any SDK or network error, keep the menu alive.
+            logging.error("Error fetching the licenses for MSP %s: %s", msp_id, e)  # Failure context.
+            logging.info("! Error fetching MSP license data: %s", e)  # ASCII-only user notice.

--- a/src/refactors/endpoint_primary_key_strategies.py
+++ b/src/refactors/endpoint_primary_key_strategies.py
@@ -792,6 +792,20 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "unique_constraints": [],
         "description": "License records from canonical list endpoint",
     },
+    "listMspLicenses": {  # Issue #1260 -- the MSP counter row that menu 238 writes.
+        "type": "natural_pk",  # The endpoint returns one aggregate for each MSP.
+        "primary_key": ["msp_id"],  # The MSP identifier keys the single counter row.
+        "indexes": [],  # A one-row-per-MSP table needs no secondary index.
+        "unique_constraints": [],  # The natural primary key already enforces uniqueness.
+        "description": "MSP license entitlement and usage counters (listMspLicenses summary)",
+    },
+    "listMspLicensesDetails": {  # Issue #1260 -- the per-record rows that menu 238 writes.
+        "type": "natural_pk",  # Every subscription and every amendment carries a stable UUID.
+        "primary_key": ["id"],  # The record UUID keys the row, so a repeat run upserts.
+        "indexes": ["msp_id", "org_id", "subscription_id", "type", "record_type"],  # Common filter columns.
+        "unique_constraints": [],  # The natural primary key already enforces uniqueness.
+        "description": "MSP license subscription and amendment records (listMspLicenses detail)",
+    },
     # Site Inventory Health Analysis reports
     "sitesMissingInfrastructure": {
         "type": "natural_pk",

--- a/src/utils/input_utils.py
+++ b/src/utils/input_utils.py
@@ -71,6 +71,33 @@ class InputUtils:
         return user_input  # Normal path: return the trimmed user response.
 
     @staticmethod
+    def prompt_msp_id() -> str | None:
+        """Ask the operator for an MSP identifier and reject an empty answer.
+
+        Why:
+            MistHelper caches an org identifier and a site identifier, but it
+            caches no MSP identifier. Every MSP-scoped menu therefore asks for
+            the value. One method keeps the prompt text, the trim, and the abort
+            rule identical across those menus.
+
+        Returns:
+            The trimmed MSP identifier, or None when the operator declines. An
+            empty answer, an EOF, and a Ctrl+C all reach this method as an empty
+            string, so all three return None.
+        """
+        logging.info("Prompting the operator for the MSP identifier")  # Action log before the prompt.
+        value = InputUtils.safe_input(
+            "Enter MSP ID: ",
+            allow_empty=False,  # An empty identifier cannot build the API path.
+            context="input_utils.msp_id",
+        ).strip()
+        logging.debug("Completed the MSP prompt with value_present=%s", bool(value))  # Result trace.
+        if not value:  # A blank answer, an EOF, or an interrupt must abort before any API call.
+            logging.info("! No MSP ID supplied. Returning to the menu.")  # User-facing cancel line.
+            return None
+        return value
+
+    @staticmethod
     def _handle_empty(default_value: str, allow_empty: bool, context: str) -> str:
         """Resolve the empty-input case per default/allow_empty policy."""
         # WHY: extracted to keep safe_input CC<=5 and length<=25 lines.

--- a/src/utils/operation_registry.py
+++ b/src/utils/operation_registry.py
@@ -300,6 +300,7 @@ class OperationRegistry:
         "235": {"category": "interactive_safe", "skip_reason": "Requires a count operation choice"},
         "236": {"category": "interactive_safe", "skip_reason": "Requires a count operation and site"},
         "237": {"category": "interactive_safe", "skip_reason": "Requires a count operation and MSP ID"},
+        "238": {"category": "interactive_safe", "skip_reason": "Requires an MSP ID"},
         "186": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Deletes all generated cache CSV files"},
         "58": {"category": "safe"},
         "187": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Creates config objects in destination org"},

--- a/tests/unit/export/test_count_exporter_workflows.py
+++ b/tests/unit/export/test_count_exporter_workflows.py
@@ -18,6 +18,7 @@ import mistapi
 import pytest
 
 from src.export.count_exporter import _MSP_OPS, _ORG_OPS, _SITE_OPS, CountExporter, _CountOp
+from src.utils.input_utils import InputUtils
 
 
 @pytest.fixture
@@ -180,14 +181,19 @@ class TestSiteCounts:
 
 
 class TestMspCounts:
-    """Cover ``msp_counts`` and ``_prompt_msp_id``, the menu 237 entry point."""
+    """Cover ``msp_counts``, the menu 237 entry point.
+
+    The identifier prompt now lives in ``InputUtils.prompt_msp_id``, because
+    menu 238 asks for the same value. ``tests/unit/utils/test_input_utils_wave9.py``
+    covers the prompt itself, so these tests patch it and cover the routing only.
+    """
 
     def test_msp_counts_returns_when_the_operator_declines_the_operation(self, fake_mh: Any) -> None:
         """A declined operation must abort before the identifier prompt runs."""
         with (
             patch.object(importlib, "import_module", return_value=fake_mh),
             patch.object(CountExporter, "_choose", return_value=None),
-            patch.object(CountExporter, "_prompt_msp_id") as prompt_spy,
+            patch.object(InputUtils, "prompt_msp_id") as prompt_spy,
             patch.object(CountExporter, "_run") as run_spy,
         ):
             CountExporter.msp_counts()  # WHY: drive the first guard branch.
@@ -199,7 +205,7 @@ class TestMspCounts:
         with (
             patch.object(importlib, "import_module", return_value=fake_mh),
             patch.object(CountExporter, "_choose", return_value=_MSP_OPS[0]),
-            patch.object(CountExporter, "_prompt_msp_id", return_value=None),
+            patch.object(InputUtils, "prompt_msp_id", return_value=None),
             patch.object(CountExporter, "_run") as run_spy,
         ):
             CountExporter.msp_counts()  # WHY: drive the declined-identifier guard.
@@ -210,27 +216,9 @@ class TestMspCounts:
         with (
             patch.object(importlib, "import_module", return_value=fake_mh),
             patch.object(CountExporter, "_choose", return_value=_MSP_OPS[0]),
-            patch.object(CountExporter, "_prompt_msp_id", return_value="msp-9"),
+            patch.object(InputUtils, "prompt_msp_id", return_value="msp-9"),
             patch.object(CountExporter, "_run") as run_spy,
         ):
             CountExporter.msp_counts()  # WHY: drive the happy path.
         # WHY: the MSP path has no friendly name, so the identifier doubles as the label.
         run_spy.assert_called_once_with(_MSP_OPS[0], "msp-9", "msp-9")
-
-    def test_prompt_msp_id_returns_none_for_a_blank_answer(self, fake_mh: Any) -> None:
-        """A blank answer must abort, because the API path needs an identifier."""
-        fake_mh.InputUtils.safe_input.return_value = "   "  # WHY: whitespace collapses to empty.
-        with patch.object(importlib, "import_module", return_value=fake_mh):
-            assert CountExporter._prompt_msp_id() is None  # WHY: the guard must reject it.
-
-    def test_prompt_msp_id_trims_the_answer(self, fake_mh: Any) -> None:
-        """A pasted identifier keeps stray whitespace, so the prompt must trim it."""
-        fake_mh.InputUtils.safe_input.return_value = "  msp-9  "  # WHY: mimic a paste with padding.
-        with patch.object(importlib, "import_module", return_value=fake_mh):
-            assert CountExporter._prompt_msp_id() == "msp-9"  # WHY: trimmed value reaches the URL.
-
-    def test_prompt_msp_id_rejects_an_empty_answer(self, fake_mh: Any) -> None:
-        """An empty answer must not become part of an API path."""
-        fake_mh.InputUtils.safe_input.return_value = ""  # WHY: mimic an immediate Enter press.
-        with patch.object(importlib, "import_module", return_value=fake_mh):
-            assert CountExporter._prompt_msp_id() is None  # WHY: the guard must reject it.

--- a/tests/unit/export/test_msp_license_exporter.py
+++ b/tests/unit/export/test_msp_license_exporter.py
@@ -1,0 +1,224 @@
+"""Tests for ``MSPLicenseExporter``, the menu 238 entry point (issue #1260).
+
+Why:
+    The exporter owns one prompt, one Mist API call, two row builders, and two
+    writes. Each part holds a guard that keeps the menu alive when the MSP has
+    no license, when the body is malformed, or when the network fails. This
+    module covers every one of those paths. Every Mist call is mocked, so no
+    test reaches the live cloud.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import mistapi
+import pytest
+
+from src.export.msp_license_exporter import MSPLicenseExporter
+from src.refactors.endpoint_primary_key_strategies import ENDPOINT_PRIMARY_KEY_STRATEGIES
+from src.utils.input_utils import InputUtils
+
+# One realistic body, trimmed to the fields the exporter reads.
+_PAYLOAD: dict[str, Any] = {
+    "entitled": {"SUB-MAN": 10, "SUB-VNA": 4},
+    "fully_loaded": {"SUB-MAN": 12},
+    "summary": {"SUB-MAN": 7},
+    "usages": {"SUB-MAN": 3},
+    "licenses": [
+        {"id": "lic-1", "org_id": "org-1", "subscription_id": "MAN-1", "type": "SUB-MAN", "quantity": 10},
+        {"id": "lic-2", "org_id": "org-2", "subscription_id": "VNA-1", "type": "SUB-VNA", "quantity": 4},
+    ],
+    "amendments": [
+        {"id": "amd-1", "subscription_id": "MAN-1", "type": "SUB-MAN", "quantity": -1},
+    ],
+}
+
+
+@pytest.fixture
+def fake_mh() -> Any:
+    """Return a MistHelper stand-in holding every collaborator the exporter reads.
+
+    Why:
+        The exporter resolves ``apisession``, ``InputUtils``, and ``DataExporter``
+        through a lazy ``importlib.import_module("MistHelper")`` call. One stub
+        covers all three and records what the exporter wrote.
+    """
+    module = MagicMock()  # WHY: a MagicMock auto-creates each attribute the exporter reads.
+    module.apisession = MagicMock()  # WHY: the SDK call receives this as its first argument.
+    return module
+
+
+class TestFetch:
+    """Cover ``_fetch``, which owns the SDK call and normalizes the body."""
+
+    def test_passes_the_session_and_the_identifier_positionally(self, fake_mh: Any) -> None:
+        """The SDK contract is exactly two positional arguments, session first."""
+        sdk_callable = MagicMock(return_value=MagicMock(data=_PAYLOAD))  # WHY: stand in for the SDK function.
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(mistapi.api.v1.msps.licenses, "listMspLicenses", sdk_callable),
+        ):
+            assert MSPLicenseExporter._fetch("msp-1") == _PAYLOAD
+        sdk_callable.assert_called_once_with(fake_mh.apisession, "msp-1")
+
+    @pytest.mark.parametrize("body", [None, [], "unexpected"])
+    def test_returns_an_empty_dict_for_a_non_dict_body(self, fake_mh: Any, body: Any) -> None:
+        """A null body or a list body means the MSP holds no license record."""
+        sdk_callable = MagicMock(return_value=MagicMock(data=body))  # WHY: drive the non-dict guard.
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(mistapi.api.v1.msps.licenses, "listMspLicenses", sdk_callable),
+        ):
+            assert MSPLicenseExporter._fetch("msp-1") == {}
+
+
+class TestBuildSummaryRow:
+    """Cover ``_build_summary_row``, which keeps the counters and drops the arrays."""
+
+    def test_leads_with_the_msp_id_primary_key(self) -> None:
+        """``msp_id`` is the declared primary key, so every row must carry it."""
+        row = MSPLicenseExporter._build_summary_row("msp-1", _PAYLOAD)  # WHY: run the happy path.
+        assert row["msp_id"] == "msp-1"
+
+    def test_flattens_each_counter_map_into_columns(self) -> None:
+        """A counter map must become one column for each license type."""
+        row = MSPLicenseExporter._build_summary_row("msp-1", _PAYLOAD)  # WHY: run the happy path.
+        assert row["entitled_SUB-MAN"] == 10  # WHY: the flatten helper joins the keys with an underscore.
+        assert row["usages_SUB-MAN"] == 3
+
+    def test_drops_the_record_arrays(self) -> None:
+        """The detail file owns the arrays, so the summary row must not repeat them."""
+        row = MSPLicenseExporter._build_summary_row("msp-1", _PAYLOAD)  # WHY: run the happy path.
+        assert not [key for key in row if key.startswith(("licenses", "amendments"))]
+
+
+class TestBuildDetailRows:
+    """Cover ``_build_detail_rows``, which merges two arrays into one row set."""
+
+    def test_emits_one_row_for_each_subscription_and_amendment(self) -> None:
+        """Two subscriptions and one amendment must produce three rows."""
+        rows = MSPLicenseExporter._build_detail_rows("msp-1", _PAYLOAD)  # WHY: run the happy path.
+        assert len(rows) == 3
+
+    def test_tags_each_row_with_its_record_type_and_msp(self) -> None:
+        """The ``record_type`` column is what separates the two kinds in one table."""
+        rows = MSPLicenseExporter._build_detail_rows("msp-1", _PAYLOAD)  # WHY: run the happy path.
+        assert [row["record_type"] for row in rows] == ["license", "license", "amendment"]
+        assert {row["msp_id"] for row in rows} == {"msp-1"}
+
+    def test_keeps_the_record_id_as_the_primary_key(self) -> None:
+        """``id`` is the declared primary key, so a repeat run must upsert."""
+        rows = MSPLicenseExporter._build_detail_rows("msp-1", _PAYLOAD)  # WHY: run the happy path.
+        assert [row["id"] for row in rows] == ["lic-1", "lic-2", "amd-1"]
+
+    def test_returns_no_row_for_an_empty_payload(self) -> None:
+        """An MSP with no license is legitimate and must not raise."""
+        assert MSPLicenseExporter._build_detail_rows("msp-1", {}) == []
+
+    def test_skips_a_non_list_array_field(self, caplog: Any) -> None:
+        """A malformed body must be reported, not raised into the menu loop."""
+        caplog.set_level("WARNING")  # WHY: the guard reports the malformed field at WARNING level.
+        rows = MSPLicenseExporter._build_detail_rows("msp-1", {"licenses": {"id": "lic-1"}})
+        assert rows == []
+        assert "non-list licenses field" in caplog.text
+
+    def test_skips_a_non_dict_entry(self, caplog: Any) -> None:
+        """One bad entry must not discard the entries beside it."""
+        caplog.set_level("WARNING")  # WHY: the guard reports the skipped entry at WARNING level.
+        rows = MSPLicenseExporter._build_detail_rows("msp-1", {"licenses": ["oops", {"id": "lic-1"}]})
+        assert [row["id"] for row in rows] == ["lic-1"]
+        assert "non-dict entry" in caplog.text
+
+
+class TestPersist:
+    """Cover ``_persist``, which owns the write and the empty-result notice."""
+
+    def test_writes_nothing_when_there_is_no_row(self, fake_mh: Any) -> None:
+        """An empty result must report plainly instead of writing an empty file."""
+        with patch.object(importlib, "import_module", return_value=fake_mh):
+            MSPLicenseExporter._persist([], "x.csv", "listMspLicenses", "license summary")
+        fake_mh.DataExporter.write_with_format_selection.assert_not_called()
+
+    def test_routes_the_write_through_the_declared_api_function_name(self, fake_mh: Any) -> None:
+        """The api_function_name is what selects the primary-key strategy."""
+        with patch.object(importlib, "import_module", return_value=fake_mh):
+            MSPLicenseExporter._persist([{"msp_id": "msp-1"}], "x.csv", "listMspLicenses", "license summary")
+        _, kwargs = fake_mh.DataExporter.write_with_format_selection.call_args  # WHY: read the routing key.
+        assert kwargs["api_function_name"] == "listMspLicenses"
+
+
+class TestLicensesEntryPoint:
+    """Cover ``licenses``, the menu 238 entry point."""
+
+    def test_aborts_before_any_api_call_when_the_operator_declines(self, fake_mh: Any) -> None:
+        """No MSP identifier means no API call and no write."""
+        sdk_callable = MagicMock()  # WHY: assert the SDK is never reached.
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(InputUtils, "prompt_msp_id", return_value=None),
+            patch.object(mistapi.api.v1.msps.licenses, "listMspLicenses", sdk_callable),
+        ):
+            MSPLicenseExporter.licenses()
+        sdk_callable.assert_not_called()
+        fake_mh.DataExporter.write_with_format_selection.assert_not_called()
+
+    def test_writes_a_summary_file_and_a_detail_file(self, fake_mh: Any) -> None:
+        """One API call must produce exactly two writes with distinct names."""
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(InputUtils, "prompt_msp_id", return_value="msp-1"),
+            patch.object(MSPLicenseExporter, "_fetch", return_value=_PAYLOAD),
+        ):
+            MSPLicenseExporter.licenses()
+        written = [call.args[1] for call in fake_mh.DataExporter.write_with_format_selection.call_args_list]
+        assert written == ["MSPLicenses_msp-1_summary.csv", "MSPLicenses_msp-1_details.csv"]
+
+    def test_writes_nothing_when_the_msp_holds_no_license(self, fake_mh: Any) -> None:
+        """An empty body must produce no summary row and no detail row."""
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(InputUtils, "prompt_msp_id", return_value="msp-1"),
+            patch.object(MSPLicenseExporter, "_fetch", return_value={}),
+        ):
+            MSPLicenseExporter.licenses()
+        fake_mh.DataExporter.write_with_format_selection.assert_not_called()
+
+    def test_swallows_an_sdk_error_so_the_menu_survives(self, fake_mh: Any, caplog: Any) -> None:
+        """A network or SDK failure must be logged, not raised into the menu loop."""
+        caplog.set_level("ERROR")  # WHY: the handler reports the failure at ERROR level.
+        with (
+            patch.object(importlib, "import_module", return_value=fake_mh),
+            patch.object(InputUtils, "prompt_msp_id", return_value="msp-1"),
+            patch.object(MSPLicenseExporter, "_fetch", side_effect=RuntimeError("connection reset")),
+        ):
+            MSPLicenseExporter.licenses()  # WHY: the menu loop must keep running.
+        assert "connection reset" in caplog.text
+
+
+class TestPrimaryKeyStrategies:
+    """Guard the two strategy entries the exporter routes through."""
+
+    @pytest.mark.parametrize(
+        ("api_function_name", "expected_key"),
+        [("listMspLicenses", ["msp_id"]), ("listMspLicensesDetails", ["id"])],
+    )
+    def test_each_write_target_declares_a_natural_primary_key(self, api_function_name: str, expected_key: Any) -> None:
+        """A natural key is what makes a repeat run upsert instead of duplicate."""
+        entry = ENDPOINT_PRIMARY_KEY_STRATEGIES[api_function_name]  # WHY: the router reads this table.
+        assert entry["type"] == "natural_pk"
+        assert entry["primary_key"] == expected_key
+
+
+class TestMenuRegistration:
+    """Guard the menu wiring, which is what makes the exporter reachable."""
+
+    def test_menu_238_calls_the_exporter_and_is_interactive_safe(self) -> None:
+        """Menu 238 must route to the exporter and must skip the automated --test run."""
+        import MistHelper  # WHY: menu_actions is the authoritative runtime mapping.
+        from src.utils.operation_registry import OperationRegistry
+
+        assert MistHelper.menu_actions["238"][0] is MSPLicenseExporter.licenses
+        assert OperationRegistry.get("238")["category"] == "interactive_safe"

--- a/tests/unit/utils/test_input_utils_wave9.py
+++ b/tests/unit/utils/test_input_utils_wave9.py
@@ -184,3 +184,30 @@ class TestSafeInputDefaultArguments:
         result = InputUtils.safe_input("Enter: ")  # WHY: exercise defaults
         assert result == "value"  # WHY: normal path returns value
         assert called.get("ok") is True  # WHY: input was invoked
+
+
+class TestPromptMspId:
+    """Cover ``prompt_msp_id``, the shared prompt every MSP-scoped menu calls."""
+
+    def test_returns_the_trimmed_identifier(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # WHY: an operator pastes a padded value, and the padding must not reach the API path
+        monkeypatch.setattr("builtins.input", lambda _prompt: "  msp-9  ")  # WHY: mimic a padded paste
+        assert InputUtils.prompt_msp_id() == "msp-9"  # WHY: the trimmed value reaches the URL
+
+    def test_returns_none_for_a_whitespace_answer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # WHY: whitespace collapses to empty, so the guard must reject it
+        monkeypatch.setattr("builtins.input", lambda _prompt: "   ")  # WHY: mimic a space bar press
+        assert InputUtils.prompt_msp_id() is None  # WHY: an empty identifier cannot build a path
+
+    def test_returns_none_for_an_empty_answer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # WHY: an immediate Enter press must abort before any API call
+        monkeypatch.setattr("builtins.input", lambda _prompt: "")  # WHY: mimic an immediate Enter press
+        assert InputUtils.prompt_msp_id() is None  # WHY: the guard must reject it
+
+    def test_returns_none_on_eof(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # WHY: an SSH disconnect or a container EOF must return to the menu, not raise
+        def _raise_eof(_prompt: str) -> str:  # WHY: drive the EOF branch of safe_input
+            raise EOFError
+
+        monkeypatch.setattr("builtins.input", _raise_eof)  # WHY: mimic a closed input stream
+        assert InputUtils.prompt_msp_id() is None  # WHY: safe_input degrades to "" and the guard returns None


### PR DESCRIPTION
## Summary

Closes #1260. Spec: `specs/752-mist-list-msp-licenses/spec.md`.

The Mist endpoint `listMspLicenses` (`GET /api/v1/msps/{msp_id}/licenses`) had
no menu entry. An operator who manages an MSP had to write custom code to read
the license entitlement, the usage counters, and the subscription records. This
pull request adds menu 238 for that endpoint.

## Response shape and the two output files

The endpoint returns one aggregate object, not a list. The object holds four
counter maps (`entitled`, `fully_loaded`, `summary`, `usages`), one `licenses`
array, and one `amendments` array. The endpoint is not paginated, so the
exporter reads `response.data` instead of running `mistapi.get_all`.

The exporter writes two files, which follows the pattern `LicenseExportUtils`
established for the org async-claim export:

| File | Rows | `api_function_name` | Primary key |
| - | - | - | - |
| `MSPLicenses_<msp>_summary.csv` | One for each MSP | `listMspLicenses` | `natural_pk` on `msp_id` |
| `MSPLicenses_<msp>_details.csv` | One for each subscription and each amendment | `listMspLicensesDetails` | `natural_pk` on `id` |

One wide row would hold one column for each subscription field, so the column
count would change every time the MSP buys or retires a subscription. Two files
keep both schemas stable. The detail file carries a `record_type` column,
because a subscription record and an amendment record share their field names.
Both keys are natural, so a repeat run upserts and writes no duplicate row.

## Shared MSP prompt

`InputUtils.prompt_msp_id` now holds the MSP identifier prompt. Menu 237 carried
its own copy inside `CountExporter`. A second copy made Pylint report duplicate
code (`R0801`), and the aggregate score has a 0.03 margin above the 9.5 floor.
`CountExporter._prompt_msp_id` is deleted, not delegated, because the project
forbids a wrapper. Its three prompt tests moved to
`tests/unit/utils/test_input_utils_wave9.py`, and one EOF test was added there.

## Conformance

- [x] Menu item added invoking `mistapi.api.v1.msps.licenses.listMspLicenses()`
- [x] `ENDPOINT_PRIMARY_KEY_STRATEGIES` updated
- [x] Inline comments and action logging on every new line
- [x] `DataExporter.write_with_format_selection` used for output
- [x] `safe_input()` used for prompts, through `InputUtils.prompt_msp_id`
- [x] Menu 238 registered `interactive_safe` in `OperationRegistry`
- [x] README.md and CHANGELOG.md updated
- [x] No secret added. The token still loads from `.env`.

## Verification

Every gate ran locally against this branch.

| Gate | Result |
| - | - |
| `py_compile` | No output |
| `ruff check src/ tests/unit/export tests/unit/utils` | `All checks passed!` |
| `black --check` | 418 files unchanged |
| `mypy src/ MistHelper.py wsgi.py` | `Success: no issues found in 343 source files` |
| `pytest tests/unit/export tests/unit/utils tests/guardrails` | 1491 passed |
| `pylint src/ --fail-under=9.5` | 9.53, unchanged from the base |
| `pylint --enable=R0801` on the three touched modules | 10.00, no duplicate code |
| `pydocstyle` | Clean |
| `interrogate` | 100 percent |
| `radon cc -n C` | No block above C |
| `vulture src/ MistHelper.py wsgi.py --min-confidence 70` | No finding |
| `bandit -r` | No finding |

The registry guardrail `tests/guardrails/test_operation_registry_menu_coverage.py`
passes, so `menu_actions` and `OperationRegistry` agree on menu 238.

### Runtime validation

Menu 238 ran end to end three times with a stubbed SDK and no cloud access.

1. **Happy path.** The SDK received `(apisession, "msp-smoke-2")`. The exporter
   wrote both files. The summary row read
   `entitled_SUB-MAN,msp_id,summary_SUB-MAN,usages_SUB-MAN`. The detail file held
   one `license` row and one `amendment` row, both carrying `msp_id`.
2. **EOF at the prompt.** `input()` raised `EOFError`, which mimics an SSH
   disconnect. The exporter made no API call, wrote no file, and raised nothing.
3. **API failure.** The SDK raised `RuntimeError`. The exporter logged the
   failure, wrote no file, and returned to the menu.

## Test plan

`tests/unit/export/test_msp_license_exporter.py` holds 22 tests covering the SDK
call contract, the non-dict body, both row builders, the malformed-array guards,
the empty result, the write routing, the error handler, both primary-key
entries, and the menu wiring. `tests/unit/utils/test_input_utils_wave9.py` gains
4 tests for the shared prompt. Every Mist call is mocked, so no test reaches the
live cloud.

## Migration and compatibility

No schema migration. The two primary-key strategies are new keys, so no existing
table changes. No new environment variable, so `deploy/.env.example` is
unchanged. Menu 238 is additive, and menus 0 through 237 keep their numbers.
