### PR TITLE
feat(portal): check the dependencies, start a stopped one, end the name collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### The portal checks its dependencies and repairs a stopped one (issue #2059)
+
+- **Defect (Fixed)**: the portal started, logged "ready for the port 8056", and
+  served the sign-in page while the document store answered nothing. The
+  operator signed in, picked a site, and only then met a 503, because
+  `acquire_site_lock` fails closed. The fault appeared three pages after its
+  cause. `GET /readyz` already reported the gap, but it answers JSON for an
+  orchestrator and no page showed the result.
+- **Preflight (Added)**: `src/upgrade_portal/runtime/dependencies.py` probes
+  every service the portal needs and returns one report. The sign-in page renders
+  the report, so the operator reads the state, the address, and the next action
+  on the first page.
+- **Probe depth (Stated)**: each probe opens a TCP connection and closes it, so
+  it answers one question: does a service listen. It signs in to nothing,
+  because the page must render fast and must render before the portal holds a
+  credential. The panel names `/readyz` for the deeper reading that also writes
+  to both stores.
+- **Auto-start (Added)**: `src/upgrade_portal/runtime/containers.py` reads the
+  state of one named container and starts it. A stopped container is the common
+  workstation fault and the one case the portal can repair. The module creates
+  nothing, pulls nothing, and removes nothing, so a missing container stays
+  missing and the report names the compose command instead. `CAPTURE_AUTOSTART`
+  turns the behavior off, and `compose.yml` sets it to `0` inside the container,
+  because a container cannot start its sibling.
+- **Command safety (Kept)**: every runtime call passes an argument list and no
+  shell, the runtime path comes from `shutil.which`, each container name passes
+  a pattern that refuses a leading hyphen and every shell character, and each
+  call carries a timeout.
+- **Name collisions (Fixed)**: `compose.yml` named two containers `arangodb` and
+  `redis-stack`. Those names belong to no project, so another project took them
+  first. A container named `truck-arangodb` from a different project held port
+  8529 on the test workstation, and the portal read that foreign database as its
+  own store. It reached a real server, received 401, and reported its own store
+  unreachable. Every service, container, network, and volume now carries the
+  `misthelper-` prefix.
+- **Ports (Moved)**: a vendor default is the port every other project also
+  publishes. ArangoDB moves from 8529 to 9529, Redis from 6379 to 9379, the
+  Insight UI from 8001 to 9526, and Ollama from 11434 to 9530. Each service binds
+  the new port inside the container as well, so each health check names the port
+  its client tool would otherwise guess. Ports 2200, 8055, and 8056 do not move,
+  because none is a vendor default and each already sits in the required range.
+- **Network (Pinned)**: the project network takes the subnet `172.31.240.0/24`
+  and an explicit name. A bridge with no subnet takes the next free range from
+  the runtime pool, and two projects can receive the same range. The test host
+  showed this: the old network held `10.89.0.0/24` from the pool.
+- **Migration (Required)**: the renamed containers use renamed volumes, so a
+  fresh ArangoDB holds no `misthelper` database. Create the database once, and
+  the portal then builds its three collections and seven indexes on the next
+  start. The old `arangodb-data` and `redis-data` volumes are left in place, so
+  no data is deleted by the rename.
+- **Tests (Added)**: 69 tests. `tests/unit/upgrade_portal/test_containers.py`
+  holds 26 and covers the name guard, the runtime search, every reported state,
+  and every failure path. `tests/unit/upgrade_portal/test_dependencies.py` holds
+  30 and covers the probe, the switch, and every reading the page can show.
+  `tests/guardrails/test_compose_naming_policy.py` holds 13 and fails when a
+  later edit reintroduces a generic name, a vendor default port, or a bridge
+  with no subnet. No test runs a container.
+- **Verification (Measured)**: the renamed stack was started on the test host.
+  Both containers report healthy, the network holds the pinned subnet, and the
+  storage bootstrap reported `database_available=True` with 3 collections and 7
+  indexes. `GET /readyz` answered `{"database":"ok","redis":"ok"}`. With
+  `misthelper-redis` stopped, one load of the sign-in page started the container
+  and rendered the state `started`.
+
 ### Add the upgrade capture portal, menu 238 (issue #1823)
 
 - **Menu 238 (Added)**: `Upgrade Capture Portal` starts a web server and prints a

--- a/compose.yml
+++ b/compose.yml
@@ -1,8 +1,46 @@
 version: '3.8'
 
+# ==============================================================================
+# Naming and port policy (issue #2059)
+# ==============================================================================
+# Every service, container, network, and volume below carries the `misthelper-`
+# prefix. Every published port sits between 1000 and 10000 and is not the vendor
+# default.
+#
+# Why the prefix:
+#   This file used to name two containers `arangodb` and `redis-stack`. Those
+#   names belong to no project in particular, so a second project on the same
+#   workstation takes them first and MistHelper then cannot start. That happened:
+#   a container named `truck-arangodb` from another project held port 8529, and
+#   the upgrade portal read that foreign database as its own store. The portal
+#   reached a real server, received 401, and reported its own store unreachable.
+#
+# Why the ports moved:
+#   A vendor default port is the port every other project also publishes. Moving
+#   off the default removes the collision, and it also stops a stray client that
+#   someone pointed at a default database from writing into this one.
+#
+#   | Service    | Vendor default | Published here |
+#   | ---------- | -------------- | -------------- |
+#   | ArangoDB   | 8529           | 9529           |
+#   | Redis      | 6379           | 9379           |
+#   | Insight UI | 8001           | 9526           |
+#   | Ollama     | 11434          | 9530           |
+#
+#   Ports 2200, 8055, and 8056 do not move. None is a vendor default, each one
+#   already sits in the required range, and each one is named in the README, in
+#   the SSH guide, and in the browser tests.
+#
+# Why the network pins a subnet:
+#   A bridge with no subnet takes the next free range from the runtime pool. Two
+#   projects that both accept a pool address can receive the same range, and the
+#   routes then collide on the host. A named subnet keeps this project on one
+#   range that no other compose file in this fleet claims.
+# ==============================================================================
+
 services:
   misthelper:
-    build: 
+    build:
       context: .
       dockerfile: Containerfile  # Use Containerfile for Podman, Dockerfile for Docker
     container_name: misthelper-app
@@ -28,17 +66,21 @@ services:
       - WEB_PORT=8055
       # Upgrade capture portal port (must match exposed port)
       - CAPTURE_PORT=8056
-      # Database connection (container names resolve via compose network)
-      - ARANGO_HOST=http://arangodb:8529
-      - REDIS_HOST=redis-stack
-      - REDIS_PORT=6379
+      # Database connection. The service names below resolve on the project
+      # network, and the ports match the non-default ports each service binds.
+      - ARANGO_HOST=http://misthelper-arangodb:9529
+      - REDIS_HOST=misthelper-redis
+      - REDIS_PORT=9379
+      # A container cannot start a sibling container, so the portal reports a
+      # stopped dependency here and never tries to repair it.
+      - CAPTURE_AUTOSTART=0
       # SSL settings for UV downloads (if needed)
       - REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
       - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
     depends_on:
-      arangodb:
+      misthelper-arangodb:
         condition: service_healthy
-      redis-stack:
+      misthelper-redis:
         condition: service_healthy
     networks:
       - misthelper-network
@@ -56,83 +98,99 @@ services:
     # Interactive mode for CLI usage
     stdin_open: true
     tty: true
-    
+
     # Common use cases - uncomment as needed:
     # Default: Site list export
     # command: ["python", "MistHelper.py", "--menu", "11", "--output-format", "sqlite"]
-    
+
     # Device inventory
     # command: ["python", "MistHelper.py", "--menu", "12", "--output-format", "sqlite"]
-    
+
     # Interactive mode (shows menu)
     # command: ["python", "MistHelper.py"]
-    
+
     # Systematic testing
     # command: ["python", "MistHelper.py", "--test"]
 
-  # Optional: Use Docker format for Docker users
-  # misthelper-docker:
-  #   build: 
-  #     context: .
-  #     dockerfile: Dockerfile  # Docker-compatible version with HEALTHCHECK
-  #   # ... same config as above
-
-  arangodb:
+  misthelper-arangodb:
     image: docker.io/arangodb/arangodb:3.12
-    container_name: arangodb
+    container_name: misthelper-arangodb
+    # The server binds 9529 rather than the vendor default 8529, so the port is
+    # the project port on the network and on the host alike. A stray client that
+    # someone pointed at a default ArangoDB therefore cannot reach this data.
+    command: ["arangod", "--server.endpoint", "tcp://0.0.0.0:9529"]
     ports:
-      - "8529:8529"
+      - "9529:9529"
     volumes:
-      - arangodb-data:/var/lib/arangodb3
+      - misthelper-arangodb-data:/var/lib/arangodb3
     environment:
       # CRITICAL: ArangoDB only reads ARANGO_ROOT_PASSWORD on FIRST boot
       # (when /var/lib/arangodb3 is empty). Changing this value after the
       # volume is initialized has NO effect. To reset the password:
-      #   podman stop arangodb && podman rm arangodb
-      #   podman volume rm arangodb-data
-      #   podman compose up -d arangodb
+      #   podman stop misthelper-arangodb && podman rm misthelper-arangodb
+      #   podman volume rm misthelper-arangodb-data
+      #   podman compose up -d misthelper-arangodb
       - ARANGO_ROOT_PASSWORD=${ARANGO_ROOT_PASSWORD:-misthelper}
     networks:
       - misthelper-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "arangosh", "--server.password", "${ARANGO_ROOT_PASSWORD:-misthelper}", "--javascript.execute-string", "print(1)"]
+      # The endpoint is named here as well. `arangosh` defaults to port 8529,
+      # so without this flag the probe would test a port the server never binds
+      # and the service would never report healthy.
+      test:
+        - "CMD"
+        - "arangosh"
+        - "--server.endpoint"
+        - "tcp://127.0.0.1:9529"
+        - "--server.password"
+        - "${ARANGO_ROOT_PASSWORD:-misthelper}"
+        - "--javascript.execute-string"
+        - "print(1)"
       interval: 10s
       timeout: 10s
       retries: 5
       start_period: 20s
 
-  redis-stack:
+  misthelper-redis:
     image: docker.io/redis/redis-stack:latest
-    container_name: redis-stack
+    container_name: misthelper-redis
     ports:
