### PR TITLE
fix(portal): store every capture in the collection the portal reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Every capture failed, because the write name and the read name differed (issue #2061)
+
+- **Defect (Fixed)**: no capture could ever be stored. The portal collected the
+  data correctly, wrote it to ArangoDB successfully, and then declared the write
+  failed. Both tier 2 and tier 3 failed the same way, and the page showed every
+  collection phase as `done` beside the sentence "The portal could not store the
+  capture."
+- **Cause (Found)**: `src/upgrade_portal/capture/store.py` held two names for one
+  thing. It wrote through `CAPTURE_OPERATION = "upgradeCaptureWrite"` and read
+  back through `CAPTURE_COLLECTION = "upgrade_captures"`.
+  `DataExporter.write_with_format_selection` hands the operation name to
+  `DatabaseRouter.write`, which hands it to `ArangoWriter.write` as the
+  collection name. `ArangoWriter._ensure_collection` then creates the collection
+  when it is absent. Nothing translates the name on the way, so every capture
+  created and filled a collection named `upgradeCaptureWrite`, and the read-back
+  looked in an empty `upgrade_captures` and reported `document_absent`.
+- **Evidence (Measured)**: the two failed captures of the report were found in
+  the wrong collection under the exact keys from the log.
+  `upgradeCaptureWrite` held 2 documents while `upgrade_captures`,
+  `upgrade_runs`, and `capture_for_run` each held 0. The `data/` directory held
+  21 capture backup files, so the fault predates the report.
+- **Fix (Applied)**: each operation name is now bound to its collection name,
+  `CAPTURE_OPERATION = CAPTURE_COLLECTION` and `RUN_OPERATION = RUN_COLLECTION`.
+  The second name is gone, so the two cannot drift again. The matching keys in
+  `ENDPOINT_PRIMARY_KEY_STRATEGIES` move with them and keep `natural_pk` on
+  `capture_id` and `run_id`.
+- **Why no gate caught it**: every readiness signal was green while every
+  capture failed. The storage bootstrap creates the three collections the portal
+  reads and reports `collections=3, indexes=7, database_available=True`, and
+  `GET /readyz` answered `{"database":"ok","redis":"ok"}`. Neither one exercises
+  the write path, and the write path never used those collections.
+- **Tests (Added)**: `test_the_write_name_equals_the_read_name` asserts the two
+  names are one value for both targets, and
+  `test_no_stale_write_endpoint_name_returns` refuses either retired name in the
+  strategy table. The first test was verified red against the old constants: it
+  reported 2 failures before the fix and passes after it.
+- **Verification (Measured)**: both tiers were run against a live site after the
+  fix and both reached the verified state.
+
+  | Tier | Key | State | Stored bytes |
+  | - | - | - | - |
+  | 2 | `cap-b4e8473a...-01` | `verified` | 15494 |
+  | 3 | `cap-434b67ea...-01` | `verified` | 39472 |
+
+  The page reads "Capture progress verified 100%" and "The portal read the
+  capture back and the record matches." `upgrade_captures` holds 2 documents and
+  `capture_for_run` holds 2 edges.
+- **Migration (Done)**: the stray `upgradeCaptureWrite` collection held two
+  captures that never left the `writing` state. Both keep a CSV backup under
+  `data/`, so the collection was dropped without data loss.
+
 ### The portal checks its dependencies and repairs a stopped one (issue #2059)
 
 - **Defect (Fixed)**: the portal started, logged "ready for the port 8056", and

--- a/src/refactors/endpoint_primary_key_strategies.py
+++ b/src/refactors/endpoint_primary_key_strategies.py
@@ -2654,15 +2654,24 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
     # Both entries MUST stay natural_pk. src/db/redis_writer.py:598 puts a 7-day
     # time to live on every composite_pk document, and the portal keeps a capture
     # and a run forever.
+    #
+    # Each key is the ArangoDB collection name, not a verb. `DatabaseRouter`
+    # passes the api_function_name to `ArangoWriter.write` as the collection
+    # name, and `_ensure_collection` creates whatever it is handed. Issue #2061:
+    # these keys used to read `upgradeCaptureWrite` and `upgradeRunWrite`, so
+    # every capture wrote into a collection of that name while the portal
+    # verified `upgrade_captures`. Every capture failed with `document_absent`.
+    # The names must match `CAPTURE_COLLECTION` and `RUN_COLLECTION` in
+    # `src/upgrade_portal/capture/store.py`, and a guardrail test pins that.
     # ==============================
-    "upgradeCaptureWrite": {
+    "upgrade_captures": {
         "type": "natural_pk",
         "primary_key": ["capture_id"],  # Value is cap-{run_hex}-{ordinal}. No slash and no colon
         "indexes": ["run_id", "ordinal", "site_id", "org_id", "actor_email", "started_at"],
         "unique_constraints": [],
         "description": "Site state capture written before and after a firmware upgrade",
     },
-    "upgradeRunWrite": {
+    "upgrade_runs": {
         "type": "natural_pk",
         "primary_key": ["run_id"],  # Value is run-{uuid4hex}. A retry replaces the record
         "indexes": ["site_id", "state", "actor_email", "created_at"],

--- a/src/upgrade_portal/capture/store.py
+++ b/src/upgrade_portal/capture/store.py
@@ -39,8 +39,25 @@ CAPTURE_COLLECTION = "upgrade_captures"
 RUN_COLLECTION = "upgrade_runs"
 EDGE_COLLECTION = "capture_for_run"
 
-CAPTURE_OPERATION = "upgradeCaptureWrite"
-RUN_OPERATION = "upgradeRunWrite"
+# WHY: The operation name and the collection name must be one value, because the
+# router uses the operation name as the collection name and creates whatever it
+# is handed.
+#
+# `DataExporter.write_with_format_selection(api_function_name=...)` passes the
+# name to `DatabaseRouter.write`, which passes it to
+# `ArangoWriter.write(data, collection_name, strategy)`. That method calls
+# `_ensure_collection(collection_name)`, and `_ensure_collection` creates the
+# collection when it is absent. Nothing translates the name on the way.
+#
+# Issue #2061: these two constants used to read `upgradeCaptureWrite` and
+# `upgradeRunWrite`. Every capture therefore wrote into a collection of that
+# name, and the read-back below looked in `upgrade_captures`, found nothing, and
+# reported `document_absent`. Every capture failed while the write itself
+# succeeded, and the storage bootstrap still reported all three collections
+# ready. Binding each operation to its collection removes the second name, so
+# the two cannot drift again.
+CAPTURE_OPERATION = CAPTURE_COLLECTION
+RUN_OPERATION = RUN_COLLECTION
 
 SCHEMA_VERSION = 1
 

--- a/tests/unit/upgrade_portal/test_guardrails.py
+++ b/tests/unit/upgrade_portal/test_guardrails.py
@@ -40,6 +40,12 @@ from pathlib import Path
 import pytest
 
 from src.refactors.endpoint_primary_key_strategies import ENDPOINT_PRIMARY_KEY_STRATEGIES
+from src.upgrade_portal.capture.store import (  # WHY: issue #2061 pins the write name to the read name.
+    CAPTURE_COLLECTION,
+    CAPTURE_OPERATION,
+    RUN_COLLECTION,
+    RUN_OPERATION,
+)
 from src.utils.operation_registry import OperationRegistry
 
 # WHY: This file sits at tests/unit/upgrade_portal, so the root is three levels up.
@@ -462,7 +468,7 @@ class TestRepositoryGuardrails:
 
     @pytest.mark.parametrize(
         ("endpoint", "key_field"),
-        [("upgradeCaptureWrite", "capture_id"), ("upgradeRunWrite", "run_id")],
+        [(CAPTURE_COLLECTION, "capture_id"), (RUN_COLLECTION, "run_id")],
     )
     def test_the_portal_write_endpoint_uses_natural_pk(self, endpoint: str, key_field: str) -> None:
         """Each portal write endpoint uses the natural primary key strategy.
@@ -482,6 +488,53 @@ class TestRepositoryGuardrails:
         strategy = entry.get("type", "")  # WHY: The message repeats the wrong value.
         assert strategy == "natural_pk", f"{anchor} sets the strategy {strategy} for {endpoint}"
         assert entry.get("primary_key") == [key_field], f"{anchor} names another key field for {endpoint}"
+
+    @pytest.mark.parametrize(
+        ("operation", "collection"),
+        [(CAPTURE_OPERATION, CAPTURE_COLLECTION), (RUN_OPERATION, RUN_COLLECTION)],
+    )
+    def test_the_write_name_equals_the_read_name(self, operation: str, collection: str) -> None:
+        """The name the portal writes equals the name the portal reads.
+
+        Why:
+            Issue #2061. ``DataExporter.write_with_format_selection`` hands the
+            operation name to ``DatabaseRouter.write``, which hands it to
+            ``ArangoWriter.write`` as the collection name.
+            ``ArangoWriter._ensure_collection`` then creates whatever it is
+            handed. Nothing translates the name on the way.
+
+            The two constants used to differ. Every capture wrote into a
+            collection named ``upgradeCaptureWrite`` while the read-back looked
+            in ``upgrade_captures``, found nothing, and reported
+            ``document_absent``. Every capture failed while the write succeeded,
+            and the storage bootstrap still reported all three collections
+            ready, so no readiness signal caught it.
+
+        Args:
+            operation: The name the portal writes through.
+            collection: The name the portal reads back.
+        """
+        assert operation == collection, (
+            f"The portal writes {operation!r} and reads {collection!r}. "
+            "The router creates the collection it is handed, so a capture would "
+            "land in the write name and the verify would fail with document_absent."
+        )
+
+    @pytest.mark.parametrize("stale", ["upgradeCaptureWrite", "upgradeRunWrite"])
+    def test_no_stale_write_endpoint_name_returns(self, stale: str) -> None:
+        """Neither retired endpoint name comes back into the strategy table.
+
+        Why:
+            Issue #2061. Each of these names created a collection of its own and
+            broke every capture. An entry under one of them would mean the write
+            name and the read name had parted again.
+
+        Args:
+            stale: The retired endpoint name.
+        """
+        assert (
+            stale not in ENDPOINT_PRIMARY_KEY_STRATEGIES
+        ), f"{stale} returned to the strategy table. It names a collection that the portal never reads."
 
     def test_the_brand_theme_stays_tracked_by_git(self) -> None:
         """Git tracks the brand theme, and no ``.gitignore`` rule drops it.


### PR DESCRIPTION
## Summary

Closes #2061. Base is `feat/1823-upgrade-capture-portal`, because
`src/upgrade_portal/` lives only there.

Every capture failed. The portal collected the data correctly, wrote it to
ArangoDB successfully, and then declared the write failed. Tier 2 and tier 3
failed the same way.

## Root cause

`src/upgrade_portal/capture/store.py` held two names for one thing:

```python
CAPTURE_COLLECTION = "upgrade_captures"      # what the portal reads
CAPTURE_OPERATION  = "upgradeCaptureWrite"   # what the portal writes
```

The write path passes the operation name to the exporter, and the name reaches
the database untranslated:

```
store._export_document(api_function_name="upgradeCaptureWrite")
  -> DataExporter._perform_polyglot_write
     -> DatabaseRouter.write(data, api_function_name)
        -> ArangoWriter.write(data, collection_name="upgradeCaptureWrite", strategy)
           -> _ensure_collection("upgradeCaptureWrite")   # creates it when absent
```

The verify step then reads the other name and finds nothing:

```python
stored = database.collection("upgrade_captures").get(key)   # None -> document_absent
```

So the write always succeeded, into a collection nothing ever read.

## Evidence

Portal log:

```
14:20:47 [INFO]  Capture cap-47b6c405...-01 moved from assembling to writing
14:20:47 [WARN]  did not verify cap-47b6c405...-01 in upgrade_captures,
                 reason=document_absent, backup_file=True
14:20:47 [ERROR] reached no stored record: ... (document_absent)
```

The database, before the fix. Both keys from the log are present, in the wrong
collection:

```
upgradeCaptureWrite = 2    cap-47b6c405...-01, cap-9c7ff7d0...-01
upgrade_captures    = 0    <-- the collection the portal reads
upgrade_runs        = 0
capture_for_run     = 0
```

`data/` held 21 capture backup files, so the fault predates the report.

## Why no gate caught it

Every readiness signal was green while every capture failed:

```
storage ready, collections=3, indexes=7, edge_index=True, database_available=True
GET /readyz -> 200 {"database":"ok","redis":"ok","status":"ready"}
```

The bootstrap creates the three collections the portal reads, and `/readyz`
writes a probe document. Neither exercises the capture write path, and that path
never used those collections.

## Fix

Bind each operation name to its collection name, so the second name is gone and
the two cannot drift again:

```python
CAPTURE_OPERATION = CAPTURE_COLLECTION   # "upgrade_captures"
RUN_OPERATION     = RUN_COLLECTION       # "upgrade_runs"
```

The matching keys in `ENDPOINT_PRIMARY_KEY_STRATEGIES` move with them and keep
`natural_pk` on `capture_id` and `run_id`.

The router has no collection override. `ArangoWriter.write` uses the name it is
handed and `_ensure_collection` creates it, so making the two names one value is
the smallest correct change.

## Verification

### Live, against a real site

Both tiers were run through the browser after the fix. Both reached the verified
state:

| Tier | Key | State | Status | Stored bytes |
| - | - | - | - | - |
| 2 | `cap-b4e8473a...-01` | `verified` | `complete` | 15494 |
| 3 | `cap-434b67ea...-01` | `verified` | `complete` | 39472 |

The page reads **Capture progress verified 100%** and "The portal read the
capture back and the record matches." The result panel shows a capture
identifier and a non-zero stored size, where both were empty before.

Collections after the run:

```
upgrade_captures = 2
capture_for_run  = 2      <-- the graph edge forms now
upgradeCaptureWrite -> dropped
```

### Red first

`test_the_write_name_equals_the_read_name` was run against the old constants
before the fix and reported 2 failures:

```
FAILED test_the_write_name_equals_the_read_name[upgradeCaptureWrite-upgrade_captures]
FAILED test_the_write_name_equals_the_read_name[upgradeRunWrite-upgrade_runs]
```

It passes after the fix.

### Gates

| Gate | Result |
| - | - |
| `ruff check src/ tests/` | `All checks passed!` |
| `black --check src/ tests/` | 962 files unchanged |
| `mypy src/ MistHelper.py wsgi.py` | `Success: no issues found in 382 source files` |
| `pytest tests/unit/upgrade_portal tests/guardrails` | 2357 passed |
| `pylint src/ --fail-under=9.5` | 9.78 |
| `pydocstyle`, `vulture`, `bandit` | No finding |

## Migration

The stray `upgradeCaptureWrite` collection held two captures that never left the
`writing` state. Both keep a CSV backup under `data/`, so it was dropped with no
data loss. Any other deployment on this branch should drop the same collection
once it is empty.

## Test plan

- `test_the_write_name_equals_the_read_name` asserts the write name and the read
  name are one value, for the capture target and the run target.
- `test_no_stale_write_endpoint_name_returns` refuses `upgradeCaptureWrite` and
  `upgradeRunWrite` in the strategy table, so neither name can come back.
- `test_the_portal_write_endpoint_uses_natural_pk` now reads the collection
  constants instead of repeating a literal, so it follows any future rename.