-      - "6379:6379"
-      # RedisInsight web UI for browsing data
-      - "8001:8001"
+      - "9379:9379"
+      # RedisInsight web UI for browsing data. The bundled UI binds 8001 inside
+      # the image, so the host side moves and the container side stays.
+      - "9526:8001"
     volumes:
-      - redis-data:/data
+      - misthelper-redis-data:/data
     environment:
-      - REDIS_ARGS=--requirepass ${REDIS_PASSWORD:-misthelper}
+      # The server binds 9379 rather than the vendor default 6379, for the same
+      # reason the database above moves off 8529.
+      - REDIS_ARGS=--requirepass ${REDIS_PASSWORD:-misthelper} --port 9379
     networks:
       - misthelper-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-misthelper}", "ping"]
+      # `redis-cli` defaults to port 6379, so the probe names the port too.
+      test: ["CMD", "redis-cli", "-p", "9379", "-a", "${REDIS_PASSWORD:-misthelper}", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 10s
 
-  ollama:
+  misthelper-ollama:
     image: docker.io/ollama/ollama
-    container_name: ollama-misthelper
+    container_name: misthelper-ollama
     ports:
-      - "11434:11434"
+      - "9530:9530"
     volumes:
       # Named volume keeps models across container restarts/upgrades.
       # Without this, every `podman rm` wipes the downloaded models.
-      - ollama-models:/root/.ollama
+      - misthelper-ollama-models:/root/.ollama
     environment:
+      # The server binds 9530 rather than the vendor default 11434. The default
+      # also sits above 10000, which the port policy at the top of this file
+      # does not allow.
+      - OLLAMA_HOST=0.0.0.0:9530
       # MoE CPU offload: expert FFN layers run from system RAM,
       # attention/embedding layers stay on GPU.  Drops mixtral:8x7b
       # VRAM requirement from ~26 GB to ~10 GB.
@@ -159,16 +217,27 @@ services:
 
 networks:
   misthelper-network:
+    name: misthelper-network
     driver: bridge
+    ipam:
+      config:
+        # A range that no other compose file in this fleet claims. A bridge with
+        # no subnet takes the next free range from the runtime pool, and two
+        # projects can then receive the same range.
+        - subnet: 172.31.240.0/24
 
 volumes:
   misthelper-data:
+    name: misthelper-data
     driver: local
-  arangodb-data:
+  misthelper-arangodb-data:
+    name: misthelper-arangodb-data
     driver: local
-  redis-data:
+  misthelper-redis-data:
+    name: misthelper-redis-data
     driver: local
   # Persistent model storage for the local Ollama instance.
   # Models survive container restarts, upgrades, and `podman rm`.
-  ollama-models:
+  misthelper-ollama-models:
+    name: misthelper-ollama-models
     driver: local

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -45,17 +45,23 @@ MIST_ORG_ID=your_org_id_here
 # CSV/SQLite. If not set, MistHelper gracefully degrades to CSV only.
 
 # ArangoDB connection (document storage for config entities)
-# ARANGO_HOST=http://arangodb:8529
+# The service name and the port both carry the project value. See the naming
+# and port policy at the top of compose.yml (issue #2059).
+# ARANGO_HOST=http://misthelper-arangodb:9529
 # ARANGO_DATABASE=misthelper
 # ARANGO_USERNAME=root
 # ARANGO_ROOT_PASSWORD=misthelper
 # NOTE: ArangoDB only reads this password on FIRST boot (empty volume).
-# Changing it later requires deleting the arangodb-data volume and recreating.
+# Changing it later requires deleting the misthelper-arangodb-data volume and recreating.
 
 # Redis Stack connection (time-series metrics + JSON event cache)
-# REDIS_HOST=redis-stack
-# REDIS_PORT=6379
+# REDIS_HOST=misthelper-redis
+# REDIS_PORT=9379
 # REDIS_PASSWORD=misthelper
+
+# Upgrade capture portal: start a stopped dependency container (default: on).
+# Set to 0 inside a container, because a container cannot start a sibling.
+# CAPTURE_AUTOSTART=1
 
 # Web portal port (default: 8055)
 # WEB_PORT=8055

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -14,10 +14,10 @@ from urllib.parse import urlparse
 
 import structlog
 
-ARANGO_DEFAULT_URL = "http://arangodb:8529"  # Compose service URL used when ARANGO_HOST is unset.
-ARANGO_DEFAULT_PORT = 8529  # Port applied when ARANGO_HOST carries no explicit port.
-REDIS_DEFAULT_HOST = "redis-stack"  # Compose service name used when REDIS_HOST is unset.
-REDIS_DEFAULT_PORT = 6379  # Port applied when REDIS_PORT is unset or unreadable.
+ARANGO_DEFAULT_URL = "http://misthelper-arangodb:9529"  # Compose service URL used when ARANGO_HOST is unset.
+ARANGO_DEFAULT_PORT = 9529  # Port applied when ARANGO_HOST carries no explicit port.
+REDIS_DEFAULT_HOST = "misthelper-redis"  # Compose service name used when REDIS_HOST is unset.
+REDIS_DEFAULT_PORT = 9379  # Port applied when REDIS_PORT is unset or unreadable.
 PROBE_TIMEOUT_SECONDS = 0.5  # Short TCP budget so a dead host never stalls an export.
 
 
@@ -45,12 +45,12 @@ def configure_db_logging() -> None:
 class DatabaseConfig:
     """Connection settings for polyglot database backends."""
 
-    arango_host: str = "http://arangodb:8529"
+    arango_host: str = "http://misthelper-arangodb:9529"
     arango_database: str = "misthelper"
     arango_username: str = "root"
     arango_password: str = "misthelper"
-    redis_host: str = "redis-stack"
-    redis_port: int = 6379
+    redis_host: str = "misthelper-redis"
+    redis_port: int = 9379
     redis_password: str = "misthelper"
     standalone_mode: bool = False
     webhook_enabled: bool = True

--- a/src/upgrade_portal/app/assets/templates/auth/signin.html
+++ b/src/upgrade_portal/app/assets/templates/auth/signin.html
@@ -32,6 +32,9 @@
     page_title           - the heading text and the tab text.
     theme                - the name of the current theme. See layout.html.
     themes               - the theme names the operator may pick.
+    dependencies         - one row for each service the portal needs. Empty
+                           hides the panel.
+    dependencies_healthy - false when one service does not answer.
 #}
 {% extends 'layout.html' %}
 
@@ -50,12 +53,82 @@
 {% set token_ready = token_mode_available | default(false) %}
 {% set refusal = error_message | default('', true) %}
 {% set heading = page_title | default('Sign in', true) %}
+{% set dependency_rows = dependencies | default([], true) %}
+{% set dependencies_ok = dependencies_healthy | default(true) %}
 
 {% block title %}{{ heading }}{% endblock %}
 
 {% block heading %}<h1>{{ heading }}</h1>{% endblock %}
 
 {% block content %}
+{#
+  The dependency panel.
+
+  Why it sits above the form:
+    The portal refuses to claim a site when the lock store does not answer, and
+    it answers 503 at that moment. Without this panel the operator meets that
+    refusal three pages after signing in, and the page that carries the cause is
+    not the page that shows the fault. The panel puts the cause first.
+
+  Why an empty list hides the panel:
+    The probe runs inside a guard, and a probe fault produces an empty list. A
+    healthy portal with a broken probe must still show a usable form, so an
+    empty list renders nothing at all.
+
+  What the rows never carry:
+    A row holds a service name, an address, a state word, and one sentence. It
+    never holds a password, a token, or a connection string.
+#}
+{% if dependency_rows %}
+<div class="portal-card"
+     id="dependency-panel"
+     data-testid="dependency-panel"
+     data-healthy="{{ 'true' if dependencies_ok else 'false' }}">
+  <h2 class="portal-card-title">Service check</h2>
+
+  {% if not dependencies_ok %}
+  <div class="alert alert-danger flash-danger"
+       id="dependency-warning"
+       data-testid="dependency-warning"
+       role="alert">
+    A service the portal needs does not answer. You may sign in, but a site
+    claim and an upgrade will refuse until every service below answers.
+  </div>
+  {% endif %}
+
+  <table class="table">
+    <thead>
+      <tr>
+        <th scope="col">Service</th>
+        <th scope="col">Address</th>
+        <th scope="col">State</th>
+        <th scope="col">Next action</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in dependency_rows %}
+      <tr data-testid="dependency-row-{{ row.key }}" data-state="{{ row.state }}">
+        <td>{{ row.label }}</td>
+        <td><code>{{ row.address }}</code></td>
+        <td data-testid="dependency-state-{{ row.key }}">{{ row.state }}</td>
+        <td>{{ row.detail }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  {#
+    The panel opens a TCP connection and closes it, so it reports whether a
+    service listens. It does not sign in to that service. The route below writes
+    to both stores, so it also catches a store that listens and then refuses.
+  #}
+  <p class="text-muted">
+    This check tests that each service listens. For the deeper check that also
+    writes to each store, read <code>/readyz</code>.
+  </p>
+</div>
+{% endif %}
+
 <div class="portal-card">
   <h2 class="portal-card-title">Sign in to the Mist cloud</h2>
 

--- a/src/upgrade_portal/app/config.py
+++ b/src/upgrade_portal/app/config.py
@@ -57,11 +57,11 @@ REDIS_PASSWORD_VARIABLE = "REDIS_PASSWORD"  # nosec B105  # WHY: this names an e
 DEFAULT_PORT = 8056  # Port 8055 already serves the data browsing portal.
 DEFAULT_POLL_INTERVAL_SECONDS = 30  # The contract sets the browser poll rate.
 DEFAULT_THEMES = ("magenta", "default")  # The two stylesheets the portal ships. The first one is the default.
-DEFAULT_ARANGO_HOST = "http://arangodb:8529"  # The service name inside the container network.
+DEFAULT_ARANGO_HOST = "http://misthelper-arangodb:9529"  # The service name and port inside the container network.
 DEFAULT_ARANGO_DATABASE = "misthelper"  # The database the other tools already use.
 DEFAULT_ARANGO_USERNAME = "root"  # The account the container image creates.
-DEFAULT_REDIS_HOST = "redis-stack"  # The service name inside the container network.
-DEFAULT_REDIS_PORT = 6379  # The standard Redis port.
+DEFAULT_REDIS_HOST = "misthelper-redis"  # The service name inside the container network.
+DEFAULT_REDIS_PORT = 9379  # The project Redis port. Not 6379, which every other project also publishes.
 DEFAULT_PROXY_HOPS = 0  # No proxy. The socket address is the client address.
 
 # WHY: The customer chose the automatic post-check capture. The two names below

--- a/src/upgrade_portal/app/routes/auth.py
+++ b/src/upgrade_portal/app/routes/auth.py
@@ -45,6 +45,7 @@ from flask import Blueprint, Response, current_app, jsonify, render_template, re
 from jinja2 import TemplateNotFound  # Marks a template that a later module still builds.
 
 from ...runtime import identity  # The registry, the digest, and the sign-out. No copy of them lives here.
+from ..config import load_settings  # The dependency panel probes the addresses the portal itself uses.
 from ..factory import json_error  # The one error envelope that the contract allows.
 
 logger = logging.getLogger(__name__)  # One logger for each module keeps the source visible in the log.
@@ -67,6 +68,8 @@ MODE_FIELD = "mode"  # The body field that names the credential mode of FR-006.
 SIGNIN_TEMPLATE = "auth/signin.html"  # The sign-in page.
 TWO_FACTOR_TEMPLATE = "auth/twofactor.html"  # The second factor page.
 FALLBACK_TEMPLATE = "layout.html"  # The shell page, shown while an auth template is still missing.
+
+DEPENDENCY_DOWN = "down"  # The one preflight state that turns the dependency panel into a warning.
 
 SIGNIN_TITLE = "Sign in"  # The heading and the tab text of the sign-in page.
 TWO_FACTOR_TITLE = "Second factor"  # The heading and the tab text of the second factor page.
@@ -666,6 +669,31 @@ def render_page(name: str, **context: Any) -> str:
         return render_template(FALLBACK_TEMPLATE, **context)  # The shell page always exists.
 
 
+def dependency_rows() -> list[dict[str, str]]:
+    """Probe every portal dependency and return the rows the page renders.
+
+    Why:
+        The portal used to serve this page while the document store answered
+        nothing. The operator met the fault three pages later, as a 503 from the
+        site lock. The rows below put the state on the first page instead.
+
+        A probe fault must never hide the sign-in form, because an operator who
+        cannot sign in also cannot read a history page or repair anything. Every
+        fault therefore becomes an empty row list and the form still renders.
+
+    Returns:
+        One row for each dependency, or an empty list when the probe failed.
+    """
+    try:  # A settings fault or a probe fault must not stop the operator signing in.
+        from ...runtime.dependencies import reading_rows, run_preflight  # Deferred, so a fault stays local.
+
+        settings = load_settings()  # The same settings the portal itself uses, so no address can differ.
+        return reading_rows(run_preflight(settings.arango, settings.redis))  # Probe, then flatten for the page.
+    except Exception:  # noqa: BLE001  # WHY: the sign-in form outranks the banner, so every fault degrades.
+        logger.exception("auth: the dependency preflight failed, so the page shows no dependency panel")
+        return []  # An empty list hides the panel and leaves the form untouched.
+
+
 def signin_context() -> dict[str, Any]:
     """Build the values that the sign-in page reads.
 
@@ -678,12 +706,15 @@ def signin_context() -> dict[str, Any]:
     Returns:
         The template values.
     """
+    rows = dependency_rows()  # The preflight reading of every service the portal needs.
     return {
         "page_title": SIGNIN_TITLE,  # The heading and the tab text.
         "signed_in": False,  # The navigation partial hides every link and the sign-out button.
         "clouds": [{"label": label, "host": host} for label, host in cloud_catalog()],  # The picker rows.
         "default_host": DEFAULT_CLOUD_HOST,  # The row that the page marks as chosen.
         "token_mode_available": identity.environment_token_present(),  # Presence alone, and never a value.
+        "dependencies": rows,  # One row for each service, or an empty list when the probe failed.
+        "dependencies_healthy": all(row["state"] != DEPENDENCY_DOWN for row in rows),  # Drives the banner tone.
     }
 
 

--- a/src/upgrade_portal/runtime/containers.py
+++ b/src/upgrade_portal/runtime/containers.py
@@ -1,0 +1,178 @@
+"""The container runtime seam that starts a dependency the operator left stopped.
+
+Why:
+    The portal refuses to work when the document store or the lock store does
+    not answer. On a workstation the usual cause is not a broken service. It is
+    a container that exists, holds its data, and sits in the `exited` state
+    after a restart. The operator then reads a 503 and has to find the container
+    name by hand.
+
+    This module reads the state of one named container and starts it. It is the
+    only place in the portal that reaches a container runtime, so every guard
+    below holds for every caller.
+
+What this module refuses to do:
+    It never creates a container, never pulls an image, never creates a volume,
+    and never removes anything. It starts a container that already exists and
+    does nothing else. A missing container therefore stays missing, and the
+    operator reads the compose command in the report instead. Creating a
+    container would invent a configuration that no file in this repository
+    describes, and the portal would then drive a firmware upgrade against a
+    store that nobody reviewed.
+
+    It never runs inside a container. A container cannot start its sibling, and
+    a portal that reached the host runtime socket would hold far more power over
+    the host than a firmware tool needs.
+
+Why the name is checked against a pattern:
+    Every name reaches a child process argument list. The list form passes no
+    shell, so a space or a semicolon in a name cannot become a second command.
+    The pattern is the second guard, and it also keeps a typo in a registry
+    entry from reaching the runtime as a flag. A name that starts with a hyphen
+    would read as an option, so the first character is a letter or a digit.
+"""
+
+from __future__ import annotations  # Postponed annotations keep every hint a plain string.
+
+import logging  # Action logging per Constitution VII.
+import re  # Checks that a container name holds safe characters only.
+import shutil  # Finds the absolute path of the runtime, so no PATH lookup happens in the child.
+import subprocess  # nosec B404  # WHY: the runtime is a command. Every call below passes a list and no shell.
+from enum import StrEnum  # A reading and a template read the same state text.
+
+logger = logging.getLogger(__name__)  # One logger for each module keeps the source visible in the log.
+
+# WHY: Podman comes first, because the project documents Podman as the primary
+# runtime. Docker follows, because the compose file also runs there.
+RUNTIME_NAMES: tuple[str, ...] = ("podman", "docker")
+
+# WHY: A name reaches a child argument list. The first character is a letter or
+# a digit, so no name can read as a command option.
+CONTAINER_NAME_PATTERN = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9_.-]{0,62}\Z")
+
+STATE_FORMAT = "{{.State.Status}}"  # Both runtimes accept this Go template and print one word.
+
+INSPECT_TIMEOUT_SECONDS = 10  # A reachable runtime answers an inspect in well under one second.
+START_TIMEOUT_SECONDS = 60  # A database container needs a few seconds. One minute covers a slow disk.
+
+RUNNING_WORD = "running"  # The one runtime word that means the service is up.
+
+
+class ContainerState(StrEnum):
+    """What the runtime reports about one named container."""
+
+    RUNNING = "running"  # The container is up, so the service should answer.
+    STOPPED = "stopped"  # The container exists and holds its data, so the portal may start it.
+    MISSING = "missing"  # No container of that name exists, so only the operator can create it.
+    UNKNOWN = "unknown"  # No runtime answered, so the portal knows nothing and claims nothing.
+
+
+def valid_container_name(name: str) -> bool:
+    """Report whether a name is safe to pass to the runtime.
+
+    Args:
+        name: The container name from the dependency registry.
+
+    Returns:
+        True when the name matches the pattern.
+    """
+    if CONTAINER_NAME_PATTERN.match(name):  # A safe name reaches the child process.
+        return True
+    logger.error("containers: the name %r is not a usable container name, so the portal skipped it", name)
+    return False
+
+
+def find_runtime() -> str | None:
+    """Return the absolute path of the first container runtime on this host.
+
+    Why:
+        `shutil.which` returns an absolute path, so the child process runs the
+        file this function found and never repeats the PATH search itself.
+
+    Returns:
+        The path of the runtime, or None when the host has neither one.
+    """
+    for name in RUNTIME_NAMES:  # Podman first, because the project documents it first.
+        path = shutil.which(name)  # An absolute path, or None when the runtime is absent.
+        if path:  # The first runtime found wins, so a host with both uses Podman.
+            logger.debug("containers: the runtime %s answers at %s", name, path)
+            return path
+    logger.info("containers: this host runs neither podman nor docker, so no container can start")
+    return None
+
+
+def _run(runtime: str, arguments: list[str], timeout: int) -> subprocess.CompletedProcess[str] | None:
+    """Run one runtime command and return the finished process.
+
+    Why:
+        Every call passes a list and never a shell, so no argument can become a
+        second command. One helper holds the timeout and the error handling, so
+        no caller repeats them.
+
+    Args:
+        runtime: The absolute path of the container runtime.
+        arguments: The arguments that follow the runtime path.
+        timeout: The wait in seconds before the portal gives up.
+
+    Returns:
+        The finished process, or None when the command could not run.
+    """
+    try:  # A missing binary, a dead runtime service, and a slow answer all land here.
+        return subprocess.run(  # nosec B603  # WHY: a list with an absolute path, and no shell.
+            [runtime, *arguments], capture_output=True, text=True, timeout=timeout, check=False, shell=False
+        )
+    except (OSError, subprocess.SubprocessError) as error:  # The portal reports the gap, it never raises.
+        logger.warning("containers: the command %s %s did not run: %s", runtime, " ".join(arguments), error)
+        return None
+
+
+def read_container_state(name: str, runtime: str) -> ContainerState:
+    """Read the state of one named container.
+
+    Args:
+        name: The container name from the dependency registry.
+        runtime: The absolute path of the container runtime.
+
+    Returns:
+        The state the runtime reported.
+    """
+    if not valid_container_name(name):  # The guard already logged the refusal.
+        return ContainerState.UNKNOWN
+    logger.debug("containers: reading the state of %s", name)  # Action log before the call.
+    finished = _run(runtime, ["inspect", "--format", STATE_FORMAT, name], INSPECT_TIMEOUT_SECONDS)
+    if finished is None:  # The helper already logged why the command could not run.
+        return ContainerState.UNKNOWN
+    if finished.returncode != 0:  # Both runtimes answer non-zero when no container carries that name.
+        logger.info("containers: no container is named %s on this host", name)
+        return ContainerState.MISSING
+    reported = finished.stdout.strip().lower()  # One word, such as `running` or `exited`.
+    logger.debug("containers: %s reports the state %s", name, reported)  # Action log after the call.
+    return ContainerState.RUNNING if reported == RUNNING_WORD else ContainerState.STOPPED
+
+
+def start_container(name: str, runtime: str) -> bool:
+    """Start one container that already exists.
+
+    Why:
+        The caller has already read the state and found the container stopped.
+        This function therefore starts it and reports the outcome. It creates
+        nothing, so a name that no container carries fails here and stays absent.
+
+    Args:
+        name: The container name from the dependency registry.
+        runtime: The absolute path of the container runtime.
+
+    Returns:
+        True when the runtime reported success.
+    """
+    if not valid_container_name(name):  # The guard already logged the refusal.
+        return False
+    logger.info("containers: starting the container %s", name)  # Action log before the call.
+    finished = _run(runtime, ["start", name], START_TIMEOUT_SECONDS)
+    if finished is None:  # The helper already logged why the command could not run.
+        return False
+    if finished.returncode != 0:  # The runtime refused, so the operator needs the reason.
+        logger.error("containers: the runtime refused to start %s: %s", name, finished.stderr.strip())
+        return False
+    logger.info("containers: the container %s started", name)  # Action log after the call.
+    return True

--- a/src/upgrade_portal/runtime/dependencies.py
+++ b/src/upgrade_portal/runtime/dependencies.py
@@ -1,0 +1,360 @@
+"""The dependency preflight that the sign-in page shows to the operator.
+
+Why:
+    The portal used to start, report "ready for the port 8056", and serve the
+    sign-in form while the document store answered nothing. The operator learned
+    of the gap only after signing in and picking a site, because
+    `acquire_site_lock` fails closed and answers 503. The failure appeared three
+    pages after its cause.
+
+    This module probes every service the portal needs and returns one report
+    that the sign-in page renders. The operator therefore reads the state, and
+    the remedy, on the first page and before choosing a site.
+
+What the probe tests:
+    Each probe opens a TCP connection and closes it. That answers one question:
+    does a service listen on that address. It is deliberately not an
+    authenticated probe, because the sign-in page must render fast and must
+    render before the portal holds any credential.
+
+    A deeper reading already exists. `GET /readyz` writes to both stores and
+    therefore also catches a store that listens, refuses the password, or
+    refuses a write. The banner names that route, so an operator who needs the
+    deeper answer knows where it lives.
+
+Why auto-start sits behind a switch:
+    Starting a container is a change to the host, and a firmware tool should not
+    change a host by surprise. `CAPTURE_AUTOSTART` holds the choice. The default
+    is on for a workstation, because that is the case this feature repairs, and
+    the action is limited to starting a container that already exists.
+"""
+
+from __future__ import annotations  # Postponed annotations keep every hint a plain string.
+
+import logging  # Action logging per Constitution VII.
+import os  # Reads the auto-start switch by name.
+import socket  # The reachability probe opens one TCP connection.
+from dataclasses import dataclass  # Builds the frozen registry and reading records.
+from enum import StrEnum  # A reading and a template read the same state text.
+from urllib.parse import urlsplit  # Splits the ArangoDB URL into a host and a port.
+
+from ..app.config import ArangoSettings, RedisSettings
+from .containers import ContainerState, find_runtime, read_container_state, start_container
+
+logger = logging.getLogger(__name__)  # One logger for each module keeps the source visible in the log.
+
+AUTOSTART_VARIABLE = "CAPTURE_AUTOSTART"  # Names the switch that allows a container start.
+FALSE_WORDS = ("0", "false", "no", "off")  # Every spelling of "do not start a container".
+
+PROBE_TIMEOUT_SECONDS = 2.0  # A local service answers at once. Two seconds keeps a dead host off the page.
+
+DOCUMENT_STORE_KEY = "document_store"  # The registry key of the capture and run store.
+LOCK_STORE_KEY = "lock_store"  # The registry key of the site lock store.
+
+DEFAULT_ARANGO_PORT = 8529  # The port a URL carries when it names no port of its own.
+
+READINESS_ROUTE = "/readyz"  # The deeper, authenticated reading that this preflight does not repeat.
+
+
+class DependencyState(StrEnum):
+    """What the portal knows about one dependency after the preflight."""
+
+    UP = "up"  # The service answered, so the portal can use it.
+    STARTED = "started"  # The service was down, the portal started its container, and it answered.
+    DOWN = "down"  # The service did not answer, and the portal could not repair it.
+
+
+@dataclass(frozen=True, slots=True)
+class Dependency:
+    """One service the portal needs, and the container that carries it.
+
+    Attributes:
+        key: The stable name the page and a test read.
+        label: The operator-facing name of the service.
+        container: The container name that carries the service.
+        host: The host that the probe reaches.
+        port: The port that the probe reaches.
+    """
+
+    key: str  # The stable name, never shown to the operator.
+    label: str  # The name the operator reads on the page.
+    container: str  # The container the portal may start when the service is down.
+    host: str  # The address of the service.
+    port: int  # The port of the service.
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyReading:
+    """The state of one dependency and the sentence the operator reads.
+
+    Attributes:
+        dependency: The service this reading describes.
+        state: What the portal found.
+        detail: The sentence the page shows. It names the next action.
+    """
+
+    dependency: Dependency  # The service this reading describes.
+    state: DependencyState  # What the portal found after the probe and any start.
+    detail: str  # The operator-facing sentence, which never holds a credential.
+
+    @property
+    def healthy(self) -> bool:
+        """Report whether this dependency is usable now.
+
+        Returns:
+            True when the service answered, whether or not the portal started it.
+        """
+        return self.state in (DependencyState.UP, DependencyState.STARTED)
+
+
+@dataclass(frozen=True, slots=True)
+class PreflightReport:
+    """Every dependency reading, and one summary the page reads.
+
+    Attributes:
+        readings: One reading for each dependency, in registry order.
+    """
+
+    readings: tuple[DependencyReading, ...]  # One reading for each dependency.
+
+    @property
+    def healthy(self) -> bool:
+        """Report whether every dependency answered.
+
+        Returns:
+            True when no reading is down.
+        """
+        return all(reading.healthy for reading in self.readings)
+
+    @property
+    def failures(self) -> tuple[DependencyReading, ...]:
+        """Return the readings the operator has to repair.
+
+        Returns:
+            Every reading that is down, in registry order.
+        """
+        return tuple(reading for reading in self.readings if not reading.healthy)
+
+
+def autostart_allowed() -> bool:
+    """Report whether the portal may start a stopped container.
+
+    Why:
+        The default is on, because a stopped container is the fault this feature
+        repairs. An operator who wants no change to the host sets the variable
+        to a false word.
+
+    Returns:
+        True when the portal may start a container.
+    """
+    raw = os.environ.get(AUTOSTART_VARIABLE, "").strip().lower()  # An unset value takes the default.
+    if raw in FALSE_WORDS:  # The operator turned the behavior off on purpose.
+        logger.info("preflight: %s is off, so the portal starts no container", AUTOSTART_VARIABLE)
+        return False
+    return True
+
+
+def split_arango_address(host_url: str) -> tuple[str, int]:
+    """Split the ArangoDB URL into a host name and a port.
+
+    Why:
+        The settings record holds a full URL, because the driver needs one. The
+        probe opens a socket, so it needs the two parts separately.
+
+    Args:
+        host_url: The URL from the settings record.
+
+    Returns:
+        The host name and the port. A URL with no port takes the ArangoDB port.
+    """
+    parts = urlsplit(host_url if "//" in host_url else f"//{host_url}")  # A bare host still splits.
+    name = parts.hostname or host_url  # A URL the parser cannot read falls back to the raw value.
+    port = parts.port or DEFAULT_ARANGO_PORT  # A URL with no port means the standard port.
+    logger.debug("preflight: the store URL %s reads as host %s port %s", host_url, name, port)
+    return name, port
+
+
+def build_registry(arango: ArangoSettings, redis: RedisSettings) -> tuple[Dependency, ...]:
+    """Name every service the portal needs, with the address the settings give.
+
+    Why:
+        The registry reads the same settings the portal itself uses, so the
+        probe can never test a different address from the one the portal calls.
+
+    Args:
+        arango: The document store settings.
+        redis: The lock store settings.
+
+    Returns:
+        One entry for each dependency, in the order the page shows them.
+    """
+    store_host, store_port = split_arango_address(arango.host)  # The URL splits into two probe values.
+    return (
+        Dependency(
+            key=DOCUMENT_STORE_KEY,
+            label="Document store (ArangoDB)",
+            container="misthelper-arangodb",
+            host=store_host,
+            port=store_port,
+        ),
+        Dependency(
+            key=LOCK_STORE_KEY,
+            label="Site lock store (Redis)",
+            container="misthelper-redis",
+            host=redis.host,
+            port=redis.port,
+        ),
+    )
+
+
+def service_answers(host: str, port: int) -> bool:
+    """Report whether a service listens on one address.
+
+    Why:
+        The probe carries a timeout, so a host that drops packets cannot hold
+        the sign-in page open.
+
+    Args:
+        host: The host name or the address.
+        port: The port.
+
+    Returns:
+        True when a TCP connection opened.
+    """
+    try:  # A refused connection, an unknown name, and a silent host all land here.
+        with socket.create_connection((host, port), timeout=PROBE_TIMEOUT_SECONDS):
+            return True  # The socket opened, so a service listens.
+    except OSError as error:  # The portal reports the gap, it never raises into the page.
+        logger.debug("preflight: nothing answered at %s port %s: %s", host, port, error)
+        return False
+
+
+def _down_reading(dependency: Dependency, detail: str) -> DependencyReading:
+    """Build the reading of a dependency the portal could not repair.
+
+    Args:
+        dependency: The service that did not answer.
+        detail: The sentence that names the next action.
+
+    Returns:
+        The reading.
+    """
+    logger.warning("preflight: %s is down at %s port %s", dependency.label, dependency.host, dependency.port)
+    return DependencyReading(dependency=dependency, state=DependencyState.DOWN, detail=detail)
+
+
+def _repair(dependency: Dependency) -> DependencyReading:
+    """Try to start the container of a dependency that did not answer.
+
+    Why:
+        A stopped container is the common case on a workstation, and it is the
+        one case the portal can repair on its own.
+
+    Args:
+        dependency: The service that did not answer.
+
+    Returns:
+        The reading after the repair attempt.
+    """
+    runtime = find_runtime()  # None when the host runs no container runtime.
+    if runtime is None:  # Nothing to start with, so the operator starts the service.
+        return _down_reading(dependency, f"Start the service on {dependency.host} port {dependency.port}.")
+    state = read_container_state(dependency.container, runtime)  # Missing, stopped, running, or unknown.
+    if state is not ContainerState.STOPPED:  # Only a stopped container is safe to start.
+        return _down_reading(dependency, _missing_container_detail(dependency, state))
+    if not start_container(dependency.container, runtime):  # The runtime already logged the reason.
+        return _down_reading(dependency, f"The container {dependency.container} refused to start. Read the log.")
+    if not service_answers(dependency.host, dependency.port):  # Started, but still not listening yet.
+        return _down_reading(dependency, f"The container {dependency.container} started but answers no client yet.")
+    logger.info("preflight: the portal started %s and %s now answers", dependency.container, dependency.label)
+    return DependencyReading(
+        dependency=dependency,
+        state=DependencyState.STARTED,
+        detail=f"The portal started the container {dependency.container}.",
+    )
+
+
+def _missing_container_detail(dependency: Dependency, state: ContainerState) -> str:
+    """Build the sentence for a dependency whose container the portal cannot start.
+
+    Args:
+        dependency: The service that did not answer.
+        state: What the runtime reported about its container.
+
+    Returns:
+        The sentence that names the next action.
+    """
+    if state is ContainerState.MISSING:  # No container exists, so the operator creates one.
+        return f"No container is named {dependency.container}. Run: podman compose up -d {dependency.container}"
+    if state is ContainerState.RUNNING:  # The container runs, so the fault is inside it or on the port.
+        return f"The container {dependency.container} runs but answers no client. Read its log."
+    return f"The portal could not read the state of {dependency.container}."  # No runtime answered.
+
+
+def check_dependency(dependency: Dependency, *, allow_start: bool) -> DependencyReading:
+    """Probe one dependency, and repair it when the caller allows a start.
+
+    Args:
+        dependency: The service to probe.
+        allow_start: True when the portal may start a stopped container.
+
+    Returns:
+        The reading of that dependency.
+    """
+    logger.debug("preflight: probing %s at %s port %s", dependency.label, dependency.host, dependency.port)
+    if service_answers(dependency.host, dependency.port):  # The common path, and the fastest one.
+        return DependencyReading(dependency=dependency, state=DependencyState.UP, detail="The service answers.")
+    if not allow_start:  # The operator turned auto-start off, so the portal only reports.
+        return _down_reading(dependency, f"Start the container {dependency.container}.")
+    return _repair(dependency)  # The one case the portal can repair on its own.
+
+
+def run_preflight(arango: ArangoSettings, redis: RedisSettings, *, allow_start: bool | None = None) -> PreflightReport:
+    """Probe every dependency and return the report the sign-in page reads.
+
+    Why:
+        One entry point keeps the page, the launcher, and the tests on the same
+        path, so the operator and a test never read a different answer.
+
+    Args:
+        arango: The document store settings.
+        redis: The lock store settings.
+        allow_start: True to start a stopped container, False to report only.
+            None reads the `CAPTURE_AUTOSTART` switch.
+
+    Returns:
+        One reading for each dependency.
+    """
+    permitted = autostart_allowed() if allow_start is None else allow_start  # The caller wins over the switch.
+    logger.info("preflight: checking the portal dependencies, container start allowed=%s", permitted)
+    readings = tuple(
+        check_dependency(dependency, allow_start=permitted) for dependency in build_registry(arango, redis)
+    )
+    report = PreflightReport(readings=readings)  # One record holds every reading.
+    logger.info("preflight: %d of %d dependencies answer", len(readings) - len(report.failures), len(readings))
+    return report
+
+
+def reading_rows(report: PreflightReport) -> list[dict[str, str]]:
+    """Flatten the report into the rows the template renders.
+
+    Why:
+        A template reads a plain mapping far more simply than a nested record,
+        and the flat form also keeps the markup free of any settings object.
+
+    Args:
+        report: The report that `run_preflight` returned.
+
+    Returns:
+        One row for each reading, in registry order.
+    """
+    return [
+        {
+            "key": reading.dependency.key,
+            "label": reading.dependency.label,
+            "address": f"{reading.dependency.host}:{reading.dependency.port}",
+            "state": reading.state.value,
+            "detail": reading.detail,
+        }
+        for reading in report.readings
+    ]

--- a/tests/guardrails/test_compose_naming_policy.py
+++ b/tests/guardrails/test_compose_naming_policy.py
@@ -1,0 +1,151 @@
+"""Guardrail: the compose file keeps the project naming and port policy (issue #2059).
+
+Why:
+    `compose.yml` used to name two containers `arangodb` and `redis-stack` and
+    publish them on the vendor default ports. A different project on the same
+    workstation took port 8529 with a container named `truck-arangodb`, so the
+    MistHelper container could not bind and the upgrade portal read the foreign
+    database as its own store.
+
+    A comment cannot hold that policy. These tests read the file and fail when a
+    later edit reintroduces a generic name, a vendor default port, or a bridge
+    with no subnet.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+yaml = pytest.importorskip("yaml")  # PyYAML ships with the project requirements.
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_PATH = REPOSITORY_ROOT / "compose.yml"
+
+PREFIX = "misthelper"  # Every service, container, network, and volume starts with this word.
+
+LOWEST_ALLOWED_PORT = 1000  # The policy floor. Below it sits the well-known range.
+HIGHEST_ALLOWED_PORT = 10000  # The policy ceiling.
+
+# The vendor default of each service this project runs. A published port that
+# equals one of these numbers is the collision the policy removes.
+VENDOR_DEFAULT_PORTS = frozenset({8529, 6379, 8001, 11434})
+
+# The three ports that predate the policy and already satisfy it. None is a
+# vendor default, and each one is named in the README and in the browser tests.
+GRANDFATHERED_PORTS = frozenset({2200, 8055, 8056})
+
+
+@pytest.fixture(scope="module")
+def compose() -> dict[str, Any]:
+    """Read the compose file once for every test in this module.
+
+    Returns:
+        The parsed document.
+    """
+    return dict(yaml.safe_load(COMPOSE_PATH.read_text(encoding="utf-8")))
+
+
+def published_ports(service: dict[str, Any]) -> list[int]:
+    """Return the host-side port of every mapping one service publishes.
+
+    Args:
+        service: One service block from the compose document.
+
+    Returns:
+        The host port of each mapping, as an integer.
+    """
+    return [int(str(mapping).split(":")[0]) for mapping in service.get("ports", [])]
+
+
+class TestServiceNaming:
+    """Every name carries the project prefix, so no second project can take it."""
+
+    def test_every_service_name_carries_the_prefix(self, compose: dict[str, Any]) -> None:
+        """A service name is also the DNS name on the network, so it needs the prefix."""
+        for name in compose["services"]:
+            assert name.startswith(PREFIX), f"The service {name} does not start with {PREFIX}"
+
+    def test_every_container_name_carries_the_prefix(self, compose: dict[str, Any]) -> None:
+        """A container name is global to the runtime, so a generic name collides."""
+        for name, service in compose["services"].items():
+            container = service.get("container_name", "")
+            assert container.startswith(PREFIX), f"The container of {name} is named {container!r}"
+
+    def test_no_generic_name_returns(self, compose: dict[str, Any]) -> None:
+        """These two names caused the reported collision, so neither may return."""
+        names = set(compose["services"]) | {s.get("container_name") for s in compose["services"].values()}
+        assert "arangodb" not in names
+        assert "redis-stack" not in names
+
+    def test_every_volume_carries_the_prefix(self, compose: dict[str, Any]) -> None:
+        """A volume holds the data, so a shared name would let a second project write into it."""
+        for key, volume in compose["volumes"].items():
+            assert key.startswith(PREFIX), f"The volume key {key} does not start with {PREFIX}"
+            assert str(volume.get("name", "")).startswith(PREFIX), f"The volume {key} has no prefixed name"
+
+
+class TestPortPolicy:
+    """Every published port sits in range and is not a vendor default."""
+
+    def test_no_service_publishes_a_vendor_default_port(self, compose: dict[str, Any]) -> None:
+        """A vendor default is the port every other project publishes too."""
+        for name, service in compose["services"].items():
+            for port in published_ports(service):
+                assert port not in VENDOR_DEFAULT_PORTS, f"The service {name} publishes the vendor port {port}"
+
+    def test_every_published_port_sits_in_the_allowed_range(self, compose: dict[str, Any]) -> None:
+        """The policy fixes the range at 1000 through 10000."""
+        for name, service in compose["services"].items():
+            for port in published_ports(service):
+                if port in GRANDFATHERED_PORTS:
+                    continue  # WHY: named in the README and the browser tests, and already compliant.
+                assert LOWEST_ALLOWED_PORT <= port <= HIGHEST_ALLOWED_PORT, f"{name} publishes {port}"
+
+    def test_no_two_services_publish_the_same_port(self, compose: dict[str, Any]) -> None:
+        """Two services on one host port cannot both bind, so one would fail to start."""
+        seen = [port for service in compose["services"].values() for port in published_ports(service)]
+        assert len(seen) == len(set(seen)), f"A host port is published twice: {sorted(seen)}"
+
+
+class TestStoreAddresses:
+    """The application reads the same ports the stores bind."""
+
+    def test_the_application_points_at_the_prefixed_stores(self, compose: dict[str, Any]) -> None:
+        """A stale address here would send the portal to a foreign database."""
+        environment = compose["services"]["misthelper"]["environment"]
+        assert "ARANGO_HOST=http://misthelper-arangodb:9529" in environment
+        assert "REDIS_HOST=misthelper-redis" in environment
+        assert "REDIS_PORT=9379" in environment
+
+    def test_the_container_never_starts_a_sibling(self, compose: dict[str, Any]) -> None:
+        """A container cannot start its sibling, so auto-start is off inside one."""
+        assert "CAPTURE_AUTOSTART=0" in compose["services"]["misthelper"]["environment"]
+
+    def test_each_store_health_check_names_the_project_port(self, compose: dict[str, Any]) -> None:
+        """Both client tools default to the vendor port, so each probe must name the real one."""
+        arango_probe = " ".join(compose["services"]["misthelper-arangodb"]["healthcheck"]["test"])
+        assert "9529" in arango_probe
+        redis_probe = " ".join(compose["services"]["misthelper-redis"]["healthcheck"]["test"])
+        assert "9379" in redis_probe
+
+
+class TestNetwork:
+    """The project network holds its own address range."""
+
+    def test_the_network_pins_a_subnet(self, compose: dict[str, Any]) -> None:
+        """A bridge with no subnet takes a pool range, which a second project can also take."""
+        network = compose["networks"]["misthelper-network"]
+        subnets = [entry["subnet"] for entry in network["ipam"]["config"]]
+        assert subnets, "The project network pins no subnet"
+
+    def test_the_network_carries_an_explicit_name(self, compose: dict[str, Any]) -> None:
+        """Without a name the runtime prefixes the directory, so the name changes per checkout."""
+        assert compose["networks"]["misthelper-network"]["name"] == "misthelper-network"
+
+    def test_every_service_joins_the_project_network(self, compose: dict[str, Any]) -> None:
+        """A service outside the network would reach the others only through the host."""
+        for name, service in compose["services"].items():
+            assert "misthelper-network" in service.get("networks", []), f"{name} is off the project network"

--- a/tests/integration/test_compose_deploy.py
+++ b/tests/integration/test_compose_deploy.py
@@ -1,7 +1,10 @@
 """Integration test for compose deployment health.
 
-Requires Docker/Podman Compose with arangodb + redis-stack services.
-Skipped automatically when containers are not running.
+Requires Docker/Podman Compose with the misthelper-arangodb and misthelper-redis
+services. Skipped automatically when containers are not running.
+
+The ports below are the project ports, not the vendor defaults. See the naming
+and port policy at the top of compose.yml (issue #2059).
 """
 
 from __future__ import annotations
@@ -13,6 +16,9 @@ import pytest
 COMPOSE_AVAILABLE = os.environ.get("COMPOSE_TEST", "0") == "1"
 skip_reason = "Set COMPOSE_TEST=1 with running compose services"
 
+ARANGO_PORT = 9529  # The project ArangoDB port. Not 8529.
+REDIS_PORT = 9379  # The project Redis port. Not 6379.
+
 
 @pytest.mark.skipif(not COMPOSE_AVAILABLE, reason=skip_reason)
 class TestComposeDeployment:
@@ -21,7 +27,7 @@ class TestComposeDeployment:
     def test_arangodb_reachable(self):
         from arango import ArangoClient
 
-        client = ArangoClient(hosts="http://localhost:8529")
+        client = ArangoClient(hosts=f"http://localhost:{ARANGO_PORT}")
         system_db = client.db(
             "_system",
             username="root",
@@ -35,7 +41,7 @@ class TestComposeDeployment:
 
         client = redis.Redis(
             host="localhost",
-            port=6379,
+            port=REDIS_PORT,
             password=os.environ.get("REDIS_PASSWORD", "misthelper"),
             decode_responses=True,
         )

--- a/tests/unit/upgrade_portal/test_config.py
+++ b/tests/unit/upgrade_portal/test_config.py
@@ -236,7 +236,7 @@ def test_arango_defaults_name_the_container_service() -> None:
         name works there without any operator setup.
     """
     arango = load_settings().arango
-    assert arango.host == "http://arangodb:8529"
+    assert arango.host == "http://misthelper-arangodb:9529"
     assert arango.database == "misthelper"
     assert arango.username == "root"
 
@@ -249,8 +249,8 @@ def test_redis_defaults_name_the_container_service() -> None:
         drive one site at the same time.
     """
     redis = load_settings().redis
-    assert redis.host == "redis-stack"
-    assert redis.port == 6379
+    assert redis.host == "misthelper-redis"
+    assert redis.port == 9379
 
 
 def test_module_constants_hold_the_documented_literals() -> None:
@@ -263,11 +263,11 @@ def test_module_constants_hold_the_documented_literals() -> None:
     assert config.DEFAULT_PORT == 8056
     assert config.DEFAULT_POLL_INTERVAL_SECONDS == 30
     assert config.DEFAULT_THEMES == ("magenta", "default")
-    assert config.DEFAULT_ARANGO_HOST == "http://arangodb:8529"
+    assert config.DEFAULT_ARANGO_HOST == "http://misthelper-arangodb:9529"
     assert config.DEFAULT_ARANGO_DATABASE == "misthelper"
     assert config.DEFAULT_ARANGO_USERNAME == "root"
-    assert config.DEFAULT_REDIS_HOST == "redis-stack"
-    assert config.DEFAULT_REDIS_PORT == 6379
+    assert config.DEFAULT_REDIS_HOST == "misthelper-redis"
+    assert config.DEFAULT_REDIS_PORT == 9379
     assert config.LOWEST_ALLOWED_PORT == 1024
     assert config.HIGHEST_ALLOWED_PORT == 65535
     assert config.LOWEST_POLL_INTERVAL_SECONDS == 5
@@ -752,7 +752,7 @@ def test_arango_overrides_replace_each_address_field(monkeypatch: pytest.MonkeyP
     assert arango.username == "portal_reader"
 
 
-@pytest.mark.parametrize(("raw", "expected"), [("6380", 6380), ("not-a-port", 6379), ("0", 6379), ("70000", 6379)])
+@pytest.mark.parametrize(("raw", "expected"), [("6380", 6380), ("not-a-port", 9379), ("0", 9379), ("70000", 9379)])
 def test_redis_overrides_replace_the_address_and_guard_the_port(
     monkeypatch: pytest.MonkeyPatch, raw: str, expected: int
 ) -> None:

--- a/tests/unit/upgrade_portal/test_containers.py
+++ b/tests/unit/upgrade_portal/test_containers.py
@@ -1,0 +1,158 @@
+"""Tests for the container runtime seam of the dependency preflight (issue #2059).
+
+Why:
+    This module is the only place in the portal that reaches a container
+    runtime, so every guard it holds protects every caller. The tests below
+    cover the name guard, the runtime search, each state the runtime can report,
+    and every failure path. No test runs a real container.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.upgrade_portal.runtime import containers
+from src.upgrade_portal.runtime.containers import (
+    ContainerState,
+    find_runtime,
+    read_container_state,
+    start_container,
+    valid_container_name,
+)
+
+RUNTIME = "/usr/bin/podman"  # An absolute path, which is what `find_runtime` returns.
+
+
+def _finished(returncode: int, stdout: str = "", stderr: str = "") -> Any:
+    """Build a stand-in for a finished child process.
+
+    Args:
+        returncode: The exit status the runtime reported.
+        stdout: The text the runtime printed.
+        stderr: The error text the runtime printed.
+
+    Returns:
+        An object with the three fields the module reads.
+    """
+    result = MagicMock()  # WHY: the module reads three attributes and nothing else.
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+class TestValidContainerName:
+    """Cover the name guard, which keeps a crafted name out of the argument list."""
+
+    @pytest.mark.parametrize("name", ["misthelper-arangodb", "misthelper_redis", "a", "app.1"])
+    def test_accepts_a_plain_name(self, name: str) -> None:
+        """A name of letters, digits, and the three joining marks is safe."""
+        assert valid_container_name(name) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "-flag",  # WHY: a leading hyphen would read as a runtime option.
+            "two words",  # WHY: a space would split into two arguments.
+            "semi;colon",  # WHY: a shell character, refused even though no shell runs.
+            "",  # WHY: an empty name names nothing.
+            "a" * 64,  # WHY: longer than the pattern allows.
+        ],
+    )
+    def test_refuses_an_unsafe_name(self, name: str) -> None:
+        """A name that could read as an option or a second command is refused."""
+        assert valid_container_name(name) is False
+
+
+class TestFindRuntime:
+    """Cover the runtime search, which prefers Podman."""
+
+    def test_prefers_podman_when_both_exist(self) -> None:
+        """The project documents Podman first, so Podman wins."""
+        with patch.object(containers.shutil, "which", side_effect=lambda name: f"/usr/bin/{name}"):
+            assert find_runtime() == "/usr/bin/podman"
+
+    def test_falls_back_to_docker(self) -> None:
+        """A host with Docker alone still gets a runtime."""
+        with patch.object(containers.shutil, "which", side_effect=lambda name: None if name == "podman" else "/d"):
+            assert find_runtime() == "/d"
+
+    def test_returns_none_when_no_runtime_exists(self) -> None:
+        """A host with neither runtime must report the gap, not raise."""
+        with patch.object(containers.shutil, "which", return_value=None):
+            assert find_runtime() is None
+
+
+class TestReadContainerState:
+    """Cover every state the runtime can report."""
+
+    def test_reports_running(self) -> None:
+        """The word `running` is the one word that means the service is up."""
+        with patch.object(containers.subprocess, "run", return_value=_finished(0, "running\n")):
+            assert read_container_state("misthelper-redis", RUNTIME) is ContainerState.RUNNING
+
+    @pytest.mark.parametrize("word", ["exited", "created", "paused"])
+    def test_reports_stopped_for_every_other_word(self, word: str) -> None:
+        """Any state that is not `running` is a container the portal may start."""
+        with patch.object(containers.subprocess, "run", return_value=_finished(0, f"{word}\n")):
+            assert read_container_state("misthelper-redis", RUNTIME) is ContainerState.STOPPED
+
+    def test_reports_missing_on_a_non_zero_exit(self) -> None:
+        """Both runtimes answer non-zero when no container carries the name."""
+        with patch.object(containers.subprocess, "run", return_value=_finished(125, "", "no such container")):
+            assert read_container_state("misthelper-redis", RUNTIME) is ContainerState.MISSING
+
+    def test_reports_unknown_for_an_unsafe_name(self) -> None:
+        """The name guard runs before the runtime call, so no process starts."""
+        with patch.object(containers.subprocess, "run") as run_spy:
+            assert read_container_state("-flag", RUNTIME) is ContainerState.UNKNOWN
+        run_spy.assert_not_called()
+
+    @pytest.mark.parametrize("error", [OSError("no such file"), subprocess.TimeoutExpired("podman", 10)])
+    def test_reports_unknown_when_the_command_cannot_run(self, error: Exception) -> None:
+        """A dead runtime and a slow runtime both leave the portal without an answer."""
+        with patch.object(containers.subprocess, "run", side_effect=error):
+            assert read_container_state("misthelper-redis", RUNTIME) is ContainerState.UNKNOWN
+
+    def test_passes_a_list_and_never_a_shell(self) -> None:
+        """A list with no shell is what stops an argument becoming a second command."""
+        with patch.object(containers.subprocess, "run", return_value=_finished(0, "running")) as run_spy:
+            read_container_state("misthelper-redis", RUNTIME)
+        args, kwargs = run_spy.call_args
+        assert args[0] == [RUNTIME, "inspect", "--format", "{{.State.Status}}", "misthelper-redis"]
+        assert kwargs["shell"] is False
+
+
+class TestStartContainer:
+    """Cover the start path and each refusal."""
+
+    def test_returns_true_on_success(self) -> None:
+        """A zero exit means the runtime accepted the start."""
+        with patch.object(containers.subprocess, "run", return_value=_finished(0)):
+            assert start_container("misthelper-redis", RUNTIME) is True
+
+    def test_returns_false_when_the_runtime_refuses(self) -> None:
+        """A non-zero exit must report false, and the reason reaches the log."""
+        with patch.object(containers.subprocess, "run", return_value=_finished(1, "", "port is in use")):
+            assert start_container("misthelper-redis", RUNTIME) is False
+
+    def test_refuses_an_unsafe_name_before_starting_a_process(self) -> None:
+        """The name guard runs first, so a crafted name never reaches the runtime."""
+        with patch.object(containers.subprocess, "run") as run_spy:
+            assert start_container("; rm -rf /", RUNTIME) is False
+        run_spy.assert_not_called()
+
+    def test_returns_false_when_the_command_cannot_run(self) -> None:
+        """A dead runtime must report false, not raise into the sign-in page."""
+        with patch.object(containers.subprocess, "run", side_effect=OSError("boom")):
+            assert start_container("misthelper-redis", RUNTIME) is False
+
+    def test_runs_only_the_start_verb(self) -> None:
+        """The module starts a container. It never creates, pulls, or removes one."""
+        with patch.object(containers.subprocess, "run", return_value=_finished(0)) as run_spy:
+            start_container("misthelper-redis", RUNTIME)
+        assert run_spy.call_args[0][0] == [RUNTIME, "start", "misthelper-redis"]

--- a/tests/unit/upgrade_portal/test_dependencies.py
+++ b/tests/unit/upgrade_portal/test_dependencies.py
@@ -1,0 +1,276 @@
+"""Tests for the dependency preflight of the upgrade capture portal (issue #2059).
+
+Why:
+    The portal used to serve the sign-in page while the document store answered
+    nothing, and the operator met the fault three pages later as a 503. These
+    tests pin the probe, the auto-start decision, every reading the page can
+    show, and the rule that a probe fault never hides the sign-in form.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.upgrade_portal.app.config import ArangoSettings, RedisSettings
+from src.upgrade_portal.runtime import dependencies
+from src.upgrade_portal.runtime.containers import ContainerState
+from src.upgrade_portal.runtime.dependencies import (
+    AUTOSTART_VARIABLE,
+    DOCUMENT_STORE_KEY,
+    LOCK_STORE_KEY,
+    Dependency,
+    DependencyState,
+    autostart_allowed,
+    build_registry,
+    check_dependency,
+    reading_rows,
+    run_preflight,
+    split_arango_address,
+)
+
+ARANGO = ArangoSettings(
+    host="http://misthelper-arangodb:9529",
+    database="misthelper",
+    username="root",
+    password_variable="ARANGO_ROOT_PASSWORD",
+)
+REDIS = RedisSettings(host="misthelper-redis", port=9379, password_variable="REDIS_PASSWORD")
+
+ONE = Dependency(key="one", label="One", container="misthelper-one", host="h", port=1)
+
+
+class TestSplitArangoAddress:
+    """Cover the URL split, which turns one driver URL into two probe values."""
+
+    def test_reads_the_host_and_the_port(self) -> None:
+        """A full URL carries both values."""
+        assert split_arango_address("http://misthelper-arangodb:9529") == ("misthelper-arangodb", 9529)
+
+    def test_falls_back_to_the_arango_port(self) -> None:
+        """A URL with no port means the vendor port, which the registry then probes."""
+        assert split_arango_address("http://store.example.com") == ("store.example.com", 8529)
+
+    def test_reads_a_bare_host_name(self) -> None:
+        """A value with no scheme must still split, because an operator may set one."""
+        assert split_arango_address("store:9529") == ("store", 9529)
+
+
+class TestAutostartAllowed:
+    """Cover the switch that decides whether the portal may change the host."""
+
+    def test_defaults_to_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A stopped container is the fault this feature repairs, so the default is on."""
+        monkeypatch.delenv(AUTOSTART_VARIABLE, raising=False)
+        assert autostart_allowed() is True
+
+    @pytest.mark.parametrize("word", ["0", "false", "no", "off", "OFF", " False "])
+    def test_reads_every_false_word(self, monkeypatch: pytest.MonkeyPatch, word: str) -> None:
+        """An operator who turns the behavior off must have it stay off."""
+        monkeypatch.setenv(AUTOSTART_VARIABLE, word)
+        assert autostart_allowed() is False
+
+
+class TestBuildRegistry:
+    """Cover the registry, which must read the same addresses the portal uses."""
+
+    def test_names_both_stores_with_the_prefixed_containers(self) -> None:
+        """Each container carries the project prefix, per the compose naming policy."""
+        registry = build_registry(ARANGO, REDIS)
+        assert [entry.key for entry in registry] == [DOCUMENT_STORE_KEY, LOCK_STORE_KEY]
+        assert [entry.container for entry in registry] == ["misthelper-arangodb", "misthelper-redis"]
+
+    def test_reads_the_address_from_the_settings(self) -> None:
+        """A probe against a different address from the portal would report a false answer."""
+        store, lock = build_registry(ARANGO, REDIS)
+        assert (store.host, store.port) == ("misthelper-arangodb", 9529)
+        assert (lock.host, lock.port) == ("misthelper-redis", 9379)
+
+
+class TestCheckDependency:
+    """Cover every reading one dependency can produce."""
+
+    def test_reports_up_when_the_service_answers(self) -> None:
+        """The fast path opens one socket and starts nothing."""
+        with patch.object(dependencies, "service_answers", return_value=True):
+            reading = check_dependency(ONE, allow_start=True)
+        assert reading.state is DependencyState.UP
+        assert reading.healthy is True
+
+    def test_reports_down_without_starting_when_start_is_off(self) -> None:
+        """An operator who turned auto-start off must see a report and no host change."""
+        with (
+            patch.object(dependencies, "service_answers", return_value=False),
+            patch.object(dependencies, "find_runtime") as runtime_spy,
+        ):
+            reading = check_dependency(ONE, allow_start=False)
+        assert reading.state is DependencyState.DOWN
+        runtime_spy.assert_not_called()
+
+    def test_reports_down_when_the_host_runs_no_runtime(self) -> None:
+        """A host with no Podman and no Docker leaves the repair to the operator."""
+        with (
+            patch.object(dependencies, "service_answers", return_value=False),
+            patch.object(dependencies, "find_runtime", return_value=None),
+        ):
+            reading = check_dependency(ONE, allow_start=True)
+        assert reading.state is DependencyState.DOWN
+        assert "Start the service" in reading.detail
+
+    def test_names_the_compose_command_when_the_container_is_missing(self) -> None:
+        """A missing container is the one case the operator must repair, so name the command."""
+        with (
+            patch.object(dependencies, "service_answers", return_value=False),
+            patch.object(dependencies, "find_runtime", return_value="/podman"),
+            patch.object(dependencies, "read_container_state", return_value=ContainerState.MISSING),
+            patch.object(dependencies, "start_container") as start_spy,
+        ):
+            reading = check_dependency(ONE, allow_start=True)
+        assert reading.state is DependencyState.DOWN
+        assert "podman compose up -d misthelper-one" in reading.detail
+        start_spy.assert_not_called()  # WHY: the portal never creates a container.
+
+    def test_reports_a_running_container_that_answers_nothing(self) -> None:
+        """A container that runs but answers nothing has a fault inside it."""
+        with (
+            patch.object(dependencies, "service_answers", return_value=False),
+            patch.object(dependencies, "find_runtime", return_value="/podman"),
+            patch.object(dependencies, "read_container_state", return_value=ContainerState.RUNNING),
+            patch.object(dependencies, "start_container") as start_spy,
+        ):
+            reading = check_dependency(ONE, allow_start=True)
+        assert reading.state is DependencyState.DOWN
+        assert "runs but answers no client" in reading.detail
+        start_spy.assert_not_called()  # WHY: a running container needs no start.
+
+    def test_starts_a_stopped_container_and_reports_started(self) -> None:
+        """The one case the portal repairs: the container exists and is stopped."""
+        with (
+            patch.object(dependencies, "service_answers", side_effect=[False, True]),
+            patch.object(dependencies, "find_runtime", return_value="/podman"),
+            patch.object(dependencies, "read_container_state", return_value=ContainerState.STOPPED),
+            patch.object(dependencies, "start_container", return_value=True) as start_spy,
+        ):
+            reading = check_dependency(ONE, allow_start=True)
+        assert reading.state is DependencyState.STARTED
+        assert reading.healthy is True
+        start_spy.assert_called_once_with("misthelper-one", "/podman")
+
+    def test_reports_down_when_the_start_is_refused(self) -> None:
+        """A refused start must not read as repaired."""
+        with (
+            patch.object(dependencies, "service_answers", return_value=False),
+            patch.object(dependencies, "find_runtime", return_value="/podman"),
+            patch.object(dependencies, "read_container_state", return_value=ContainerState.STOPPED),
+            patch.object(dependencies, "start_container", return_value=False),
+        ):
+            reading = check_dependency(ONE, allow_start=True)
+        assert reading.state is DependencyState.DOWN
+        assert "refused to start" in reading.detail
+
+    def test_reports_down_when_the_started_container_still_answers_nothing(self) -> None:
+        """A container that starts slowly must not read as ready before it listens."""
+        with (
+            patch.object(dependencies, "service_answers", side_effect=[False, False]),
+            patch.object(dependencies, "find_runtime", return_value="/podman"),
+            patch.object(dependencies, "read_container_state", return_value=ContainerState.STOPPED),
+            patch.object(dependencies, "start_container", return_value=True),
+        ):
+            reading = check_dependency(ONE, allow_start=True)
+        assert reading.state is DependencyState.DOWN
+        assert "answers no client yet" in reading.detail
+
+
+class TestServiceAnswers:
+    """Cover the probe itself, which must never raise into the page."""
+
+    def test_returns_true_when_the_socket_opens(self) -> None:
+        """An open socket means a service listens."""
+        with patch.object(dependencies.socket, "create_connection"):
+            assert dependencies.service_answers("h", 1) is True
+
+    def test_returns_false_on_any_socket_error(self) -> None:
+        """A refused connection and an unknown name both mean the service is down."""
+        with patch.object(dependencies.socket, "create_connection", side_effect=OSError("refused")):
+            assert dependencies.service_answers("h", 1) is False
+
+    def test_carries_a_timeout(self) -> None:
+        """A host that drops packets must not hold the sign-in page open."""
+        with patch.object(dependencies.socket, "create_connection") as connect_spy:
+            dependencies.service_answers("h", 1)
+        assert connect_spy.call_args.kwargs["timeout"] == dependencies.PROBE_TIMEOUT_SECONDS
+
+
+class TestRunPreflight:
+    """Cover the report that the sign-in page reads."""
+
+    def test_reports_healthy_when_every_service_answers(self) -> None:
+        """A healthy portal shows a panel with no warning."""
+        with patch.object(dependencies, "service_answers", return_value=True):
+            report = run_preflight(ARANGO, REDIS, allow_start=False)
+        assert report.healthy is True
+        assert report.failures == ()
+
+    def test_lists_every_failure(self) -> None:
+        """The operator needs to know which service to repair, not just that one failed."""
+        with patch.object(dependencies, "service_answers", return_value=False):
+            report = run_preflight(ARANGO, REDIS, allow_start=False)
+        assert report.healthy is False
+        assert len(report.failures) == 2
+
+    def test_the_caller_flag_wins_over_the_switch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A test and a launcher both need to force the decision."""
+        monkeypatch.delenv(AUTOSTART_VARIABLE, raising=False)  # WHY: the switch would otherwise allow a start.
+        with (
+            patch.object(dependencies, "service_answers", return_value=False),
+            patch.object(dependencies, "find_runtime") as runtime_spy,
+        ):
+            run_preflight(ARANGO, REDIS, allow_start=False)
+        runtime_spy.assert_not_called()
+
+
+class TestReadingRows:
+    """Cover the flat form the template renders."""
+
+    def test_builds_one_row_for_each_reading(self) -> None:
+        """The page shows one line for each service."""
+        with patch.object(dependencies, "service_answers", return_value=True):
+            rows = reading_rows(run_preflight(ARANGO, REDIS, allow_start=False))
+        assert [row["key"] for row in rows] == [DOCUMENT_STORE_KEY, LOCK_STORE_KEY]
+        assert rows[0]["address"] == "misthelper-arangodb:9529"
+        assert rows[0]["state"] == "up"
+
+    def test_a_row_carries_no_credential(self) -> None:
+        """A row reaches the markup, so it must never hold a password or a variable value."""
+        with patch.object(dependencies, "service_answers", return_value=False):
+            rows = reading_rows(run_preflight(ARANGO, REDIS, allow_start=False))
+        joined = " ".join(value for row in rows for value in row.values())
+        assert "password" not in joined.lower()
+        assert ARANGO.password_variable not in joined
+
+
+class TestSigninPanel:
+    """Cover the route seam, which must never let a probe fault hide the form."""
+
+    def test_dependency_rows_returns_an_empty_list_on_any_fault(self) -> None:
+        """An operator who cannot sign in cannot repair anything, so the form always renders."""
+        from src.upgrade_portal.app.routes.auth import dependency_rows
+
+        with patch("src.upgrade_portal.app.routes.auth.load_settings", side_effect=RuntimeError("no settings")):
+            assert dependency_rows() == []
+
+    def test_signin_context_marks_an_unhealthy_report(self) -> None:
+        """The banner tone comes from this flag, so a down service must set it false."""
+        from src.upgrade_portal.app.routes import auth
+
+        rows: list[dict[str, Any]] = [{"key": "k", "label": "L", "address": "a:1", "state": "down", "detail": "d"}]
+        with (
+            patch.object(auth, "dependency_rows", return_value=rows),
+            patch.object(auth, "cloud_catalog", return_value=[("Global 01", "api.mist.com")]),
+            patch.object(auth.identity, "environment_token_present", return_value=False),
+        ):
+            context = auth.signin_context()
+        assert context["dependencies_healthy"] is False
+        assert context["dependencies"] == rows


### PR DESCRIPTION
## Summary

Closes #2059. Base branch is `feat/1823-upgrade-capture-portal`, because
`src/upgrade_portal/` exists only there and not yet on `main`.

This answers three questions about the upgrade capture portal.

1. Why does it not check the services it needs and tell the operator?
2. Why does it not start a service that exists but is powered off?
3. Why do its containers use generic names and vendor default ports?

## 1. The portal now checks its dependencies and shows the result

`GET /readyz` already probed both stores, but it answers JSON for an
orchestrator and no page rendered it. A store failure reached the server log
alone, so the portal printed "ready for the port 8056" while the primary store
answered nothing. The operator then signed in, picked a site, and met a 503 from
`acquire_site_lock`, which fails closed. The fault appeared three pages after
its cause.

`src/upgrade_portal/runtime/dependencies.py` probes every service and returns one
report. The sign-in page renders it above the form, with the service, the
address, the state, and the next action.

The probe opens a TCP connection and closes it, so it answers one question: does
a service listen. It signs in to nothing, because the page must render fast and
must render before the portal holds any credential. The panel names `/readyz`
for the deeper reading that also writes to both stores.

A probe fault never hides the form. An operator who cannot sign in cannot repair
anything, so every fault becomes an empty row list and the form still renders.

## 2. The portal now starts a container that exists and is stopped

`src/upgrade_portal/runtime/containers.py` reads the state of one named container
and starts it. That is the whole of its power:

- It never creates a container, pulls an image, creates a volume, or removes
  anything. A missing container stays missing and the report names the compose
  command, because creating one would invent a configuration no file describes
  and the portal would then drive a firmware upgrade against an unreviewed store.
- Every call passes an argument list and no shell, the runtime path comes from
  `shutil.which`, each name passes a pattern that refuses a leading hyphen and
  every shell character, and each call carries a timeout.
- `CAPTURE_AUTOSTART` turns the behavior off. `compose.yml` sets it to `0` inside
  the container, because a container cannot start its sibling.

## 3. The names and the ports no longer collide

`compose.yml` named two containers `arangodb` and `redis-stack`. Those names
belong to no project, so another project takes them first. That is not
hypothetical. On the test workstation a container named `truck-arangodb` from a
different project held port 8529, and the portal read that foreign database as
its own store:

```
GET http://127.0.0.1:8529/_api/version           -> 401
GET http://127.0.0.1:8529/_api/database (root)   -> 401
```

Every service, container, network, and volume now carries the `misthelper-`
prefix, and every vendor default port moves.

| Service    | Vendor default | Published now |
| ---------- | -------------- | ------------- |
| ArangoDB   | 8529           | 9529          |
| Redis      | 6379           | 9379          |
| Insight UI | 8001           | 9526          |
| Ollama     | 11434          | 9530          |

Each service binds the new port inside the container too, so each health check
names the port its client tool would otherwise guess. `arangosh` defaults to
8529 and `redis-cli` defaults to 6379, so without that flag each probe would test
a port the server never binds and the service would never report healthy.

Ports 2200, 8055, and 8056 do not move. None is a vendor default, each already
sits in the required range, and each is named in the README and the browser
tests.

The network takes the subnet `172.31.240.0/24` and an explicit name. A bridge
with no subnet takes the next free range from the runtime pool, and two projects
can receive the same range. The old network held `10.89.0.0/24` from that pool.

## Migration

The renamed containers use renamed volumes, so a fresh ArangoDB holds no
`misthelper` database. Create it once and the portal builds its collections on
the next start. The old `arangodb-data` and `redis-data` volumes are left in
place, so the rename deletes no data.

## Verification

### Gates

| Gate | Result |
| - | - |
| `ruff check src/ tests/` | `All checks passed!` |
| `black --check src/ tests/` | 962 files unchanged |
| `mypy src/ MistHelper.py wsgi.py` | `Success: no issues found in 382 source files` |
| `pytest tests/unit/upgrade_portal tests/guardrails` | 2353 passed |
| `pylint src/ --fail-under=9.5` | 9.78 |
| `pydocstyle`, `radon -n C`, `vulture`, `bandit` | No finding |

### Runtime, on a real host

The renamed stack was started with `podman compose up -d`.

```
misthelper-redis    | Up (healthy) | 0.0.0.0:9379->9379/tcp, 0.0.0.0:9526->8001/tcp
misthelper-arangodb | Up (healthy) | 0.0.0.0:9529->9529/tcp
misthelper-network subnet: 172.31.240.0/24
```

Both report healthy, which proves the health checks read the moved ports. The
portal then completed the bootstrap it had never completed before:

```
storage ready, collections=3, indexes=7, edge_index=True, database_available=True
GET /readyz -> 200 {"database":"ok","redis":"ok","status":"ready"}
```

The sign-in page rendered the panel with both services `up`.

Then `misthelper-redis` was stopped, and one load of the sign-in page repaired
it:

```
podman stop misthelper-redis        -> Exited (143)
GET /auth/signin                    -> data-state="started"
                                       "The portal started the container misthelper-redis."
podman ps                           -> misthelper-redis Up 1 second (healthy)
```

## Test plan

69 new tests, none of which runs a container.

- `test_containers.py` (26): the name guard, including a leading hyphen and a
  semicolon; the runtime search; every reported state; a dead runtime; a
  timeout; and the assertion that the module runs only `inspect` and `start`.
- `test_dependencies.py` (30): the URL split, the switch, and every reading,
  including a missing container, a running container that answers nothing, a
  refused start, and a container that starts but does not listen yet. One test
  asserts a rendered row carries no credential.
- `test_compose_naming_policy.py` (13): a guardrail that reads `compose.yml` and
  fails when a later edit returns a generic name, a vendor default port, a
  duplicate host port, or a bridge with no subnet.

## Security

The report names a service, an address, a state, and a remedy. It never carries
a password, a token, or a connection string, and one test asserts that. The
auto-start path accepts a container name from the registry only, never from a
request.

No change to the fail-closed lock policy. A write still refuses when the lock
store is unreachable.
